### PR TITLE
fix memory safety issue in LightEpoch class

### DIFF
--- a/cc/src/core/light_epoch.h
+++ b/cc/src/core/light_epoch.h
@@ -294,7 +294,7 @@ class LightEpoch {
 
   /// CPR checkpoint functions.
   inline void ResetPhaseFinished() {
-    for(size_t idx = 0; idx < Thread::kMaxNumThreads; ++idx) {
+    for(uint32_t idx = 1; idx <= num_entries_; ++idx) {
       assert(table_[idx].phase_finished.load() == Phase::REST ||
              table_[idx].phase_finished.load() == Phase::PERSISTENCE_CALLBACK ||
              table_[idx].phase_finished.load() == Phase::GC_IN_PROGRESS ||
@@ -307,7 +307,7 @@ class LightEpoch {
     uint32_t entry = Thread::id();
     table_[entry].phase_finished = phase;
     // Check if other threads have reported complete.
-    for(size_t idx = 0; idx < Thread::kMaxNumThreads; ++idx) {
+    for(uint32_t idx = 1; idx <= num_entries_; ++idx) {
       Phase entry_phase = table_[idx].phase_finished.load();
       uint64_t entry_epoch = table_[idx].local_current_epoch;
       if(entry_epoch != 0 && entry_phase != phase) {


### PR DESCRIPTION
The constant `kTableSize` is the same as `Thread::kMaxNumThreads`: https://github.com/Microsoft/FASTER/blob/9c9d3e4c86f8e83c505290cf9f0baed549d3943b/cc/src/core/light_epoch.h#L120

The constructor allows one to specify a `size` but defaults to `kTableSize`: https://github.com/Microsoft/FASTER/blob/9c9d3e4c86f8e83c505290cf9f0baed549d3943b/cc/src/core/light_epoch.h#L140-L146

In `Initialize`, we set the `table_` to an allocation based on the `size`: https://github.com/Microsoft/FASTER/blob/9c9d3e4c86f8e83c505290cf9f0baed549d3943b/cc/src/core/light_epoch.h#L153-L158

These methods loop over the `table_` based on `Thread::kMaxNumThreads` instead of the appropriate size: https://github.com/Microsoft/FASTER/blob/9c9d3e4c86f8e83c505290cf9f0baed549d3943b/cc/src/core/light_epoch.h#L296-L318