### PR TITLE
Add C++ and C# (Linux) build support to azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,13 +1,8 @@
-# .NET Desktop
-# Build and run tests for .NET Desktop or Windows classic desktop solutions.
-# Add steps that publish symbols, save build artifacts, and more:
-# https://docs.microsoft.com/vsts/pipelines/apps/windows/dot-net
-
 variables:
   solution: 'cs/FASTER.sln'
 
 jobs:
-- job: Build
+- job: Build C# using .NET (Windows)
   strategy:
     maxParallel: 2
     matrix:
@@ -40,3 +35,32 @@ jobs:
     inputs:
       platform: '$(buildPlatform)'
       configuration: '$(buildConfiguration)'
+
+- job: Build C++ (Linux)
+  steps:
+  - script: |
+      sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+      sudo apt update
+      sudo apt install -y g++-7 libaio-dev uuid-dev libtbb-dev
+    displayName: 'Install depdendencies'
+  
+  - script: |
+      export CXX='g++-7'
+      cd cc
+      mkdir -p build/Debug build/Release
+      cd build/Debug
+      cmake -DCMAKE_BUILD_TYPE=Debug ../..
+      make -j
+      cd ../../build/Release
+      cmake -DCMAKE_BUILD_TYPE=Release ../..
+      make -j
+    displayNmae: 'Build'
+
+- job: Build C# using Mono (Linux)
+  steps:
+  - script: |
+      mono --version
+      msbuild /version
+      
+      nuget restore $(solution)
+      msbuild /p:Configuration=Release $(solution)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@ variables:
 
 jobs:
 - job: 'dotNetWindows'
+  dependsOn: 'monoLinux'
   strategy:
     maxParallel: 2
     matrix:
@@ -61,6 +62,5 @@ jobs:
   - script: |
       mono --version
       msbuild /version
-
-      nuget restore $(solution)
+      msbuild /t:restore $(solution)
       msbuild /p:Configuration=Release $(solution)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ variables:
   solution: 'cs/FASTER.sln'
 
 jobs:
-- job: Build C# using .NET (Windows)
+- job: 'dotNetWindows'
   strategy:
     maxParallel: 2
     matrix:
@@ -36,7 +36,7 @@ jobs:
       platform: '$(buildPlatform)'
       configuration: '$(buildConfiguration)'
 
-- job: Build C++ (Linux)
+- job: 'cppLinux'
   steps:
   - script: |
       sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
@@ -54,13 +54,13 @@ jobs:
       cd ../../build/Release
       cmake -DCMAKE_BUILD_TYPE=Release ../..
       make -j
-    displayNmae: 'Build'
+    displayName: 'Build'
 
-- job: Build C# using Mono (Linux)
+- job: 'monoLinux'
   steps:
   - script: |
       mono --version
       msbuild /version
-      
+
       nuget restore $(solution)
       msbuild /p:Configuration=Release $(solution)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,8 +2,11 @@ variables:
   solution: 'cs/FASTER.sln'
 
 jobs:
-- job: 'dotNetWindows'
-  dependsOn: 'monoLinux'
+- job: 'csharpWindows'  
+  pool:
+    vmImage: vs2017-win2016    
+  displayName: 'C# (Windows)'
+
   strategy:
     maxParallel: 2
     matrix:
@@ -19,6 +22,7 @@ jobs:
       x64-Release:
         buildPlatform: 'x64'
         buildConfiguration: 'Release'
+  
   steps:
   - task: NuGetToolInstaller@0
 
@@ -38,6 +42,10 @@ jobs:
       configuration: '$(buildConfiguration)'
 
 - job: 'cppLinux'
+  pool:
+    vmImage: ubuntu-16.04
+  displayName: 'C++ (Linux)'
+  
   steps:
   - script: |
       sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
@@ -55,12 +63,17 @@ jobs:
       cd ../../build/Release
       cmake -DCMAKE_BUILD_TYPE=Release ../..
       make -j
-    displayName: 'Build'
+    displayName: 'Compile'
 
-- job: 'monoLinux'
+- job: 'csharpLinux'
+  pool:
+    vmImage: ubuntu-16.04
+  displayName: 'C# (Linux)'
+
   steps:
   - script: |
       mono --version
       msbuild /version
       msbuild /t:restore $(solution)
       msbuild /p:Configuration=Release $(solution)
+    displayName: 'Build'


### PR DESCRIPTION
Adds support for building C# (Windows), C++ (Linux), and C# (Linux) on Azure Pipelines.

See latest build results: https://dev.azure.com/ms/FASTER/_build/results?buildId=125&view=logs

![image](https://user-images.githubusercontent.com/2503052/48587271-82e33400-e900-11e8-8fda-bc532fc8350d.png)
