### PR TITLE
Some bug fixes; fixes issue #80

### DIFF
--- a/cs/playground/SumStore/LatestRecoveryTest.cs
+++ b/cs/playground/SumStore/LatestRecoveryTest.cs
@@ -123,7 +123,6 @@ namespace SumStore
 
         private void PeriodicCheckpoints()
         {
-            Thread.Sleep(10 * 1000);
 
             Console.WriteLine("Started checkpoint thread");
 
@@ -131,13 +130,9 @@ namespace SumStore
             {
                 Thread.Sleep(checkpointInterval);
 
-                fht.StartSession();
-
                 fht.TakeFullCheckpoint(out Guid token);
 
                 fht.CompleteCheckpoint(true);
-
-                fht.StopSession();
 
                 Console.WriteLine("Completed checkpoint {0}", token);
             }

--- a/cs/playground/SumStore/Properties/launchSettings.json
+++ b/cs/playground/SumStore/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "SumStore": {
       "commandName": "Project",
-      "commandLineArgs": "latest continue"
+      "commandLineArgs": "latest recover"
     }
   }
 }

--- a/cs/playground/SumStore/Properties/launchSettings.json
+++ b/cs/playground/SumStore/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "SumStore": {
       "commandName": "Project",
-      "commandLineArgs": "test"
+      "commandLineArgs": "latest continue"
     }
   }
 }

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -1040,6 +1040,14 @@ namespace FASTER.core
                 var pageIndex = GetPageIndexForAddress(addr);
                 PageStatusIndicator[pageIndex].PageFlushCloseStatus.PageCloseStatus = PMMCloseStatus.Open;
             }
+
+            // Printing debug info
+            Debug.WriteLine("******* Recovered HybridLog Stats *******");
+            Debug.WriteLine("Head Address: {0}", HeadAddress);
+            Debug.WriteLine("Safe Head Address: {0}", SafeHeadAddress);
+            Debug.WriteLine("ReadOnly Address: {0}", ReadOnlyAddress);
+            Debug.WriteLine("Safe ReadOnly Address: {0}", SafeReadOnlyAddress);
+            Debug.WriteLine("Tail Address: {0}", tailAddress);
         }
 
         /// <summary>

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -1028,18 +1028,32 @@ namespace FASTER.core
             TailPageOffset.Offset = (int)offsetInPage;
             TailPageIndex = GetPageIndexForPage(TailPageOffset.Page);
 
-            // issue read request to all pages until head lag
+            // allocate next page as well - this is an invariant in the allocator!
+            var pageIndex = (TailPageOffset.Page % BufferSize);
+            var nextPageIndex = (pageIndex + 1) % BufferSize;
+            if (tailAddress > 0)
+                AllocatePage(nextPageIndex);
+            
             HeadAddress = headAddress;
             SafeHeadAddress = headAddress;
             FlushedUntilAddress = headAddress;
             ReadOnlyAddress = tailAddress;
             SafeReadOnlyAddress = tailAddress;
 
-            for (var addr = headAddress; addr < tailAddress; addr += PageSize)
+            // ensure appropriate page status for all pages in memory
+            // note: they must have been read in previously during recovery
+            var addr = GetStartLogicalAddress(GetPage(headAddress));
+            for (; addr < tailAddress; addr += PageSize)
             {
-                var pageIndex = GetPageIndexForAddress(addr);
-                PageStatusIndicator[pageIndex].PageFlushCloseStatus.PageCloseStatus = PMMCloseStatus.Open;
+                pageIndex = GetPageIndexForAddress(addr);
+                PageStatusIndicator[pageIndex].PageFlushCloseStatus.PageCloseStatus = PMMCloseStatus.Closed;
+                PageStatusIndicator[pageIndex].PageFlushCloseStatus.PageFlushStatus = PMMFlushStatus.Flushed;
             }
+
+            // for the last page which contains tailoffset, it must be open
+            pageIndex = GetPageIndexForAddress(tailAddress);
+            PageStatusIndicator[pageIndex].PageFlushCloseStatus.PageCloseStatus = PMMCloseStatus.Open;
+            PageStatusIndicator[pageIndex].PageFlushCloseStatus.PageFlushStatus = PMMFlushStatus.Flushed;
 
             // Printing debug info
             Debug.WriteLine("******* Recovered HybridLog Stats *******");

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -405,6 +405,22 @@ namespace FASTER.core
                 }
             }
         }
+
+        public void DebugPrint()
+        {
+            Debug.WriteLine("******** HybridLog Checkpoint Info for {0} ********", guid);
+            Debug.WriteLine("Version: {0}", version);
+            Debug.WriteLine("Is Snapshot?: {0}", useSnapshotFile == 1);
+            Debug.WriteLine("Flushed LogicalAddress: {0}", flushedLogicalAddress);
+            Debug.WriteLine("Start Logical Address: {0}", startLogicalAddress);
+            Debug.WriteLine("Final Logical Address: {0}", finalLogicalAddress);
+            Debug.WriteLine("Num sessions recovered: {0}", numThreads);
+            Debug.WriteLine("Recovered sessions: ");
+            foreach(var sessionInfo in continueTokens)
+            {
+                Debug.WriteLine("{0}: {1}", sessionInfo.Key, sessionInfo.Value);
+            }
+        }
     }
 
     internal struct HybridLogCheckpointInfo
@@ -495,6 +511,16 @@ namespace FASTER.core
             writer.WriteLine(num_buckets);
             writer.WriteLine(startLogicalAddress);
             writer.WriteLine(finalLogicalAddress);
+        }
+        public void DebugPrint()
+        {
+            Debug.WriteLine("******** Index Checkpoint Info for {0} ********", token);
+            Debug.WriteLine("Table Size: {0}", table_size);
+            Debug.WriteLine("Main Table Size (in GB): {0}", ((double)num_ht_bytes)/1000.0 / 1000.0 / 1000.0);
+            Debug.WriteLine("Overflow Table Size (in GB): {0}", ((double)num_ofb_bytes) / 1000.0 / 1000.0 / 1000.0);
+            Debug.WriteLine("Num Buckets: {0}", num_buckets);
+            Debug.WriteLine("Start Logical Address: {0}", startLogicalAddress);
+            Debug.WriteLine("Final Logical Address: {0}", finalLogicalAddress);
         }
         public void Reset()
         {

--- a/cs/src/core/Index/FASTER/Checkpoint.cs
+++ b/cs/src/core/Index/FASTER/Checkpoint.cs
@@ -276,6 +276,7 @@ namespace FASTER.core
                                 _indexCheckpoint.info.num_buckets = overflowBucketsAllocator.GetMaxValidAddress();
                                 ObtainCurrentTailAddress(ref _indexCheckpoint.info.finalLogicalAddress);
                                 WriteIndexMetaFile();
+                                WriteIndexCheckpointCompleteFile();
                             }
 
                             if (FoldOverSnapshot)
@@ -312,13 +313,14 @@ namespace FASTER.core
                                                                 out _hybridLogCheckpoint.flushed);
                             }
 
-                            WriteHybridLogMetaInfo();
-
+                            
                             MakeTransition(intermediateState, nextState);
                             break;
                         }
                     case Phase.PERSISTENCE_CALLBACK:
                         {
+                            WriteHybridLogMetaInfo();
+                            WriteHybridLogCheckpointCompleteFile();
                             MakeTransition(intermediateState, nextState);
                             break;
                         }
@@ -371,6 +373,7 @@ namespace FASTER.core
                                         _indexCheckpoint.info.num_buckets = overflowBucketsAllocator.GetMaxValidAddress();
                                         ObtainCurrentTailAddress(ref _indexCheckpoint.info.finalLogicalAddress);
                                         WriteIndexMetaFile();
+                                        WriteIndexCheckpointCompleteFile();
                                         _indexCheckpoint.Reset();
                                         break;
                                     }
@@ -730,7 +733,10 @@ namespace FASTER.core
                 _hybridLogCheckpoint.info.Write(file);
                 file.Flush();
             }
+        }
 
+        private void WriteHybridLogCheckpointCompleteFile()
+        {
             string completed_filename = directoryConfiguration.GetHybridLogCheckpointFolder(_hybridLogCheckpointToken);
             completed_filename += "\\completed.dat";
             using (var file = new StreamWriter(completed_filename, false))
@@ -759,7 +765,10 @@ namespace FASTER.core
                 _indexCheckpoint.info.Write(file);
                 file.Flush();
             }
+        }
 
+        private void WriteIndexCheckpointCompleteFile()
+        {
             string completed_filename = directoryConfiguration.GetIndexCheckpointFolder(_indexCheckpointToken);
             completed_filename += "\\completed.dat";
             using (var file = new StreamWriter(completed_filename, false))
@@ -768,7 +777,6 @@ namespace FASTER.core
                 file.Flush();
             }
         }
-
         private bool ObtainCurrentTailAddress(ref long location)
         {
             var tailAddress = hlog.GetTailAddress();

--- a/cs/src/core/Index/FASTER/Checkpoint.cs
+++ b/cs/src/core/Index/FASTER/Checkpoint.cs
@@ -730,6 +730,14 @@ namespace FASTER.core
                 _hybridLogCheckpoint.info.Write(file);
                 file.Flush();
             }
+
+            string completed_filename = directoryConfiguration.GetHybridLogCheckpointFolder(_hybridLogCheckpointToken);
+            completed_filename += "\\completed.dat";
+            using (var file = new StreamWriter(completed_filename, false))
+            {
+                file.WriteLine();
+                file.Flush();
+            }
         }
 
         private void WriteHybridLogContextInfo()
@@ -752,6 +760,13 @@ namespace FASTER.core
                 file.Flush();
             }
 
+            string completed_filename = directoryConfiguration.GetIndexCheckpointFolder(_indexCheckpointToken);
+            completed_filename += "\\completed.dat";
+            using (var file = new StreamWriter(completed_filename, false))
+            {
+                file.WriteLine();
+                file.Flush();
+            }
         }
 
         private bool ObtainCurrentTailAddress(ref long location)

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -52,6 +52,8 @@ namespace FASTER.core
         private HybridLogCheckpointInfo _hybridLogCheckpoint;
         private DirectoryConfiguration directoryConfiguration;
 
+        private SafeConcurrentDictionary<Guid, long> _recoveredSessions;
+
         [ThreadStatic]
         private static FasterExecutionContext prevThreadCtx = default(FasterExecutionContext);
 
@@ -249,15 +251,34 @@ namespace FASTER.core
         /// <returns></returns>
         public bool CompleteCheckpoint(bool wait = false)
         {
-            do
+            if(threadCtx == null)
             {
-                CompletePending();
-                if (_systemState.phase == Phase.REST)
+                // the thread does not have an active session
+                // we can wait until system state becomes REST
+                do
+                {
+                    if(_systemState.phase == Phase.REST)
+                    {
+                        return true;
+                    }
+                } while (wait);
+            }
+            else
+            {
+                // the thread does has an active session and 
+                // so we need to constantly complete pending 
+                // and refresh (done inside CompletePending)
+                // for the checkpoint to be proceed
+                do
                 {
                     CompletePending();
-                    return true;
-                }
-            } while (wait);
+                    if (_systemState.phase == Phase.REST)
+                    {
+                        CompletePending();
+                        return true;
+                    }
+                } while (wait);
+            }
             return false;
         }
 

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -50,7 +50,7 @@ namespace FASTER.core
         private SystemState _systemState;
 
         private HybridLogCheckpointInfo _hybridLogCheckpoint;
-        private DirectoryConfiguration directoryConfiguration;
+        
 
         private SafeConcurrentDictionary<Guid, long> _recoveredSessions;
 

--- a/cs/src/core/Index/FASTER/Recovery.cs
+++ b/cs/src/core/Index/FASTER/Recovery.cs
@@ -67,7 +67,7 @@ namespace FASTER.core
                 // Remove incomplete checkpoints
                 if(!File.Exists(dir.FullName + "\\completed.dat"))
                 {
-                    Directory.Delete(dir.FullName);
+                    Directory.Delete(dir.FullName, true);
                 }
             }
             var latestICFolder = indexCheckpointDir.GetDirectories().OrderByDescending(f => f.LastWriteTime).First();
@@ -84,7 +84,7 @@ namespace FASTER.core
                 // Remove incomplete checkpoints
                 if (!File.Exists(dir.FullName + "\\completed.dat"))
                 {
-                    Directory.Delete(dir.FullName);
+                    Directory.Delete(dir.FullName, true);
                 }
             }
             var latestHLCFolder = hlogCheckpointDir.GetDirectories().OrderByDescending(f => f.LastWriteTime).First();

--- a/cs/src/core/Utilities/AsyncResultTypes.cs
+++ b/cs/src/core/Utilities/AsyncResultTypes.cs
@@ -25,14 +25,9 @@ namespace FASTER.core
         public bool CompletedSynchronously => throw new NotImplementedException();
     }
 
-    internal unsafe class HashIndexPageAsyncFlushResult : IAsyncResult
+    internal unsafe struct HashIndexPageAsyncFlushResult : IAsyncResult
     {
-        public HashBucket* start;
-        public int numChunks;
-        public int numIssued;
-        public int numFinished;
-        public uint chunkSize;
-        public IDevice device;
+        public int chunkIndex;
 
         public bool IsCompleted => throw new NotImplementedException();
 
@@ -43,7 +38,7 @@ namespace FASTER.core
 		public bool CompletedSynchronously => throw new NotImplementedException();
 	}
 
-    internal struct HashIndexPageAsyncReadResult : IAsyncResult
+    internal unsafe struct HashIndexPageAsyncReadResult : IAsyncResult
     {
         public int chunkIndex;
 

--- a/cs/test/FullRecoveryTests.cs
+++ b/cs/test/FullRecoveryTests.cs
@@ -47,7 +47,6 @@ namespace FASTER.test.recovery.sumstore
         [TearDown]
         public void TearDown()
         {
-            fht.StopSession();
             fht.Dispose();
             fht = null;
             log.Close();

--- a/cs/test/ObjectRecoveryTest.cs
+++ b/cs/test/ObjectRecoveryTest.cs
@@ -55,7 +55,6 @@ namespace FASTER.test.recovery.objectstore
         [TearDown]
         public void TearDown()
         {
-            fht.StopSession();
             fht.Dispose();
             fht = null;
             log.Close();


### PR DESCRIPTION
1. Fixed issue #80
2. Fixed a page allocation bug during recovery
3. Added a feature to create complete files during checkpointing to mark the safe completion of checkpoints
4. Fixed a bug during index checkpointing and recovery - simplified read/write to disk
5. Removed reuse of checkpoint info structs during recovery
6. Handled concurrent continue of sessions using a safe concurrent dictionary. Now, only one thread can continue a session and only once.
7. Fixed some tests
8. Closed index files appropriately - was causing an issue with deleting the folder during a test