### PR TITLE
Incremental large obj

### DIFF
--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -266,7 +266,7 @@ namespace FASTER.core
         /// <param name="reader"></param>
         public void Initialize(StreamReader reader)
         {
-            guids = new Guid[64];
+            guids = new Guid[LightEpoch.kTableSize + 1];
             continueTokens = new Dictionary<Guid, long>();
 
             string value = reader.ReadLine();

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -236,6 +236,10 @@ namespace FASTER.core
         /// Tokens per guid
         /// </summary>
         public Dictionary<Guid, long> continueTokens;
+        /// <summary>
+        /// Object log segment offsets
+        /// </summary>
+        public long[] objectLogSegmentOffsets;
 
         /// <summary>
         /// Initialize
@@ -253,6 +257,7 @@ namespace FASTER.core
             finalLogicalAddress = 0;
             guids = new Guid[LightEpoch.kTableSize+1];
             continueTokens = new Dictionary<Guid, long>();
+            objectLogSegmentOffsets = null;
         }
 
         /// <summary>
@@ -289,6 +294,19 @@ namespace FASTER.core
             {
                 value = reader.ReadLine();
                 guids[i] = Guid.Parse(value);
+            }
+
+            // Read object log segment offsets
+            value = reader.ReadLine();
+            var numSegments = int.Parse(value);
+            if (numSegments > 0)
+            {
+                objectLogSegmentOffsets = new long[numSegments];
+                for (int i = 0; i < numSegments; i++)
+                {
+                    value = reader.ReadLine();
+                    objectLogSegmentOffsets[i] = long.Parse(value);
+                }
             }
         }
 
@@ -363,6 +381,16 @@ namespace FASTER.core
             for(int i = 0; i < numThreads; i++)
             {
                 writer.WriteLine(guids[i]);
+            }
+
+            //Write object log segment offsets
+            writer.WriteLine(objectLogSegmentOffsets == null ? 0 : objectLogSegmentOffsets.Length);
+            if (objectLogSegmentOffsets != null)
+            {
+                for (int i = 0; i < objectLogSegmentOffsets.Length; i++)
+                {
+                    writer.WriteLine(objectLogSegmentOffsets[i]);
+                }
             }
         }
     }

--- a/cs/src/core/Index/FASTER/AsyncIO.cs
+++ b/cs/src/core/Index/FASTER/AsyncIO.cs
@@ -18,7 +18,6 @@ namespace FASTER.core
     /// </summary>
     public unsafe partial class FasterKV : FasterBase, IFasterKV
     {
-
         private void AsyncGetFromDisk(long fromLogical,
                                       int numRecords,
                                       IOCompletionCallback callback,
@@ -152,6 +151,8 @@ namespace FASTER.core
 
     internal unsafe partial class PersistentMemoryMalloc : IAllocator
     {
+        const int kObjectBlockSize = 100 * (1 << 20);
+
         #region Async file operations
 
         /// <summary>
@@ -359,9 +360,11 @@ namespace FASTER.core
         /// <param name="completed"></param>
         public void AsyncFlushPagesToDevice(long startPage, long endPage, IDevice device, IDevice objectLogDevice, out CountdownEvent completed)
         {
+            //Debugger.Break();
             int totalNumPages = (int)(endPage - startPage);
             completed = new CountdownEvent(totalNumPages);
 
+            var _segmentOffsets = new long[SegmentBufferSize];
             for (long flushPage = startPage; flushPage < endPage; flushPage++)
             {
                 var asyncResult = new PageAsyncFlushResult<Empty>
@@ -377,7 +380,7 @@ namespace FASTER.core
                             (ulong)(AlignedPageSizeBytes * (flushPage - startPage)),
                             PageSize,
                             AsyncFlushPageToDeviceCallback,
-                            asyncResult, device, objectLogDevice);
+                            asyncResult, device, objectLogDevice, flushPage, _segmentOffsets);
             }
         }
 
@@ -386,8 +389,10 @@ namespace FASTER.core
 
         private void WriteAsync<TContext>(IntPtr alignedSourceAddress, ulong alignedDestinationAddress, uint numBytesToWrite,
                                 IOCompletionCallback callback, PageAsyncFlushResult<TContext> asyncResult,
-                                IDevice device, IDevice objlogDevice)
+                                IDevice device, IDevice objlogDevice, long sourceLogicalPage = -1, long[] segmentOffsets = null)
         {
+            if (segmentOffsets == null) segmentOffsets = this.segmentOffsets;
+
             if (!Key.HasObjectsToSerialize() && !Value.HasObjectsToSerialize())
             {
                 device.WriteAsync(alignedSourceAddress, alignedDestinationAddress,
@@ -406,7 +411,8 @@ namespace FASTER.core
             asyncResult.freeBuffer1 = buffer;
 
             // Correct for page 0 of HLOG
-            if (alignedDestinationAddress >> LogPageSizeBits == 0)
+            if (sourceLogicalPage < 0) sourceLogicalPage = (long)(alignedDestinationAddress >> LogPageSizeBits);
+            if (sourceLogicalPage == 0)
                 ptr += Constants.kFirstValidAddress;
 
             while (ptr < (long)buffer.aligned_pointer + numBytesToWrite)
@@ -434,7 +440,7 @@ namespace FASTER.core
                         addr.Add((long)value);
                     }
 
-                    if (ms.Position > 100*(1<<20))
+                    if (ms.Position > kObjectBlockSize)
                     {
                         // write out the chunk
                         var _s = ms.ToArray();
@@ -457,7 +463,7 @@ namespace FASTER.core
                         objlogDevice.WriteAsync(
                             (IntPtr)_objBuffer.aligned_pointer,
                             (int)(alignedDestinationAddress >> LogSegmentSizeBits),
-                            (ulong)_objAddr, (uint)_alignedLength, AsyncFlushPartialObjectLogCallback, asyncResult);
+                            (ulong)_objAddr, (uint)_alignedLength, AsyncFlushPartialObjectLogCallback<TContext>, asyncResult);
                         asyncResult.done.WaitOne();
                         _objBuffer.Return();
                         ms.Close();
@@ -567,7 +573,7 @@ namespace FASTER.core
         /// <param name="errorCode"></param>
         /// <param name="numBytes"></param>
         /// <param name="overlap"></param>
-        private void AsyncFlushPartialObjectLogCallback(uint errorCode, uint numBytes, NativeOverlapped* overlap)
+        private void AsyncFlushPartialObjectLogCallback<TContext>(uint errorCode, uint numBytes, NativeOverlapped* overlap)
         {
             if (errorCode != 0)
             {
@@ -575,7 +581,7 @@ namespace FASTER.core
             }
 
             // Set the page status to flushed
-            PageAsyncFlushResult<Empty> result = (PageAsyncFlushResult<Empty>)Overlapped.Unpack(overlap).AsyncResult;
+            PageAsyncFlushResult<TContext> result = (PageAsyncFlushResult<TContext>)Overlapped.Unpack(overlap).AsyncResult;
             result.done.Set();
 
             Overlapped.Free(overlap);
@@ -605,91 +611,30 @@ namespace FASTER.core
 
         private void AsyncReadPageCallback<TContext>(uint errorCode, uint numBytes, NativeOverlapped* overlap)
         {
+            //Debugger.Break();
+
             if (errorCode != 0)
             {
                 Trace.TraceError("OverlappedStream GetQueuedCompletionStatus error: {0}", errorCode);
             }
 
             PageAsyncReadResult<TContext> result = (PageAsyncReadResult<TContext>)Overlapped.Unpack(overlap).AsyncResult;
+            
 
-            if (Interlocked.Decrement(ref result.count) == 1)
+            long ptr = (long)pointers[result.page % BufferSize];
+            // Correct for page 0 of HLOG
+            if (result.page == 0)
+                ptr += Constants.kFirstValidAddress;
+
+            if (result.resumeptr > ptr)
+                ptr = result.resumeptr;
+
+            if (ptr < result.untilptr)
             {
-                // We will be issuing another I/O, so free this overlap
-                Overlapped.Free(overlap);
-
-                long ptr = (long)pointers[result.page % BufferSize];
-                // Correct for page 0 of HLOG
-                if (result.page == 0)
-                    ptr += Constants.kFirstValidAddress;
-
-                long minObjAddress = long.MaxValue;
-                long maxObjAddress = long.MinValue;
-
-                while (ptr < (long)pointers[result.page % BufferSize] + PageSize)
-                {
-                    if (!Layout.GetInfo(ptr)->Invalid)
-                    {
-                        if (Key.HasObjectsToSerialize())
-                        {
-                            Key* key = Layout.GetKey(ptr);
-                            var addr = ((AddressInfo*)key)->Address;
-                            if (addr < minObjAddress) minObjAddress = addr;
-                            addr += ((AddressInfo*)key)->Size;
-                            if (addr > maxObjAddress) maxObjAddress = addr;
-                        }
-
-                        if (Value.HasObjectsToSerialize())
-                        {
-                            Value* value = Layout.GetValue(ptr);
-                            var addr = ((AddressInfo*)value)->Address;
-                            if (addr < minObjAddress) minObjAddress = addr;
-                            addr += ((AddressInfo*)value)->Size;
-                            if (addr > maxObjAddress) maxObjAddress = addr;
-                        }
-                    }
-                    ptr += Layout.GetPhysicalSize(ptr);
-                }
-
-                // Object log fragment should be aligned by construction
-                Debug.Assert(minObjAddress % sectorSize == 0);
-
-
-                var to_read_long = maxObjAddress - minObjAddress;
-                if (to_read_long > int.MaxValue)
-                    throw new Exception("Unable to read object page, total size greater than 2GB: " + to_read_long);
-
-                var to_read = (int)to_read_long;
-
-                // Handle the case where no objects are to be written
-                if (minObjAddress == long.MaxValue && maxObjAddress == long.MinValue)
-                {
-                    minObjAddress = 0;
-                    maxObjAddress = 0;
-                    to_read = 0;
-                }
-
-                var objBuffer = ioBufferPool.Get(to_read);
-                result.freeBuffer1 = objBuffer;
-                var alignedLength = (to_read + (sectorSize - 1)) & ~(sectorSize - 1);
-
-                // Request objects from objlog
-                result.objlogDevice.ReadAsync(
-                    (int)(result.page >> (LogSegmentSizeBits-LogPageSizeBits)),
-                    (ulong)minObjAddress, 
-                    (IntPtr)objBuffer.aligned_pointer, (uint)alignedLength, AsyncReadPageCallback<TContext>, result);
-            }
-            else
-            {
-                // Load objects from buffer into memory
-                long ptr = (long)pointers[result.page % BufferSize];
-                // Correct for page 0 of HLOG
-                if (result.page == 0)
-                    ptr += Constants.kFirstValidAddress;
-
                 MemoryStream ms = new MemoryStream(result.freeBuffer1.buffer);
                 ms.Seek(result.freeBuffer1.offset + result.freeBuffer1.valid_offset, SeekOrigin.Begin);
 
-                while (ptr < (long)pointers[result.page % BufferSize] + PageSize)
+                while (ptr < result.untilptr)
                 {
                     if (!Layout.GetInfo(ptr)->Invalid)
                     {
@@ -705,14 +650,98 @@ namespace FASTER.core
                     }
                     ptr += Layout.GetPhysicalSize(ptr);
                 }
+
                 ms.Dispose();
+                result.freeBuffer1.Return();
+                result.freeBuffer1.buffer = null;
+                result.resumeptr = ptr;
+            }
+
+            if (ptr >= (long)pointers[result.page % BufferSize] + PageSize)
+            {
 
                 result.Free();
 
                 // Call the "real" page read callback
                 result.callback(errorCode, numBytes, overlap);
+                return;
             }
-           
+
+            Overlapped.Free(overlap);
+
+            long minObjAddress = long.MaxValue;
+            long maxObjAddress = long.MinValue;
+            while (ptr < (long)pointers[result.page % BufferSize] + PageSize)
+            {
+                if (!Layout.GetInfo(ptr)->Invalid)
+                {
+
+                    if (Key.HasObjectsToSerialize())
+                    {
+                        Key* key = Layout.GetKey(ptr);
+                        var addr = ((AddressInfo*)key)->Address;
+
+                        if (minObjAddress != long.MaxValue && (addr - minObjAddress > kObjectBlockSize))
+                        {
+                            Debug.Assert(maxObjAddress % sectorSize == 0);
+                            break;
+                        }
+
+                        if (addr < minObjAddress) minObjAddress = addr;
+                        addr += ((AddressInfo*)key)->Size;
+                        if (addr > maxObjAddress) maxObjAddress = addr;
+                    }
+
+
+                    if (Value.HasObjectsToSerialize())
+                    {
+                        Value* value = Layout.GetValue(ptr);
+                        var addr = ((AddressInfo*)value)->Address;
+
+                        if (minObjAddress != long.MaxValue && (addr - minObjAddress > kObjectBlockSize))
+                        {
+                            Debug.Assert(maxObjAddress % sectorSize == 0);
+                            break;
+                        }
+
+                        if (addr < minObjAddress) minObjAddress = addr;
+                        addr += ((AddressInfo*)value)->Size;
+                        if (addr > maxObjAddress) maxObjAddress = addr;
+                    }
+                }
+                ptr += Layout.GetPhysicalSize(ptr);
+            }
+
+            result.untilptr = ptr;
+
+            // Object log fragment should be aligned by construction
+            Debug.Assert(minObjAddress % sectorSize == 0);
+
+
+            var to_read_long = maxObjAddress - minObjAddress;
+            if (to_read_long > int.MaxValue)
+                throw new Exception("Unable to read object page, total size greater than 2GB: " + to_read_long);
+
+            var to_read = (int)to_read_long;
+
+            // Handle the case where no objects are to be written
+            if (minObjAddress == long.MaxValue && maxObjAddress == long.MinValue)
+            {
+                minObjAddress = 0;
+                maxObjAddress = 0;
+                to_read = 0;
+            }
+
+            var objBuffer = ioBufferPool.Get(to_read);
+            result.freeBuffer1 = objBuffer;
+            var alignedLength = (to_read + (sectorSize - 1)) & ~(sectorSize - 1);
+
+            // Request objects from objlog
+            result.objlogDevice.ReadAsync(
+                (int)(result.page >> (LogSegmentSizeBits-LogPageSizeBits)),
+                (ulong)minObjAddress, 
+                (IntPtr)objBuffer.aligned_pointer, (uint)alignedLength, AsyncReadPageCallback<TContext>, result);
+
         }
         #endregion
     }

--- a/cs/src/core/Index/FASTER/AsyncIO.cs
+++ b/cs/src/core/Index/FASTER/AsyncIO.cs
@@ -152,6 +152,7 @@ namespace FASTER.core
     internal unsafe partial class PersistentMemoryMalloc : IAllocator
     {
         const int kObjectBlockSize = 100 * (1 << 20);
+        public long[] segmentOffsets = new long[SegmentBufferSize];
 
         #region Async file operations
 
@@ -360,7 +361,6 @@ namespace FASTER.core
         /// <param name="completed"></param>
         public void AsyncFlushPagesToDevice(long startPage, long endPage, IDevice device, IDevice objectLogDevice, out CountdownEvent completed)
         {
-            //Debugger.Break();
             int totalNumPages = (int)(endPage - startPage);
             completed = new CountdownEvent(totalNumPages);
 
@@ -383,9 +383,6 @@ namespace FASTER.core
                             asyncResult, device, objectLogDevice, flushPage, _segmentOffsets);
             }
         }
-
-
-        long[] segmentOffsets = new long[SegmentBufferSize];
 
         private void WriteAsync<TContext>(IntPtr alignedSourceAddress, ulong alignedDestinationAddress, uint numBytesToWrite,
                                 IOCompletionCallback callback, PageAsyncFlushResult<TContext> asyncResult,
@@ -611,8 +608,6 @@ namespace FASTER.core
 
         private void AsyncReadPageCallback<TContext>(uint errorCode, uint numBytes, NativeOverlapped* overlap)
         {
-            //Debugger.Break();
-
             if (errorCode != 0)
             {
                 Trace.TraceError("OverlappedStream GetQueuedCompletionStatus error: {0}", errorCode);

--- a/cs/src/core/Index/FASTER/Checkpoint.cs
+++ b/cs/src/core/Index/FASTER/Checkpoint.cs
@@ -240,6 +240,8 @@ namespace FASTER.core
                         }
                     case Phase.WAIT_PENDING:
                         {
+                            _hybridLogCheckpoint.info.objectLogSegmentOffsets = new long[hlog.segmentOffsets.Length];
+                            Array.Copy(hlog.segmentOffsets, _hybridLogCheckpoint.info.objectLogSegmentOffsets, hlog.segmentOffsets.Length);
                             MakeTransition(intermediateState, nextState);
                             break;
                         }

--- a/cs/src/core/Index/FASTER/Recovery.cs
+++ b/cs/src/core/Index/FASTER/Recovery.cs
@@ -154,7 +154,7 @@ namespace FASTER.core
 
             var startPage = hlog.GetPage(fromAddress);
             var endPage = hlog.GetPage(untilAddress);
-            if (untilAddress > hlog.GetStartLogicalAddress(endPage))
+            if ((untilAddress > hlog.GetStartLogicalAddress(endPage)) && (untilAddress > fromAddress))
             {
                 endPage++;
             }
@@ -274,7 +274,7 @@ namespace FASTER.core
                 var endLogicalAddress = hlog.GetStartLogicalAddress(page + 1);
 
                 // Perform recovery if page in fuzzy portion of the log
-                if (fromAddress < endLogicalAddress)
+                if ((fromAddress < endLogicalAddress) && (fromAddress < untilAddress))
                 {
                     /*
                      * Handling corner-cases:
@@ -306,6 +306,8 @@ namespace FASTER.core
                 // OS thread flushes current page and issues a read request if necessary
                 recoveryStatus.readStatus[pageIndex] = ReadStatus.Pending;
                 recoveryStatus.flushStatus[pageIndex] = FlushStatus.Pending;
+
+                // Write back records from snapshot to main hybrid log
                 hlog.AsyncFlushPages(page, 1, AsyncFlushPageCallbackForRecovery, recoveryStatus);
             }
 

--- a/cs/src/core/Index/FASTER/Recovery.cs
+++ b/cs/src/core/Index/FASTER/Recovery.cs
@@ -252,19 +252,15 @@ namespace FASTER.core
             int totalPagesToRead = (int)(endPage - startPage);
             int numPagesToReadFirst = Math.Min(capacity, totalPagesToRead);
 
-
-
-
+            hlog.AsyncReadPagesFromDevice(startPage, numPagesToReadFirst,
+                            AsyncReadPagesCallbackForRecovery,
+                            recoveryStatus,
+                            recoveryStatus.recoveryDevicePageOffset,
+                            recoveryStatus.recoveryDevice, recoveryStatus.objectLogRecoveryDevice);
 
 
             for (long page = startPage; page < endPage; page++)
             {
-                hlog.AsyncReadPagesFromDevice(page,
-                                1,
-                                AsyncReadPagesCallbackForRecovery,
-                                recoveryStatus,
-                                recoveryStatus.recoveryDevicePageOffset,
-                                recoveryStatus.recoveryDevice, recoveryStatus.objectLogRecoveryDevice);
 
                 // Ensure the page is read from file
                 int pageIndex = hlog.GetPageIndexForPage(page);

--- a/cs/src/core/Index/FASTER/Recovery.cs
+++ b/cs/src/core/Index/FASTER/Recovery.cs
@@ -22,6 +22,10 @@ namespace FASTER.core
             _indexCheckpoint.Recover(indexToken);
             _hybridLogCheckpoint.Recover(hybridLogToken);
 
+            // Recover segment offsets for object log
+            if (_hybridLogCheckpoint.info.objectLogSegmentOffsets != null)
+                hlog.segmentOffsets = _hybridLogCheckpoint.info.objectLogSegmentOffsets;
+
             _indexCheckpoint.main_ht_device = new LocalStorageDevice(DirectoryConfiguration.GetPrimaryHashTableFileName(_indexCheckpoint.info.token));
             _indexCheckpoint.ofb_device = new LocalStorageDevice(DirectoryConfiguration.GetOverflowBucketsFileName(_indexCheckpoint.info.token));
 

--- a/cs/src/core/Index/FASTER/Recovery.cs
+++ b/cs/src/core/Index/FASTER/Recovery.cs
@@ -249,17 +249,19 @@ namespace FASTER.core
             int numPagesToReadFirst = Math.Min(capacity, totalPagesToRead);
 
 
-            hlog.AsyncReadPagesFromDevice(startPage,
-                                            numPagesToReadFirst,
-                                            AsyncReadPagesCallbackForRecovery,
-                                            recoveryStatus,
-                                            recoveryStatus.recoveryDevicePageOffset,
-                                            recoveryStatus.recoveryDevice, recoveryStatus.objectLogRecoveryDevice);
+
 
 
 
             for (long page = startPage; page < endPage; page++)
             {
+                hlog.AsyncReadPagesFromDevice(page,
+                                1,
+                                AsyncReadPagesCallbackForRecovery,
+                                recoveryStatus,
+                                recoveryStatus.recoveryDevicePageOffset,
+                                recoveryStatus.recoveryDevice, recoveryStatus.objectLogRecoveryDevice);
+
                 // Ensure the page is read from file
                 int pageIndex = hlog.GetPageIndexForPage(page);
                 while (recoveryStatus.readStatus[pageIndex] == ReadStatus.Pending)

--- a/cs/src/core/Utilities/AsyncResultTypes.cs
+++ b/cs/src/core/Utilities/AsyncResultTypes.cs
@@ -77,7 +77,7 @@ namespace FASTER.core
         public IDevice objlogDevice;
         public SectorAlignedMemory freeBuffer1;
         public SectorAlignedMemory freeBuffer2;
-
+        public AutoResetEvent done;
 
         public bool IsCompleted => throw new NotImplementedException();
 

--- a/cs/src/core/Utilities/AsyncResultTypes.cs
+++ b/cs/src/core/Utilities/AsyncResultTypes.cs
@@ -45,6 +45,8 @@ namespace FASTER.core
         public IOCompletionCallback callback;
         public int count;
         public IDevice objlogDevice;
+        public long resumeptr;
+        public long untilptr;
 
         public bool IsCompleted => throw new NotImplementedException();
 

--- a/cs/test/LargeObjectTests.cs
+++ b/cs/test/LargeObjectTests.cs
@@ -21,8 +21,8 @@ namespace FASTER.test.largeobjects
         private IManagedFasterKV<MyKey, MyLargeValue, MyInput, MyLargeOutput, MyContext> fht2;
         private IDevice log, objlog;
         
-        [SetUp]
-        public void Setup()
+        [Test]
+        public void LargeObjectTest1()
         {
             log = FasterFactory.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog", deleteOnClose: true);
             objlog = FasterFactory.CreateObjectLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog", deleteOnClose: true);
@@ -42,20 +42,8 @@ namespace FASTER.test.largeobjects
                 logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 9, MemorySizeBits = 13 },
                 checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.Snapshot }
                 );
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            log.Close();
-            objlog.Close();
-            new DirectoryInfo(TestContext.CurrentContext.TestDirectory + "\\checkpoints").Delete(true);
-        }
 
 
-        [Test]
-        public void LargeObjectTest1()
-        {
             int maxSize = 1000;
             int numOps = 5000;
             //var value = new MyLargeValue(size);
@@ -92,6 +80,73 @@ namespace FASTER.test.largeobjects
             fht2.StopSession();
             fht2.Dispose();
 
+            log.Close();
+            objlog.Close();
+            new DirectoryInfo(TestContext.CurrentContext.TestDirectory + "\\checkpoints").Delete(true);
+        }
+
+        [Test]
+        public void LargeObjectTest2()
+        {
+            log = FasterFactory.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog", deleteOnClose: true);
+            objlog = FasterFactory.CreateObjectLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog", deleteOnClose: true);
+
+            Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints");
+
+            fht1 = FasterFactory.Create
+                <MyKey, MyLargeValue, MyInput, MyLargeOutput, MyContext, MyLargeFunctions>
+                (indexSizeBuckets: 128, functions: new MyLargeFunctions(),
+                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 9, MemorySizeBits = 13 },
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.FoldOver }
+                );
+
+            fht2 = FasterFactory.Create
+                <MyKey, MyLargeValue, MyInput, MyLargeOutput, MyContext, MyLargeFunctions>
+                (indexSizeBuckets: 128, functions: new MyLargeFunctions(),
+                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 9, MemorySizeBits = 13 },
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.FoldOver }
+                );
+
+
+            int maxSize = 1000;
+            int numOps = 5000;
+            //var value = new MyLargeValue(size);
+
+            fht1.StartSession();
+            Random r = new Random(33);
+            for (int key = 0; key < numOps; key++)
+            {
+                var value = new MyLargeValue(1 + r.Next(maxSize));
+                fht1.Upsert(new MyKey { key = key }, value, null, 0);
+            }
+            fht1.TakeFullCheckpoint(out Guid token);
+            fht1.CompleteCheckpoint(true);
+            fht1.StopSession();
+            fht1.Dispose();
+
+            MyLargeOutput output = new MyLargeOutput();
+            fht2.Recover(token);
+            fht2.StartSession();
+            for (int key = 0; key < numOps; key++)
+            {
+                var status = fht2.Read(new MyKey { key = key }, new MyInput(), ref output, null, 0);
+
+                if (status == Status.PENDING)
+                    fht2.CompletePending(true);
+                else
+                {
+                    for (int i = 0; i < output.value.value.Length; i++)
+                    {
+                        Assert.IsTrue(output.value.value[i] == (byte)(output.value.value.Length + i));
+                    }
+                }
+            }
+            fht2.StopSession();
+            fht2.Dispose();
+
+            log.Close();
+            objlog.Close();
+            new DirectoryInfo(TestContext.CurrentContext.TestDirectory + "\\checkpoints").Delete(true);
         }
     }
 }

--- a/cs/test/LargeObjectTests.cs
+++ b/cs/test/LargeObjectTests.cs
@@ -56,7 +56,7 @@ namespace FASTER.test.largeobjects
         [Test]
         public void LargeObjectTest1()
         {
-            int maxSize = 100;
+            int maxSize = 1000;
             int numOps = 5000;
             //var value = new MyLargeValue(size);
 

--- a/cs/test/ObjectTestTypes.cs
+++ b/cs/test/ObjectTestTypes.cs
@@ -13,6 +13,7 @@ using FASTER.core;
 using System.Runtime.CompilerServices;
 using System.IO;
 using System.Diagnostics;
+using NUnit.Framework;
 
 namespace FASTER.test
 {
@@ -169,7 +170,12 @@ namespace FASTER.test
 
         public void ReadCompletionCallback(MyContext ctx, MyLargeOutput output, Status status)
         {
+            for (int i = 0; i < output.value.value.Length; i++)
+            {
+                Assert.IsTrue(output.value.value[i] == (byte)i);
+            }
         }
+
 
         public void UpsertCompletionCallback(MyContext ctx)
         {

--- a/cs/test/ObjectTestTypes.cs
+++ b/cs/test/ObjectTestTypes.cs
@@ -133,7 +133,7 @@ namespace FASTER.test
             value = new byte[size];
             for (int i = 0; i < size; i++)
             {
-                value[i] = (byte)i;
+                value[i] = (byte)(size+i);
             }
         }
 
@@ -170,9 +170,10 @@ namespace FASTER.test
 
         public void ReadCompletionCallback(MyContext ctx, MyLargeOutput output, Status status)
         {
+            Assert.IsTrue(status == Status.OK);
             for (int i = 0; i < output.value.value.Length; i++)
             {
-                Assert.IsTrue(output.value.value[i] == (byte)i);
+                Assert.IsTrue(output.value.value[i] == (byte)(output.value.value.Length+i));
             }
         }
 


### PR DESCRIPTION
The C# version of FASTER consists of a separate object log that contains the C# objects that are heap-allocated. This checking writes and reads the object log for a page incrementally, in chunks of 100MB. This avoids collecting all the data in an in-memory buffer before reading or writing them. There is a limit of 2GB per key-value pair in this setting.