### PR TITLE
Used the CI service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: cpp
+install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt update
+  - sudo apt install -y g++-7 libaio-dev uuid-dev libtbb-dev
+script:
+  - export CXX='g++-7'
+  - cd cc
+  - mkdir -p build/Debug build/Release
+  - cd build/Debug
+  - cmake -DCMAKE_BUILD_TYPE=Debug ../..
+  - make -j
+  - cd ../../build/Release
+  - cmake -DCMAKE_BUILD_TYPE=Release ../..
+  - make -j


### PR DESCRIPTION
Hi,
I feel that it is very convenient to use a CI service to ensure pull requests can be built.
Using Travis CI may be suitable for that purpose ([Microsoft/TypeScript repository uses Travis CI](https://travis-ci.org/Microsoft/TypeScript/pull_requests)).

I already tested that CI service by my forked FASTER repository. Please check below.
https://travis-ci.org/quiye/FASTER/builds/436895454