### PR TITLE
Add azure-pipelines.yml file for Azure Pipeline build.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,42 @@
+# .NET Desktop
+# Build and run tests for .NET Desktop or Windows classic desktop solutions.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://docs.microsoft.com/vsts/pipelines/apps/windows/dot-net
+
+variables:
+  solution: 'cs/FASTER.sln'
+
+jobs:
+- job: Build
+  strategy:
+    maxParallel: 2
+    matrix:
+      AnyCPU-Debug:
+        buildPlatform: 'Any CPU'
+        buildConfiguration: 'Debug'
+      AnyCPU-Release:
+        buildPlatform: 'Any CPU'
+        buildConfiguration: 'Release'
+      x64-Debug:
+        buildPlatform: 'x64'
+        buildConfiguration: 'Debug'
+      x64-Release:
+        buildPlatform: 'x64'
+        buildConfiguration: 'Release'
+  steps:
+  - task: NuGetToolInstaller@0
+
+  - task: NuGetCommand@2
+    inputs:
+      restoreSolution: '$(solution)'
+
+  - task: VSBuild@1
+    inputs:
+      solution: '$(solution)'
+      platform: '$(buildPlatform)'
+      configuration: '$(buildConfiguration)'
+
+  - task: VSTest@2
+    inputs:
+      platform: '$(buildPlatform)'
+      configuration: '$(buildConfiguration)'


### PR DESCRIPTION
Add a build definition file for Azure Pipeline build, to build and test the C# code in this repo.
https://docs.microsoft.com/vsts/pipelines/apps/windows/dot-net

Runs multiple jobs to build + test each platform/config combination.
- (x64 | AnyCPU) * (Debug | Release)
- Runs all test cases found in builds.
- maxParallel = 2

I tested this on a private VSTS account so I can confirm this build definition runs successfully on the standard `Hosted VS2017` build hosts.

Currently, the only CI build configured for this project is for the C++ code.
https://github.com/Microsoft/FASTER/blob/master/.travis.yml
https://travis-ci.org/Microsoft/FASTER

If you want to hook this up as a CI build and PR gate check (recommended), then there are a few additional manual steps required to set up a new Azure build pipeline on your VSTS instance (see docs below).
https://docs.microsoft.com/en-us/azure/devops/pipelines/get-started-yaml
Feel free to DM me if you need any help getting that part set up.
