### PR TITLE
Partial flush with object log

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,9 @@ jobs:
   
   steps:
   - task: NuGetToolInstaller@0
-
+    inputs:
+      versionSpec: '4.4.1' 
+    
   - task: NuGetCommand@2
     inputs:
       restoreSolution: '$(solution)'

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -406,6 +406,9 @@ namespace FASTER.core
             }
         }
 
+        /// <summary>
+        /// Print checkpoint info for debugging purposes
+        /// </summary>
         public void DebugPrint()
         {
             Debug.WriteLine("******** HybridLog Checkpoint Info for {0} ********", guid);

--- a/cs/src/core/Utilities/PageAsyncResultTypes.cs
+++ b/cs/src/core/Utilities/PageAsyncResultTypes.cs
@@ -99,6 +99,7 @@ namespace FASTER.core
         public int count;
 
         internal bool partial;
+        internal long fromAddress;
         internal long untilAddress;
         internal CountdownEvent handle;
         internal IDevice objlogDevice;

--- a/cs/test/BasicDiskFASTERTests.cs
+++ b/cs/test/BasicDiskFASTERTests.cs
@@ -51,6 +51,7 @@ namespace FASTER.test
                 var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
                 fht.Upsert(ref key1, ref value, Empty.Default, 0);
             }
+            fht.CompletePending(true);
 
             r = new Random(10);
 

--- a/cs/test/ObjectFASTERTests.cs
+++ b/cs/test/ObjectFASTERTests.cs
@@ -89,6 +89,7 @@ namespace FASTER.test
                 var key = new MyKey { key = i };
                 var value = new MyValue { value = i };
                 fht.Upsert(ref key, ref value, Empty.Default, 0);
+                // fht.ShiftReadOnlyAddress(fht.LogTailAddress);
             }
 
             var key2 = new MyKey { key = 23 };

--- a/cs/test/RecoverContinueTests.cs
+++ b/cs/test/RecoverContinueTests.cs
@@ -21,8 +21,6 @@ namespace FASTER.test.recovery.sumstore.recover_continue
         private FasterKV<AdId, NumClicks, Input, Output, Empty, SimpleFunctions> fht3;
         private IDevice log;
         private int numOps;
-        private AdId[] inputArray;
-        private Output[] outputArray;
 
         [SetUp]
         public void Setup()


### PR DESCRIPTION
If we move the read-only marker by a small amount, we currently rewrite the entire page (including objects on the page), because it is currently optimized for page-aligned flushes only.

This PR fixes incremental flushes within the same page, so that we flush only the delta (at sector boundary).

Further, objects pointed to by entries in the log are now guaranteed to get serialized exactly once. When the marker moves from a location partially with a sector, we first read the existing sector from storage, update the new log entries, and write out the updated sector.