### PR TITLE
Refactoring so that PMM does not need to be codegen'ed

### DIFF
--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -93,7 +93,7 @@ namespace FASTER.benchmark
 #else
             store = new FasterKV
 #endif
-                (kMaxKey / 2, device, null);
+                (kMaxKey / 2, new LogSettings { LogDevice = device });
         }
 
         private void RunYcsb(int thread_idx)

--- a/cs/playground/ManagedSample3/Program.cs
+++ b/cs/playground/ManagedSample3/Program.cs
@@ -119,7 +119,7 @@ namespace ManagedSample3
             var h = FasterFactory.Create
                 <MyKey, MyValue, MyInput, MyOutput, MyContext, MyFunctions>
                 (128, new MyFunctions(),
-                new LogSettings {  LogDevice = log, ObjectLogDevice = objlog, MemorySizeBits = 14, PageSizeBits = 10 }
+                new LogSettings {  LogDevice = log, ObjectLogDevice = objlog, MemorySizeBits = 29 }
                 );
               
             h.StartSession();

--- a/cs/playground/ManagedSample4/Program.cs
+++ b/cs/playground/ManagedSample4/Program.cs
@@ -130,7 +130,7 @@ namespace ManagedSample4
             var h = FasterFactory.Create
                 <Wrap<int>, Wrap<int>, Wrap<int>, Wrap<int>, MyContext, MyFunctions>
                 (128, new MyFunctions(),
-                new LogSettings { LogDevice = log, MemorySizeBits = 14, PageSizeBits = 10 }
+                new LogSettings { LogDevice = log, MemorySizeBits = 29 }
                 );
 
             h.StartSession();

--- a/cs/playground/NestedTypesTest/Program.cs
+++ b/cs/playground/NestedTypesTest/Program.cs
@@ -49,7 +49,7 @@ namespace NestedTypesTest
 #endif
                 , MyFunctions>
                 (128, new MyFunctions(),
-                new LogSettings { LogDevice = log, MemorySizeBits = 14, PageSizeBits = 10 }
+                new LogSettings { LogDevice = log, MemorySizeBits = 29 }
                 );
 
             h.StartSession();

--- a/cs/src/core/Codegen/FasterHashTableCompiler.cs
+++ b/cs/src/core/Codegen/FasterHashTableCompiler.cs
@@ -38,8 +38,6 @@ namespace FASTER.core.Roslyn
                 "IndexRecovery",
                 "IndexCheckpoint",
                 "StateTransitions",
-                "PersistentMemoryMalloc",
-                "PMMAsyncIO",
         };
 
 
@@ -47,10 +45,10 @@ namespace FASTER.core.Roslyn
     /// 
     /// </summary>
     /// <returns>The generated type (to be instantiated). If null, then the error messages giving the reason for failing to generate the type.</returns>
-    public static Tuple<Type, string> GenerateFasterHashTableClass(bool persistGeneratedCode, bool optimizeCode, long LogTotalSizeBits, double LogMutableFraction, int LogPageSizeBits, int LogSegmentSizeBits, bool kFoldOverSnapshot)
+    public static Tuple<Type, string> GenerateFasterHashTableClass(bool persistGeneratedCode, bool optimizeCode)
         {
             var c = new FasterHashTableCompiler<TKey, TValue, TInput, TOutput, TContext, TFunctions, TIFaster>();
-            c.Run(persistGeneratedCode, optimizeCode, LogTotalSizeBits, LogMutableFraction, LogPageSizeBits, LogSegmentSizeBits, kFoldOverSnapshot);
+            c.Run(persistGeneratedCode, optimizeCode);
             var name = String.Format("FASTER.core.Codegen_{0}.FasterKV", c.compilation.AssemblyName);
             var r = c.Compile(persistGeneratedCode);
             var a = r.Item1;
@@ -66,7 +64,7 @@ namespace FASTER.core.Roslyn
         /// <summary>
         /// Runs the transformations needed to produce a valid compilation unit.
         /// </summary>
-        public void Run(bool persistGeneratedCode, bool optimizeCode, long LogTotalSizeBits, double LogMutableFraction, int LogPageSizeBits, int LogSegmentSizeBits, bool kFoldOverSnapshot)
+        public void Run(bool persistGeneratedCode, bool optimizeCode)
         {
 #if TIMING
             Stopwatch sw = new Stopwatch();
@@ -114,12 +112,6 @@ namespace FASTER.core.Roslyn
 
                 compilation = compilation.ReplaceSyntaxTree(oldTree, newTree);
             }
-
-            compilation = RoslynHelpers.ReplaceConstantValue(compilation, "LogMutableFraction", LogMutableFraction.ToString(CultureInfo.InvariantCulture));
-            compilation = RoslynHelpers.ReplaceConstantValue(compilation, "LogTotalSizeBits", LogTotalSizeBits.ToString(CultureInfo.InvariantCulture));
-            compilation = RoslynHelpers.ReplaceConstantValue(compilation, "LogPageSizeBits", LogPageSizeBits.ToString(CultureInfo.InvariantCulture));
-            compilation = RoslynHelpers.ReplaceConstantValue(compilation, "LogSegmentSizeBits", LogSegmentSizeBits.ToString(CultureInfo.InvariantCulture));
-            compilation = RoslynHelpers.ReplaceConstantValue(compilation, "kFoldOverSnapshot", kFoldOverSnapshot ? "true" : "false");
 
 #if TIMING
             sw.Stop();

--- a/cs/src/core/Codegen/HashTableManager.cs
+++ b/cs/src/core/Codegen/HashTableManager.cs
@@ -27,11 +27,11 @@ namespace FASTER.core
 #endif
             ;
         public static TIFaster GetFasterHashTable<TKey, TValue, TInput, TOutput, TContext, TFunctions, TIFaster>
-            (long size, IDevice logDevice, IDevice objectLogDevice, string checkpointDir, long LogTotalSizeBits, double LogMutableFraction, int LogPageSizeBits, int LogSegmentSizeBits, bool kFoldOverSnapshot, bool persistDll = PersistDll, bool optimizeCode = OptimizeCode)
+            (long size, LogSettings logSettings, CheckpointSettings checkpointSettings, bool persistDll = PersistDll, bool optimizeCode = OptimizeCode)
         {
-            var s = Roslyn.FasterHashTableCompiler<TKey, TValue, TInput, TOutput, TContext, TFunctions, TIFaster>.GenerateFasterHashTableClass(persistDll, optimizeCode, LogTotalSizeBits, LogMutableFraction, LogPageSizeBits, LogSegmentSizeBits, kFoldOverSnapshot);
+            var s = Roslyn.FasterHashTableCompiler<TKey, TValue, TInput, TOutput, TContext, TFunctions, TIFaster>.GenerateFasterHashTableClass(persistDll, optimizeCode);
             var t = s.Item1;
-            var instance = Activator.CreateInstance(t, size, logDevice, objectLogDevice, checkpointDir);
+            var instance = Activator.CreateInstance(t, size, logSettings, checkpointSettings);
             return (TIFaster)instance;
         }
 

--- a/cs/src/core/Index/FASTER/Checkpoint.cs
+++ b/cs/src/core/Index/FASTER/Checkpoint.cs
@@ -224,7 +224,7 @@ namespace FASTER.core
 
                             ObtainCurrentTailAddress(ref _hybridLogCheckpoint.info.startLogicalAddress);
 
-                            if (!Constants.kFoldOverSnapshot)
+                            if (!FoldOverSnapshot)
                             {
                                 _hybridLogCheckpoint.info.flushedLogicalAddress = hlog.FlushedUntilAddress;
                                 _hybridLogCheckpoint.info.useSnapshotFile = 1;
@@ -254,7 +254,7 @@ namespace FASTER.core
                                 WriteIndexMetaFile();
                             }
 
-                            if (Constants.kFoldOverSnapshot)
+                            if (FoldOverSnapshot)
                             {
                                 hlog.ShiftReadOnlyToTail(out long tailAddress);
 
@@ -507,7 +507,7 @@ namespace FASTER.core
                             if (!prevThreadCtx.markers[EpochPhaseIdx.WaitFlush])
                             {
                                 var notify = false;
-                                if (Constants.kFoldOverSnapshot)
+                                if (FoldOverSnapshot)
                                 {
                                     notify = (hlog.FlushedUntilAddress >= _hybridLogCheckpoint.info.finalLogicalAddress);
                                 }

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -18,8 +18,6 @@ namespace FASTER.core
         /// Size of cache line in bytes
         public const int kCacheLineBytes = 64;
 
-        public const bool kFoldOverSnapshot = false;
-
         public const bool kFineGrainedHandoverRecord = false;
 
         public const bool kFineGrainedHandoverBucket = true;

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -736,7 +736,7 @@ namespace FASTER.core
             // Mutable Region: Update the record in-place
             if (logicalAddress >= hlog.ReadOnlyAddress)
             {
-                if(Constants.kFoldOverSnapshot)
+                if(FoldOverSnapshot)
                 {
                     Debug.Assert(Layout.GetInfo(physicalAddress)->Version == threadCtx.version);
                 }
@@ -1012,7 +1012,7 @@ namespace FASTER.core
             // Mutable Region: Update the record in-place
             if (logicalAddress >= hlog.ReadOnlyAddress)
             {
-                if (Constants.kFoldOverSnapshot)
+                if (FoldOverSnapshot)
                 {
                     Debug.Assert(Layout.GetInfo(physicalAddress)->Version == threadCtx.version);
                 }

--- a/cs/src/core/ManagedLayer/FASTERFactory.cs
+++ b/cs/src/core/ManagedLayer/FASTERFactory.cs
@@ -25,11 +25,6 @@ namespace FASTER.core
         public IDevice ObjectLogDevice = new NullDevice();
 
         /// <summary>
-        /// Size of page, in bits
-        /// </summary>
-        public int PageSizeBits = 25;
-
-        /// <summary>
         /// Size of a segment (group of pages), in bits
         /// </summary>
         public int SegmentSizeBits = 30;
@@ -164,10 +159,7 @@ namespace FASTER.core
                 HashTableManager.GetFasterHashTable
                                 <TKey, TValue, TInput, TOutput,
                                 TContext, TFunctions, TIFaster>
-                                (indexSizeBuckets, logSettings.LogDevice, logSettings.ObjectLogDevice, 
-                                checkpointSettings.CheckpointDir, logSettings.MemorySizeBits, 
-                                logSettings.MutableFraction, logSettings.PageSizeBits, 
-                                logSettings.SegmentSizeBits, checkpointSettings.CheckPointType == CheckpointType.FoldOver);
+                                (indexSizeBuckets, logSettings, checkpointSettings);
         }
 
         /// <summary>

--- a/cs/src/core/Utilities/AsyncResultTypes.cs
+++ b/cs/src/core/Utilities/AsyncResultTypes.cs
@@ -12,17 +12,6 @@ using System.IO;
 
 namespace FASTER.core
 {
-    /// <summary>
-    /// FASTER configuration
-    /// </summary>
-    public static class Config
-    {
-        /// <summary>
-        /// Checkpoint directory
-        /// </summary>
-        public static string CheckpointDirectory = "C:\\data";
-    }
-
     internal struct AsyncGetFromDiskResult<TContext> : IAsyncResult
     {
         public TContext context;
@@ -34,73 +23,6 @@ namespace FASTER.core
         public object AsyncState => throw new NotImplementedException();
 
         public bool CompletedSynchronously => throw new NotImplementedException();
-    }
-
-    internal struct PageAsyncReadResult<TContext> : IAsyncResult
-    {
-        public long page;
-        public TContext context;
-        public CountdownEvent handle;
-        public SectorAlignedMemory freeBuffer1;
-        public IOCompletionCallback callback;
-        public int count;
-        public IDevice objlogDevice;
-        public long resumeptr;
-        public long untilptr;
-
-        public bool IsCompleted => throw new NotImplementedException();
-
-        public WaitHandle AsyncWaitHandle => throw new NotImplementedException();
-
-        public object AsyncState => throw new NotImplementedException();
-
-        public bool CompletedSynchronously => throw new NotImplementedException();
-
-        public void Free()
-        {
-            if (freeBuffer1.buffer != null)
-                freeBuffer1.Return();
-
-            if (handle != null)
-            {
-                handle.Signal();
-            }
-        }
-    }
-
-    internal class PageAsyncFlushResult<TContext> : IAsyncResult
-    {
-        public long page;
-        public TContext context;
-        public bool partial;
-        public long untilAddress;
-        public int count;
-        public CountdownEvent handle;
-        public IDevice objlogDevice;
-        public SectorAlignedMemory freeBuffer1;
-        public SectorAlignedMemory freeBuffer2;
-        public AutoResetEvent done;
-
-        public bool IsCompleted => throw new NotImplementedException();
-
-        public WaitHandle AsyncWaitHandle => throw new NotImplementedException();
-
-        public object AsyncState => throw new NotImplementedException();
-
-        public bool CompletedSynchronously => throw new NotImplementedException();
-
-        public void Free()
-        {
-            if (freeBuffer1.buffer != null)
-                freeBuffer1.Return();
-            if (freeBuffer2.buffer != null)
-                freeBuffer2.Return();
-
-            if (handle != null)
-            {
-                handle.Signal();
-            }
-        }
     }
 
     internal unsafe class HashIndexPageAsyncFlushResult : IAsyncResult

--- a/cs/src/core/Utilities/PageAsyncResultTypes.cs
+++ b/cs/src/core/Utilities/PageAsyncResultTypes.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+#define CALLOC
+
+using System;
+using System.Threading;
+
+namespace FASTER.core
+{
+    /// <summary>
+    /// Result of async page read
+    /// </summary>
+    /// <typeparam name="TContext"></typeparam>
+    public struct PageAsyncReadResult<TContext> : IAsyncResult
+    {
+        /// <summary>
+        /// Page
+        /// </summary>
+        public long page;
+        /// <summary>
+        /// Context
+        /// </summary>
+        public TContext context;
+        /// <summary>
+        /// Count
+        /// </summary>
+        public int count;
+
+        internal CountdownEvent handle;
+        internal SectorAlignedMemory freeBuffer1;
+        internal IOCompletionCallback callback;
+        internal IDevice objlogDevice;
+        internal long resumeptr;
+        internal long untilptr;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool IsCompleted => throw new NotImplementedException();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public WaitHandle AsyncWaitHandle => throw new NotImplementedException();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public object AsyncState => throw new NotImplementedException();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool CompletedSynchronously => throw new NotImplementedException();
+
+        /// <summary>
+        /// Free
+        /// </summary>
+        public void Free()
+        {
+            if (freeBuffer1.buffer != null)
+                freeBuffer1.Return();
+
+            if (handle != null)
+            {
+                handle.Signal();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Page async flush result
+    /// </summary>
+    /// <typeparam name="TContext"></typeparam>
+    public class PageAsyncFlushResult<TContext> : IAsyncResult
+    {
+        /// <summary>
+        /// Page
+        /// </summary>
+        public long page;
+        /// <summary>
+        /// Context
+        /// </summary>
+        public TContext context;
+        /// <summary>
+        /// Count
+        /// </summary>
+        public int count;
+
+        internal bool partial;
+        internal long untilAddress;
+        internal CountdownEvent handle;
+        internal IDevice objlogDevice;
+        internal SectorAlignedMemory freeBuffer1;
+        internal SectorAlignedMemory freeBuffer2;
+        internal AutoResetEvent done;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool IsCompleted => throw new NotImplementedException();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public WaitHandle AsyncWaitHandle => throw new NotImplementedException();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public object AsyncState => throw new NotImplementedException();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool CompletedSynchronously => throw new NotImplementedException();
+
+        /// <summary>
+        /// Free
+        /// </summary>
+        public void Free()
+        {
+            if (freeBuffer1.buffer != null)
+                freeBuffer1.Return();
+            if (freeBuffer2.buffer != null)
+                freeBuffer2.Return();
+
+            if (handle != null)
+            {
+                handle.Signal();
+            }
+        }
+    }
+}

--- a/cs/test/LargeObjectTests.cs
+++ b/cs/test/LargeObjectTests.cs
@@ -32,14 +32,14 @@ namespace FASTER.test.largeobjects
             fht1 = FasterFactory.Create
                 <MyKey, MyLargeValue, MyInput, MyLargeOutput, MyContext, MyLargeFunctions>
                 (indexSizeBuckets: 128, functions: new MyLargeFunctions(),
-                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 9, MemorySizeBits = 13 },
+                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 29 },
                 checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.Snapshot }
                 );
 
             fht2 = FasterFactory.Create
                 <MyKey, MyLargeValue, MyInput, MyLargeOutput, MyContext, MyLargeFunctions>
                 (indexSizeBuckets: 128, functions: new MyLargeFunctions(),
-                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 9, MemorySizeBits = 13 },
+                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 29 },
                 checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.Snapshot }
                 );
 
@@ -96,14 +96,14 @@ namespace FASTER.test.largeobjects
             fht1 = FasterFactory.Create
                 <MyKey, MyLargeValue, MyInput, MyLargeOutput, MyContext, MyLargeFunctions>
                 (indexSizeBuckets: 128, functions: new MyLargeFunctions(),
-                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 9, MemorySizeBits = 13 },
+                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 29 },
                 checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.FoldOver }
                 );
 
             fht2 = FasterFactory.Create
                 <MyKey, MyLargeValue, MyInput, MyLargeOutput, MyContext, MyLargeFunctions>
                 (indexSizeBuckets: 128, functions: new MyLargeFunctions(),
-                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 9, MemorySizeBits = 13 },
+                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 29 },
                 checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.FoldOver }
                 );
 

--- a/cs/test/ObjectFASTERTests.cs
+++ b/cs/test/ObjectFASTERTests.cs
@@ -29,7 +29,7 @@ namespace FASTER.test
             fht = FasterFactory.Create
                 <MyKey, MyValue, MyInput, MyOutput, MyContext, MyFunctions>
                 (indexSizeBuckets: 128, functions: new MyFunctions(),
-                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 9, MemorySizeBits = 13 },
+                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 29 },
                 checkpointSettings: new CheckpointSettings { CheckPointType = CheckpointType.FoldOver }
                 );
             fht.StartSession();

--- a/cs/test/SimpleRecoveryTest.cs
+++ b/cs/test/SimpleRecoveryTest.cs
@@ -32,14 +32,14 @@ namespace FASTER.test.recovery.sumstore.simple
             fht1 = FasterFactory.Create
                 <AdId, NumClicks, Input, Output, Empty, SimpleFunctions, ICustomFaster>
                 (indexSizeBuckets: 128,
-                logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, PageSizeBits = 9, MemorySizeBits = 13 },
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },
                 checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.Snapshot }
                 );
 
             fht2 = FasterFactory.Create
                 <AdId, NumClicks, Input, Output, Empty, SimpleFunctions, ICustomFaster>
                 (indexSizeBuckets: 128,
-                logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, PageSizeBits = 9, MemorySizeBits = 13 },
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },
                 checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.Snapshot }
                 );
 
@@ -99,14 +99,14 @@ namespace FASTER.test.recovery.sumstore.simple
             fht1 = FasterFactory.Create
                 <AdId, NumClicks, Input, Output, Empty, SimpleFunctions, ICustomFaster>
                 (indexSizeBuckets: 128,
-                logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, PageSizeBits = 9, MemorySizeBits = 13 },
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },
                 checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.FoldOver }
                 );
 
             fht2 = FasterFactory.Create
                 <AdId, NumClicks, Input, Output, Empty, SimpleFunctions, ICustomFaster>
                 (indexSizeBuckets: 128,
-                logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, PageSizeBits = 9, MemorySizeBits = 13 },
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },
                 checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.FoldOver }
                 );
 


### PR DESCRIPTION
PersistentMemoryMalloc does not need to be codegen'ed any longer. This makes debugging significantly more tractable. Log page size is now set as a constant (32MB), because making it readonly (allowing user to provide it as a log setting) results in a 5% performance penalty. When PMM was codegen'ed, we were able to replace the constant in generated code - this is no longer possible. This checkin also marks a step in the direction of having a non-codegen version of FASTER.