### PR TITLE
Minor Refactoring

### DIFF
--- a/cc/src/core/record.h
+++ b/cc/src/core/record.h
@@ -47,7 +47,6 @@ class RecordInfo {
     };
 };
 static_assert(sizeof(RecordInfo) == 8, "sizeof(RecordInfo) != 8");
-static_assert(sizeof(RecordInfo) == 8, "sizeof(RecordInfo) != 8");
 
 /// A record stored in the log. The log starts at 0 (mod 64), and consists of Records, one after
 /// the other. Each record's header is 8 bytes.

--- a/cc/src/core/recovery_status.h
+++ b/cc/src/core/recovery_status.h
@@ -32,9 +32,7 @@ class RecoveryStatus {
   }
 
   ~RecoveryStatus() {
-    if(page_status_) {
       delete page_status_;
-    }
   }
 
   const std::atomic<PageRecoveryStatus>& page_status(uint32_t page) const {

--- a/cc/src/core/thread.h
+++ b/cc/src/core/thread.h
@@ -18,7 +18,7 @@ namespace core {
 /// Gives every thread a unique, numeric thread ID, and recycles IDs when threads exit.
 class Thread {
  public:
-  /// The number of entries in table. Currently, this is fixed at 64 and never changes or grows.
+  /// The number of entries in table. Currently, this is fixed at 96 and never changes or grows.
   /// If the table runs out of entries, then the current implementation will throw a
   /// std::runtime_error.
   static constexpr size_t kMaxNumThreads = 96;


### PR DESCRIPTION
Removed a redundant static_assert() and a check against a pointer (guard for delete). Updated a comment to match a constant value.