### PR TITLE
Add missing dependency on Microsoft.CodeAnalysis.Analyzers v1.1.0

### DIFF
--- a/cs/src/core/FASTER.core.csproj
+++ b/cs/src/core/FASTER.core.csproj
@@ -35,9 +35,8 @@
   </PropertyGroup>
 
     <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting">
-      <Version>2.8.2</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.8.2" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
   </ItemGroup>


### PR DESCRIPTION
Add missing dependency on `Microsoft.CodeAnalysis.Analyzers` package, to ensure correct version is restored.

A dependency on package `Microsoft.CodeAnalysis.Analyzers` v1.1.0 implicitly shows up for csharp projects in VS2017, but that package version will not be downloaded / restored on a new machine unless the dependency is called out explicitly in the .csproj file.

