### PR TITLE
Remove CreateObjectLogDevice API due to redundancy.

### DIFF
--- a/cs/playground/ClassCache/Program.cs
+++ b/cs/playground/ClassCache/Program.cs
@@ -18,8 +18,8 @@ namespace ClassCache
         {
             var context = default(CacheContext);
 
-            var log =  Devices.CreateLogDevice(Path.GetTempPath() + "hybridlog");
-            var objlog = Devices.CreateObjectLogDevice(Path.GetTempPath() + "hybridlog");
+            var log =  Devices.CreateLogDevice(Path.GetTempPath() + "hlog.log");
+            var objlog = Devices.CreateLogDevice(Path.GetTempPath() + "hlog.obj.log");
             var h = new FasterKV
                 <CacheKey, CacheValue, CacheInput, CacheOutput, CacheContext, CacheFunctions>(
                 1L << 20, new CacheFunctions(),

--- a/cs/playground/ClassSample/Program.cs
+++ b/cs/playground/ClassSample/Program.cs
@@ -134,8 +134,8 @@ namespace ClassSample
     {
         static void Main(string[] args)
         {
-            var log = Devices.CreateLogDevice(Path.GetTempPath() + "hybridlog");
-            var objlog = Devices.CreateObjectLogDevice(Path.GetTempPath() + "hybridlog");
+            var log = Devices.CreateLogDevice(Path.GetTempPath() + "hlog.log");
+            var objlog = Devices.CreateLogDevice(Path.GetTempPath() + "hlog.obj.log");
 
             var h = new FasterKV
                 <MyKey, MyValue, MyInput, MyOutput, MyContext, MyFunctions>

--- a/cs/playground/MixedSample/Program.cs
+++ b/cs/playground/MixedSample/Program.cs
@@ -134,8 +134,8 @@ namespace MixedSample
     {
         static void Main(string[] args)
         {
-            var log = Devices.CreateLogDevice(Path.GetTempPath() + "hybridlog");
-            var objlog = Devices.CreateObjectLogDevice(Path.GetTempPath() + "hybridlog");
+            var log = Devices.CreateLogDevice(Path.GetTempPath() + "hlog.log");
+            var objlog = Devices.CreateLogDevice(Path.GetTempPath() + "hlog.obj.log");
 
             var h = new FasterKV
                 <MyKey, MyValue, MyInput, MyOutput, MyContext, MyFunctions>

--- a/cs/src/core/Device/Devices.cs
+++ b/cs/src/core/Device/Devices.cs
@@ -24,43 +24,20 @@ namespace FASTER.core
         /// <returns>Device instance</returns>
         public static IDevice CreateLogDevice(string logPath, bool preallocateFile = true, bool deleteOnClose = false)
         {
-            IDevice logDevice = new NullDevice();
             if (string.IsNullOrWhiteSpace(logPath))
-                return logDevice;
-#if DOTNETCORE
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                logDevice = new ManagedLocalStorageDevice(logPath + ".log", preallocateFile, deleteOnClose);
-            }
-            else
-#endif
-            {
-                logDevice = new LocalStorageDevice(logPath + ".log", preallocateFile, deleteOnClose);
-            }
-            return logDevice;
-        }
+                return new NullDevice();
 
-        /// <summary>
-        /// Create a storage device for the object log (for non-blittable objects)
-        /// </summary>
-        /// <param name="logPath">Path to file that will store the log (empty for null device)</param>
-        /// <param name="preallocateFile">Whether we try to preallocate the file on creation</param>
-        /// <param name="deleteOnClose">Delete files on close</param>
-        /// <returns>Device instance</returns>
-        public static IDevice CreateObjectLogDevice(string logPath, bool preallocateFile = true, bool deleteOnClose = false)
-        {
-            IDevice logDevice = new NullDevice();
-            if (String.IsNullOrWhiteSpace(logPath))
-                return logDevice;
+            IDevice logDevice;
+
 #if DOTNETCORE
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                logDevice = new ManagedLocalStorageDevice(logPath + ".obj.log", preallocateFile, deleteOnClose);
+                logDevice = new ManagedLocalStorageDevice(logPath, preallocateFile, deleteOnClose);
             }
             else
 #endif
             {
-                logDevice = new LocalStorageDevice(logPath + ".obj.log", preallocateFile, deleteOnClose);
+                logDevice = new LocalStorageDevice(logPath, preallocateFile, deleteOnClose);
             }
             return logDevice;
         }

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -117,8 +117,6 @@ namespace FASTER.core
         public const string cpr_base_folder = "cpr-checkpoints";
         public const string cpr_meta_file = "info";
 
-        public const string hlog_file = "lss.log";
-
         public void CreateIndexCheckpointFolder(Guid token)
         {
             var directory = GetIndexCheckpointFolder(token);
@@ -186,7 +184,16 @@ namespace FASTER.core
         }
         public string GetHybridLogCheckpointFileName(Guid token)
         {
-            return String.Format("{0}\\{1}\\{2}\\{3}.dat",
+            return String.Format("{0}\\{1}\\{2}\\{3}.log",
+                                    checkpointDir,
+                                    cpr_base_folder,
+                                    token,
+                                    snapshot_file);
+        }
+
+        public string GetHybridLogObjectCheckpointFileName(Guid token)
+        {
+            return String.Format("{0}\\{1}\\{2}\\{3}.obj.log",
                                     checkpointDir,
                                     cpr_base_folder,
                                     token,

--- a/cs/src/core/Index/FASTER/Checkpoint.cs
+++ b/cs/src/core/Index/FASTER/Checkpoint.cs
@@ -290,8 +290,8 @@ namespace FASTER.core
 
                                 _hybridLogCheckpoint.snapshotFileDevice = Devices.CreateLogDevice
                                     (directoryConfiguration.GetHybridLogCheckpointFileName(_hybridLogCheckpointToken), false);
-                                _hybridLogCheckpoint.snapshotFileObjectLogDevice = Devices.CreateObjectLogDevice
-                                    (directoryConfiguration.GetHybridLogCheckpointFileName(_hybridLogCheckpointToken), false);
+                                _hybridLogCheckpoint.snapshotFileObjectLogDevice = Devices.CreateLogDevice
+                                    (directoryConfiguration.GetHybridLogObjectCheckpointFileName(_hybridLogCheckpointToken), false);
                                 _hybridLogCheckpoint.snapshotFileDevice.Initialize(hlog.GetSegmentSize());
                                 _hybridLogCheckpoint.snapshotFileObjectLogDevice.Initialize(hlog.GetSegmentSize());
 

--- a/cs/src/core/Index/FASTER/Recovery.cs
+++ b/cs/src/core/Index/FASTER/Recovery.cs
@@ -247,7 +247,7 @@ namespace FASTER.core
             // By default first page has one extra record
             var capacity = hlog.GetCapacityNumPages();
             var recoveryDevice = Devices.CreateLogDevice(directoryConfiguration.GetHybridLogCheckpointFileName(recoveryInfo.guid), false);
-            var objectLogRecoveryDevice = Devices.CreateObjectLogDevice(directoryConfiguration.GetHybridLogCheckpointFileName(recoveryInfo.guid), false);
+            var objectLogRecoveryDevice = Devices.CreateLogDevice(directoryConfiguration.GetHybridLogObjectCheckpointFileName(recoveryInfo.guid), false);
             recoveryDevice.Initialize(hlog.GetSegmentSize());
             objectLogRecoveryDevice.Initialize(hlog.GetSegmentSize());
             var recoveryStatus = new RecoveryStatus(capacity, startPage, endPage)

--- a/cs/test/BasicFASTERTests.cs
+++ b/cs/test/BasicFASTERTests.cs
@@ -23,7 +23,7 @@ namespace FASTER.test
         [SetUp]
         public void Setup()
         {
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hybridlog_native.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog1.log", deleteOnClose: true);
             fht = new FasterKV<KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty, Functions>
                 (128, new Functions(), new LogSettings { LogDevice = log, MemorySizeBits = 29 });
             fht.StartSession();

--- a/cs/test/LargeObjectTests.cs
+++ b/cs/test/LargeObjectTests.cs
@@ -27,8 +27,8 @@ namespace FASTER.test.largeobjects
             MyInput input = default(MyInput);
             MyLargeOutput output = new MyLargeOutput();
 
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog", deleteOnClose: true);
-            objlog = Devices.CreateObjectLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog.obj.log", deleteOnClose: true);
 
             Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints");
 
@@ -93,8 +93,8 @@ namespace FASTER.test.largeobjects
             MyInput input = default(MyInput);
             MyLargeOutput output = new MyLargeOutput();
 
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog", deleteOnClose: true);
-            objlog = Devices.CreateObjectLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog.obj.log", deleteOnClose: true);
 
             Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints");
 

--- a/cs/test/MiscFASTERTests.cs
+++ b/cs/test/MiscFASTERTests.cs
@@ -23,8 +23,8 @@ namespace FASTER.test
         [SetUp]
         public void Setup()
         {
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog2", deleteOnClose: true);
-            objlog = Devices.CreateObjectLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog2", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog2.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog2.obj.log", deleteOnClose: true);
 
             fht = new FasterKV<int, MyValue, MyInput, MyOutput, Empty, MixedFunctions>
                 (128, new MixedFunctions(),

--- a/cs/test/ObjectFASTERTests.cs
+++ b/cs/test/ObjectFASTERTests.cs
@@ -23,8 +23,8 @@ namespace FASTER.test
         [SetUp]
         public void Setup()
         {
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog2", deleteOnClose: true);
-            objlog = Devices.CreateObjectLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog2", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog2.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog2.obj.log", deleteOnClose: true);
 
             fht = new FasterKV<MyKey, MyValue, MyInput, MyOutput, Empty, MyFunctions>
                 (128, new MyFunctions(),

--- a/cs/test/ObjectRecoveryTest.cs
+++ b/cs/test/ObjectRecoveryTest.cs
@@ -40,8 +40,8 @@ namespace FASTER.test.recovery.objectstore
                     Directory.CreateDirectory(test_path);
             }
 
-            log = Devices.CreateLogDevice(test_path + "\\ort1hlog", false);
-            objlog = Devices.CreateObjectLogDevice(test_path + "\\ort1hlog", false);
+            log = Devices.CreateLogDevice(test_path + "\\ort1hlog.log", false);
+            objlog = Devices.CreateLogDevice(test_path + "\\ort1hlog.obj.log", false);
 
             fht = new FasterKV<AdId, NumClicks, Input, Output, Empty, Functions>
                 (


### PR DESCRIPTION
We have merged the object log and normal hybrid log devices into a single storage device abstraction. This means we no longer need a separate API for CreateObjectLogDevice. To create the normal and object log devices, you do the following:

```CSharp
var log =  Devices.CreateLogDevice(Path.GetTempPath() + "hlog.log");
var objlog = Devices.CreateLogDevice(Path.GetTempPath() + "hlog.obj.log");
```

To preallocate file segments, you may pass in the argument `preallocateFile = true` to `CreateLogDevice`.