### PR TITLE
fixes for "dotnet run" and run on linux

### DIFF
--- a/cs/FASTER.sln
+++ b/cs/FASTER.sln
@@ -43,6 +43,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "adv-file-ops", "src\native\
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "readtsc", "src\native\readtsc\readtsc.vcxproj", "{A6510B80-BD50-4C11-9712-64C3B3865AFF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ManagedSampleCore", "playground\ManagedSampleCore\ManagedSampleCore.csproj", "{C9391533-1F31-47F6-BE08-9642C95401A8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -97,6 +99,10 @@ Global
 		{A6510B80-BD50-4C11-9712-64C3B3865AFF}.Debug|x64.Build.0 = Release|x64
 		{A6510B80-BD50-4C11-9712-64C3B3865AFF}.Release|x64.ActiveCfg = Release|x64
 		{A6510B80-BD50-4C11-9712-64C3B3865AFF}.Release|x64.Build.0 = Release|x64
+		{C9391533-1F31-47F6-BE08-9642C95401A8}.Debug|x64.ActiveCfg = Debug|x64
+		{C9391533-1F31-47F6-BE08-9642C95401A8}.Debug|x64.Build.0 = Debug|x64
+		{C9391533-1F31-47F6-BE08-9642C95401A8}.Release|x64.ActiveCfg = Release|x64
+		{C9391533-1F31-47F6-BE08-9642C95401A8}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -116,6 +122,7 @@ Global
 		{999943F0-CC60-4BA9-B928-275BE5C5E6B9} = {28800357-C8CE-4CD0-A2AD-D4A910ABB496}
 		{5852AC33-6B01-44F5-BAF3-2AAF796E8449} = {999943F0-CC60-4BA9-B928-275BE5C5E6B9}
 		{A6510B80-BD50-4C11-9712-64C3B3865AFF} = {999943F0-CC60-4BA9-B928-275BE5C5E6B9}
+		{C9391533-1F31-47F6-BE08-9642C95401A8} = {E6026D6A-01C5-4582-B2C1-64751490DABE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A0750637-2CCB-4139-B25E-F2CE740DCFAC}

--- a/cs/playground/ManagedSampleCore/App.config
+++ b/cs/playground/ManagedSampleCore/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+</configuration>

--- a/cs/playground/ManagedSampleCore/Functions.cs
+++ b/cs/playground/ManagedSampleCore/Functions.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using FASTER.core;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace ManagedSample1
+{
+    public unsafe class Functions
+    {
+        public static void RMWCompletionCallback(KeyStruct* key, InputStruct* output, Empty* ctx, Status status)
+        {
+        }
+
+        public static void ReadCompletionCallback(KeyStruct* key, InputStruct* input, OutputStruct* output, Empty* ctx, Status status)
+        {
+        }
+
+        public static void UpsertCompletionCallback(KeyStruct* key, ValueStruct* output, Empty* ctx)
+        {
+        }
+
+        public static void PersistenceCallback(long thread_id, long serial_num)
+        {
+            Debug.WriteLine("Thread {0} repors persistence until {1}", thread_id, serial_num);
+        }
+
+        // Read functions
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SingleReader(KeyStruct* key, InputStruct* input, ValueStruct* value, OutputStruct* dst)
+        {
+            ValueStruct.Copy(value, (ValueStruct*)dst);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ConcurrentReader(KeyStruct* key, InputStruct* input, ValueStruct* value, OutputStruct* dst)
+        {
+            ValueStruct.AcquireReadLock(value);
+            ValueStruct.Copy(value, (ValueStruct*)dst);
+            ValueStruct.ReleaseReadLock(value);
+        }
+
+        // Upsert functions
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SingleWriter(KeyStruct* key, ValueStruct* src, ValueStruct* dst)
+        {
+            ValueStruct.Copy(src, dst);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ConcurrentWriter(KeyStruct* key, ValueStruct* src, ValueStruct* dst)
+        {
+            ValueStruct.AcquireWriteLock(dst);
+            ValueStruct.Copy(src, dst);
+            ValueStruct.ReleaseWriteLock(dst);
+        }
+
+        // RMW functions
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int InitialValueLength(KeyStruct* key, InputStruct* input)
+        {
+            return ValueStruct.GetLength(default(ValueStruct*));
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void InitialUpdater(KeyStruct* key, InputStruct* input, ValueStruct* value)
+        {
+            ValueStruct.Copy((ValueStruct*)input, value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void InPlaceUpdater(KeyStruct* key, InputStruct* input, ValueStruct* value)
+        {
+            ValueStruct.AcquireWriteLock(value);
+            value->vfield1 += input->ifield1;
+            value->vfield2 += input->ifield2;
+            ValueStruct.ReleaseWriteLock(value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyUpdater(KeyStruct* key, InputStruct* input, ValueStruct* oldValue, ValueStruct* newValue)
+        {
+            newValue->vfield1 = oldValue->vfield1 + input->ifield1;
+            newValue->vfield2 = oldValue->vfield2 + input->ifield2;
+        }
+    }
+}

--- a/cs/playground/ManagedSampleCore/ICustomFaster.cs
+++ b/cs/playground/ManagedSampleCore/ICustomFaster.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using FASTER.core;
+using System;
+
+namespace ManagedSample1
+{
+    public unsafe interface ICustomFaster
+    {
+        /* Thread-related operations */
+        Guid StartSession();
+        long ContinueSession(Guid guid);
+        void StopSession();
+        void Refresh();
+
+        /* Store Interface */
+        Status Read(KeyStruct* key, InputStruct* input, OutputStruct* output, Empty* context, long lsn);
+        Status Upsert(KeyStruct* key, ValueStruct* value, Empty* context, long lsn);
+        Status RMW(KeyStruct* key, InputStruct* input, Empty* context, long lsn);
+        Status Delete(KeyStruct* key, Empty* context, long lsn);
+        bool CompletePending(bool wait);
+
+        /* Statistics */
+        long Size { get; }
+        void DumpDistribution();
+    }
+}
+

--- a/cs/playground/ManagedSampleCore/InputStruct.cs
+++ b/cs/playground/ManagedSampleCore/InputStruct.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace ManagedSample1
+{
+    public unsafe struct InputStruct
+    {
+        public long ifield1;
+        public long ifield2;
+
+        public static InputStruct* MoveToContext(InputStruct* input)
+        {
+            return input;
+        }
+    }
+}

--- a/cs/playground/ManagedSampleCore/KeyStruct.cs
+++ b/cs/playground/ManagedSampleCore/KeyStruct.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using FASTER.core;
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+namespace ManagedSample1
+{
+    public unsafe struct KeyStruct
+    {
+        public const int physicalSize = sizeof(long) + sizeof(long);
+        public long kfield1;
+        public long kfield2;
+
+        public static long GetHashCode(KeyStruct* key)
+        {
+            return Utility.GetHashCode(*((long*)key));
+        }
+        public static bool Equals(KeyStruct* k1, KeyStruct* k2)
+        {
+            return k1->kfield1 == k2->kfield1 && k1->kfield2 == k2->kfield2;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetLength(KeyStruct* key)
+        {
+            return physicalSize;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Copy(KeyStruct* src, KeyStruct* dst)
+        {
+            dst->kfield1 = src->kfield1;
+            dst->kfield2 = src->kfield2;
+        }
+
+        #region Serialization
+        public static bool HasObjectsToSerialize()
+        {
+            return false;
+        }
+
+        public static void Serialize(KeyStruct* key, Stream toStream)
+        {
+            throw new NotImplementedException();
+        }
+
+        public static void Deserialize(KeyStruct* key, Stream fromStream)
+        {
+            throw new NotImplementedException();
+        }
+
+        public static void Free(KeyStruct* key)
+        {
+            throw new NotImplementedException();
+        }
+        #endregion
+
+        public static KeyStruct* MoveToContext(KeyStruct* key)
+        {
+            return key;
+        }
+    }
+}

--- a/cs/playground/ManagedSampleCore/ManagedSampleCore.csproj
+++ b/cs/playground/ManagedSampleCore/ManagedSampleCore.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <Platforms>x64</Platforms>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>ManagedSampleCore</RootNamespace>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <DefineConstants>TRACE</DefineConstants>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\x64\Release\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\core\FASTER.core.csproj" />
+  </ItemGroup>
+</Project>

--- a/cs/playground/ManagedSampleCore/OutputStruct.cs
+++ b/cs/playground/ManagedSampleCore/OutputStruct.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace ManagedSample1
+{
+    public unsafe struct OutputStruct
+    {
+        public ValueStruct value;
+
+        public static OutputStruct* MoveToContext(OutputStruct* output)
+        {
+            return output;
+        }
+
+    }
+}

--- a/cs/playground/ManagedSampleCore/Program.cs
+++ b/cs/playground/ManagedSampleCore/Program.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using FASTER.core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ManagedSample1
+{
+    public class Program
+    {
+        static unsafe void Main(string[] args)
+        {
+            var fht = FASTERFactory.Create
+                <KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty, Functions, ICustomFaster>
+                (128, FASTERFactory.CreateLogDevice(""), LogMutableFraction: 0.5);
+
+            fht.StartSession();
+
+            OutputStruct output = default(OutputStruct);
+
+            var key1 = new KeyStruct { kfield1 = 13, kfield2 = 14 };
+            var value = new ValueStruct { vfield1 = 23, vfield2 = 24 };
+
+            // Upsert item into store, and read it back
+            fht.Upsert(&key1, &value, null, 0);
+            fht.Read(&key1, null, &output, null, 0);
+
+            if ((output.value.vfield1 != value.vfield1) || (output.value.vfield2 != value.vfield2))
+                Console.WriteLine("Error!");
+            else
+                Console.WriteLine("Success!");
+
+            var key2 = new KeyStruct { kfield1 = 15, kfield2 = 16 };
+            var input = new InputStruct { ifield1 = 25, ifield2 = 26 };
+
+            // Two read-modify-write (RMW) operations (sum aggregator)
+            // Followed by read of result
+            fht.RMW(&key2, &input, null, 0);
+            fht.RMW(&key2, &input, null, 0);
+            fht.Read(&key2, null, &output, null, 0);
+
+            if ((output.value.vfield1 != input.ifield1*2) || (output.value.vfield2 != input.ifield2*2))
+                Console.WriteLine("Error!");
+            else
+                Console.WriteLine("Success!");
+
+            fht.StopSession();
+
+            Console.ReadLine();
+        }
+    }
+}

--- a/cs/playground/ManagedSampleCore/Properties/AssemblyInfo.cs
+++ b/cs/playground/ManagedSampleCore/Properties/AssemblyInfo.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("17bdd0a5-98e5-464a-8a00-050d9ff4c562")]

--- a/cs/playground/ManagedSampleCore/ValueStruct.cs
+++ b/cs/playground/ManagedSampleCore/ValueStruct.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+namespace ManagedSample1
+{
+    public unsafe struct ValueStruct
+    {
+        public const int physicalSize = sizeof(long) + sizeof(long);
+        public long vfield1;
+        public long vfield2;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetLength(ValueStruct* input)
+        {
+            return physicalSize;
+        }
+
+        public static void Copy(ValueStruct* src, ValueStruct* dst)
+        {
+            dst->vfield1 = src->vfield1;
+            dst->vfield2 = src->vfield2;
+        }
+
+        // Shared read/write capabilities on value
+        public static void AcquireReadLock(ValueStruct* value)
+        {
+        }
+
+        public static void ReleaseReadLock(ValueStruct* value)
+        {
+        }
+
+        public static void AcquireWriteLock(ValueStruct* value)
+        {
+        }
+
+        public static void ReleaseWriteLock(ValueStruct* value)
+        {
+        }
+
+        #region Serialization
+        public static bool HasObjectsToSerialize()
+        {
+            return false;
+        }
+
+        public static void Serialize(ValueStruct* key, Stream toStream)
+        {
+            throw new NotImplementedException();
+        }
+
+        public static void Deserialize(ValueStruct* key, Stream fromStream)
+        {
+            throw new NotImplementedException();
+        }
+
+        public static void Free(ValueStruct* key)
+        {
+            throw new NotImplementedException();
+        }
+        #endregion
+
+        public static ValueStruct* MoveToContext(ValueStruct* value)
+        {
+            return value;
+        }
+    }
+}

--- a/cs/src/core/Epochs/LightEpoch.cs
+++ b/cs/src/core/Epochs/LightEpoch.cs
@@ -438,7 +438,8 @@ namespace FASTER.core
         /// <returns></returns>
         private int ReserveEntryForThread()
         {
-            int threadId = (int)Native32.GetCurrentThreadId();
+            // for portability(run on non-windows platform)
+            int threadId = Environment.OSVersion.Platform == PlatformID.Win32NT ? (int)Native32.GetCurrentThreadId() : Thread.CurrentThread.ManagedThreadId;
             int startIndex = Utility.Murmur3(threadId);
             return ReserveEntry(startIndex, threadId);
         }

--- a/cs/src/core/FASTER.core.csproj
+++ b/cs/src/core/FASTER.core.csproj
@@ -62,6 +62,29 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <EmbeddedResource Include="Index/FASTER/AsyncIO.cs" />
+    <EmbeddedResource Include="Index/FASTER/Checkpoint.cs" />
+    <EmbeddedResource Include="Index/Common/Contexts.cs" />
+    <EmbeddedResource Include="Index/FASTER/FASTER.cs" />
+    <EmbeddedResource Include="Index/FASTER/FASTERBase.cs" />
+    <EmbeddedResource Include="Index/FASTER/FASTERImpl.cs" />
+    <EmbeddedResource Include="Index/FASTER/FASTERThread.cs" />
+    <EmbeddedResource Include="ManagedLayer/IFASTER_Mixed.cs" />
+    <EmbeddedResource Include="Index/FASTER/IndexCheckpoint.cs" />
+    <EmbeddedResource Include="Index/FASTER/IndexRecovery.cs" />
+    <EmbeddedResource Include="Index/FASTER/Recovery.cs" />
+    <EmbeddedResource Include="Index/Common/Layout.cs" />
+    <EmbeddedResource Include="ManagedLayer/MixedContextWrapper.cs" />
+    <EmbeddedResource Include="ManagedLayer/MixedFunctionsWrapper.cs" />
+    <EmbeddedResource Include="ManagedLayer/MixedInputWrapper.cs" />
+    <EmbeddedResource Include="ManagedLayer/MixedKeyWrapper.cs" />
+    <EmbeddedResource Include="ManagedLayer/MixedManagedFAST.cs" />
+    <EmbeddedResource Include="ManagedLayer/MixedOutputWrapper.cs" />
+    <EmbeddedResource Include="ManagedLayer/MixedUnwrappedTypes.cs" />
+    <EmbeddedResource Include="ManagedLayer/MixedUserFunctions.cs" />
+    <EmbeddedResource Include="ManagedLayer/MixedValueWrapper.cs" />
+    <EmbeddedResource Include="Allocator/PersistentMemoryMalloc.cs" />
+    <EmbeddedResource Include="Utilities/AsyncResultTypes.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
if merged, published app with memory-only pattern on linux will be able to run.
this fix following problems.

* strange NetCoreAssemblyReferences list is built in linux(because of TRUSTED_PLATFORM_ASSEMBLIES's spec)
* exception occured when `dotnet run` because of differences of handling resource between core and netframework
    * get `..\Index\FASTER\FASTERImpl.cs;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8` from ResourceManager.GetString in netcoreapp
    * using EmbeddedResource instead
* exception occured when calling LightEpoch.ReserveEntryForThread in linux(using Thread.CurrentThread.ManagedThreadId instead)
    * be careful to performance regression