### PR TITLE
[WIP] Scan log given logical address range

### DIFF
--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -1459,5 +1459,18 @@ namespace FASTER.core
         {
             dst = src;
         }
+
+        /// <summary>
+        /// Pull-based scan interface for HLOG
+        /// </summary>
+        /// <param name="beginAddress"></param>
+        /// <param name="endAddress"></param>
+        /// <returns></returns>
+        public abstract IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress);
+    }
+
+    public interface IFasterScanIterator<Key, Value> : IDisposable
+    {
+        bool GetNext(ref Key key, ref Value value);
     }
 }

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -1476,7 +1476,8 @@ namespace FASTER.core
         /// </summary>
         /// <param name="beginAddress"></param>
         /// <param name="endAddress"></param>
+        /// <param name="scanBufferingMode"></param>
         /// <returns></returns>
-        public abstract IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress);
+        public abstract IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering);
     }
 }

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -1479,9 +1479,4 @@ namespace FASTER.core
         /// <returns></returns>
         public abstract IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress);
     }
-
-    public interface IFasterScanIterator<Key, Value> : IDisposable
-    {
-        bool GetNext(ref Key key, ref Value value);
-    }
 }

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -433,11 +433,13 @@ namespace FASTER.core
         /// <param name="firstValidAddress"></param>
         protected void Initialize(long firstValidAddress)
         {
+            Debug.Assert(firstValidAddress <= PageSize);
+            Debug.Assert(PageSize >= GetRecordSize(0));
+
             readBufferPool = SectorAlignedBufferPool.GetPool(1, sectorSize);
 
             long tailPage = firstValidAddress >> LogPageSizeBits;
             int tailPageIndex = (int)(tailPage % BufferSize);
-            Debug.Assert(tailPageIndex == 0);
             AllocatePage(tailPageIndex);
 
             // Allocate next page as well

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -1363,9 +1363,9 @@ namespace FASTER.core
                     {
                         var oldAddress = ctx.logicalAddress;
 
-                        //keys are not same. I/O is not complete
+                        // Keys are not same. I/O is not complete
                         ctx.logicalAddress = GetInfoFromBytePointer(record).PreviousAddress;
-                        if (ctx.logicalAddress != Constants.kInvalidAddress)
+                        if (ctx.logicalAddress >= BeginAddress)
                         {
                             ctx.record.Return();
                             ctx.record = ctx.objBuffer = default(SectorAlignedMemory);

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -15,6 +15,55 @@ using System.Diagnostics;
 
 namespace FASTER.core
 {
+    internal class Frame : IDisposable
+    {
+        public readonly int frameSize, pageSize, sectorSize;
+        public readonly byte[][] frame;
+        public GCHandle[] handles;
+        public long[] pointers;
+
+        public Frame(int frameSize, int pageSize, int sectorSize)
+        {
+            this.frameSize = frameSize;
+            this.pageSize = pageSize;
+            this.sectorSize = sectorSize;
+
+            frame = new byte[frameSize][];
+            handles = new GCHandle[frameSize];
+            pointers = new long[frameSize];
+        }
+        public void Allocate(int index)
+        {
+            var adjustedSize = pageSize + 2 * sectorSize;
+            byte[] tmp = new byte[adjustedSize];
+            Array.Clear(tmp, 0, adjustedSize);
+
+            handles[index] = GCHandle.Alloc(tmp, GCHandleType.Pinned);
+            long p = (long)handles[index].AddrOfPinnedObject();
+            pointers[index] = (p + (sectorSize - 1)) & ~(sectorSize - 1);
+            frame[index] = tmp;
+        }
+
+        public void Clear(int pageIndex)
+        {
+            Array.Clear(frame[pageIndex], 0, frame[pageIndex].Length);
+        }
+
+        public long GetPhysicalAddress(long frameNumber, long offset)
+        {
+            return pointers[frameNumber % frameSize] + offset;
+        }
+
+        public void Dispose()
+        {
+            for (int i = 0; i < frameSize; i++)
+            {
+                handles[i].Free();
+                frame[i] = null;
+                pointers[i] = 0;
+            }
+        }
+    }
     public unsafe sealed class BlittableAllocator<Key, Value> : AllocatorBase<Key, Value>
         where Key : new()
         where Value : new()
@@ -292,7 +341,193 @@ namespace FASTER.core
         /// <returns></returns>
         public override IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress)
         {
-            throw new NotImplementedException();
+            return new BlittableScanIterator(this, beginAddress, endAddress);
+        }
+
+
+        /// <summary>
+        /// Read pages from specified device
+        /// </summary>
+        /// <typeparam name="TContext"></typeparam>
+        /// <param name="readPageStart"></param>
+        /// <param name="numPages"></param>
+        /// <param name="callback"></param>
+        /// <param name="context"></param>
+        /// <param name="frame"></param>
+        /// <param name="completed"></param>
+        /// <param name="devicePageOffset"></param>
+        /// <param name="device"></param>
+        /// <param name="objectLogDevice"></param>
+        private void AsyncReadPagesFromDeviceToFrame<TContext>(
+                                        long readPageStart,
+                                        int numPages,
+                                        IOCompletionCallback callback,
+                                        TContext context,
+                                        Frame frame,
+                                        out CountdownEvent completed,
+                                        long devicePageOffset = 0,
+                                        IDevice device = null, IDevice objectLogDevice = null)
+        {
+            var usedDevice = device;
+            IDevice usedObjlogDevice = objectLogDevice;
+
+            if (device == null)
+            {
+                usedDevice = this.device;
+            }
+
+            completed = new CountdownEvent(numPages);
+            for (long readPage = readPageStart; readPage < (readPageStart + numPages); readPage++)
+            {
+                int pageIndex = (int)(readPage % frame.frameSize);
+                if (frame.frame[pageIndex] == null)
+                {
+                    frame.Allocate(pageIndex);
+                }
+                else
+                {
+                    frame.Clear(pageIndex);
+                }
+                var asyncResult = new PageAsyncReadResult<TContext>()
+                {
+                    page = readPage,
+                    context = context,
+                    handle = completed,
+                    count = 1,
+                    frame = frame
+                };
+
+                ulong offsetInFile = (ulong)(AlignedPageSizeBytes * readPage);
+
+                if (device != null)
+                    offsetInFile = (ulong)(AlignedPageSizeBytes * (readPage - devicePageOffset));
+
+                device.ReadAsync(offsetInFile, (IntPtr)frame.pointers[pageIndex], (uint)PageSize, callback, asyncResult);
+            }
+        }
+
+        /// <summary>
+        /// Scan iterator for hybrid log
+        /// </summary>
+        public class BlittableScanIterator : IFasterScanIterator<Key, Value>
+        {
+            private const int frameSize = 2;
+
+            private readonly BlittableAllocator<Key, Value> hlog;
+            private readonly long beginAddress, endAddress;
+
+            private readonly Frame frame;
+            private readonly CountdownEvent[] loaded;
+
+            private bool first = true;
+            private long currentAddress;
+
+            /// <summary>
+            /// Constructor
+            /// </summary>
+            /// <param name="hlog"></param>
+            /// <param name="beginAddress"></param>
+            /// <param name="endAddress"></param>
+            public BlittableScanIterator(BlittableAllocator<Key, Value> hlog, long beginAddress, long endAddress)
+            {
+                this.hlog = hlog;
+                this.beginAddress = beginAddress;
+                this.endAddress = endAddress;
+                currentAddress = beginAddress;
+
+
+                frame = new Frame(frameSize, hlog.PageSize, hlog.sectorSize);
+                loaded = new CountdownEvent[frameSize];
+
+                var frameNumber = (currentAddress >> hlog.LogPageSizeBits) % frameSize;
+                hlog.AsyncReadPagesFromDeviceToFrame
+                    (currentAddress >> hlog.LogPageSizeBits,
+                    1, AsyncReadPagesCallback, Empty.Default,
+                    frame, out loaded[frameNumber]);
+            }
+
+
+            public bool GetNext(out Key key, out Value value)
+            {
+                key = default(Key);
+                value = default(Value);
+
+                if (currentAddress >= endAddress)
+                {
+                    return false;
+                }
+
+                if (currentAddress < hlog.BeginAddress)
+                {
+                    throw new Exception("Iterator address is less than log BeginAddress " + hlog.BeginAddress);
+                }
+
+                var currentPage = currentAddress >> hlog.LogPageSizeBits;
+                var offset = (currentAddress & hlog.PageSizeMask) / recordSize;
+
+                if (currentAddress >= hlog.HeadAddress)
+                {
+                    // Read record from memory
+                    var _physicalAddress = hlog.GetPhysicalAddress(currentAddress);
+                    
+                    key = hlog.GetKey(_physicalAddress);
+                    value = hlog.GetValue(_physicalAddress);
+                    currentAddress += hlog.GetRecordSize(_physicalAddress);
+                    return true;
+                }
+
+
+                var frameNumber = currentPage % frameSize;
+                loaded[frameNumber].Wait();
+
+                if (first || (currentAddress & hlog.PageSizeMask) == 0)
+                {
+                    first = false;
+
+                    // Prefetch next page if needed
+                    var endPage = endAddress >> hlog.LogPageSizeBits;
+                    if ((endPage > currentPage) &&
+                        ((endPage > currentPage + 1) || ((endAddress & hlog.PageSizeMask) != 0)))
+                    {
+                        hlog.AsyncReadPagesFromDeviceToFrame(1 + (currentAddress >> hlog.LogPageSizeBits), 1, AsyncReadPagesCallback, Empty.Default, frame, out loaded[(currentPage + 1) % frameSize]);
+                    }
+                }
+
+                var physicalAddress = frame.GetPhysicalAddress(frameNumber, offset);
+                key = hlog.GetKey(physicalAddress);
+                value = hlog.GetValue(physicalAddress);
+                currentAddress += hlog.GetRecordSize(physicalAddress);
+                return true;
+            }
+
+            public void Dispose()
+            {
+                throw new NotImplementedException();
+            }
+
+            private void AsyncReadPagesCallback(uint errorCode, uint numBytes, NativeOverlapped* overlap)
+            {
+                if (errorCode != 0)
+                {
+                    Trace.TraceError("OverlappedStream GetQueuedCompletionStatus error: {0}", errorCode);
+                }
+
+                var result = (PageAsyncReadResult<Empty>)Overlapped.Unpack(overlap).AsyncResult;
+
+                if (result.freeBuffer1.buffer != null)
+                {
+                    hlog.PopulatePage(result.freeBuffer1.GetValidPointer(), result.freeBuffer1.required_bytes, result.page);
+                    result.freeBuffer1.Return();
+                }
+
+                if (result.handle != null)
+                {
+                    result.handle.Signal();
+                }
+
+                Interlocked.MemoryBarrier();
+                Overlapped.Free(overlap);
+            }
         }
     }
 }

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -283,5 +283,16 @@ namespace FASTER.core
             throw new Exception("BlittableAllocator memory pages are sector aligned - use direct copy");
             // Buffer.MemoryCopy(src, (void*)pointers[destinationPage % BufferSize], required_bytes, required_bytes);
         }
+
+        /// <summary>
+        /// Iterator interface for scanning FASTER log
+        /// </summary>
+        /// <param name="beginAddress"></param>
+        /// <param name="endAddress"></param>
+        /// <returns></returns>
+        public override IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/cs/src/core/Allocator/IFasterScanIterator.cs
+++ b/cs/src/core/Allocator/IFasterScanIterator.cs
@@ -6,6 +6,22 @@ using System;
 namespace FASTER.core
 {
     /// <summary>
+    /// Scan buffering mode
+    /// </summary>
+    public enum ScanBufferingMode
+    {
+        /// <summary>
+        /// Buffer only current page being scanned
+        /// </summary>
+        SinglePageBuffering,
+
+        /// <summary>
+        /// Buffer current and next page in scan sequence
+        /// </summary>
+        DoublePageBuffering
+    }
+
+    /// <summary>
     /// Scan iterator interface for FASTER log
     /// </summary>
     /// <typeparam name="Key"></typeparam>

--- a/cs/src/core/Allocator/IFasterScanIterator.cs
+++ b/cs/src/core/Allocator/IFasterScanIterator.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+
+namespace FASTER.core
+{
+    /// <summary>
+    /// Scan iterator interface for FASTER log
+    /// </summary>
+    /// <typeparam name="Key"></typeparam>
+    /// <typeparam name="Value"></typeparam>
+    public interface IFasterScanIterator<Key, Value> : IDisposable
+    {
+        /// <summary>
+        /// Get next record
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns>True if record found, false if end of scan</returns>
+        bool GetNext(out Key key, out Value value);
+    }
+}

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -412,5 +412,16 @@ namespace FASTER.core
             MallocFixedPageSize<HashBucket>.PhysicalInstance = null;
             hlog.Dispose();
         }
+
+        /// <summary>
+        /// Scan the log underlying FASTER, for address range
+        /// </summary>
+        /// <param name="beginAddress"></param>
+        /// <param name="endAddress"></param>
+        /// <returns></returns>
+        public IFasterScanIterator<Key, Value> LogScan(long beginAddress, long endAddress)
+        {
+            return hlog.Scan(beginAddress, endAddress);
+        }
     }
 }

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -418,10 +418,11 @@ namespace FASTER.core
         /// </summary>
         /// <param name="beginAddress"></param>
         /// <param name="endAddress"></param>
+        /// <param name="scanBufferingMode"></param>
         /// <returns></returns>
-        public IFasterScanIterator<Key, Value> LogScan(long beginAddress, long endAddress)
+        public IFasterScanIterator<Key, Value> LogScan(long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering)
         {
-            return hlog.Scan(beginAddress, endAddress);
+            return hlog.Scan(beginAddress, endAddress, scanBufferingMode);
         }
     }
 }

--- a/cs/src/core/Index/Interfaces/IFasterKV.cs
+++ b/cs/src/core/Index/Interfaces/IFasterKV.cs
@@ -183,5 +183,13 @@ namespace FASTER.core
         /// Dump distribution of #entries in hash table, to console
         /// </summary>
         void DumpDistribution();
+
+        /// <summary>
+        /// Scan the log underlying the hash table
+        /// </summary>
+        /// <param name="beginAddress"></param>
+        /// <param name="endAddress"></param>
+        /// <returns></returns>
+        IFasterScanIterator<Key, Value> LogScan(long beginAddress, long endAddress);
     }
 }

--- a/cs/src/core/Index/Interfaces/IFasterKV.cs
+++ b/cs/src/core/Index/Interfaces/IFasterKV.cs
@@ -189,7 +189,8 @@ namespace FASTER.core
         /// </summary>
         /// <param name="beginAddress"></param>
         /// <param name="endAddress"></param>
+        /// <param name="scanBufferingMode"></param>
         /// <returns></returns>
-        IFasterScanIterator<Key, Value> LogScan(long beginAddress, long endAddress);
+        IFasterScanIterator<Key, Value> LogScan(long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode);
     }
 }

--- a/cs/src/core/Utilities/BufferPool.cs
+++ b/cs/src/core/Utilities/BufferPool.cs
@@ -66,6 +66,7 @@ namespace FASTER.core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Return()
         {
+            valid_offset = 0;
             pool.Return(this);
         }
 

--- a/cs/src/core/Utilities/PageAsyncResultTypes.cs
+++ b/cs/src/core/Utilities/PageAsyncResultTypes.cs
@@ -34,6 +34,8 @@ namespace FASTER.core
         internal IDevice objlogDevice;
         internal long resumeptr;
         internal long untilptr;
+        internal object frame;
+        internal int frameSize;
 
         /// <summary>
         /// 
@@ -70,11 +72,6 @@ namespace FASTER.core
             {
                 freeBuffer2.Return();
                 freeBuffer2.buffer = null;
-            }
-
-            if (handle != null)
-            {
-                handle.Signal();
             }
         }
     }

--- a/cs/test/BlittableLogScanTests.cs
+++ b/cs/test/BlittableLogScanTests.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using FASTER.core;
+using System.IO;
+using NUnit.Framework;
+
+namespace FASTER.test
+{
+
+    [TestFixture]
+    internal class BlittableFASTERScanTests
+    {
+        private FasterKV<KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty, Functions> fht;
+        private IDevice log;
+
+        [SetUp]
+        public void Setup()
+        {
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog4.log", deleteOnClose: true);
+            fht = new FasterKV<KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty, Functions>
+                (1L << 20, new Functions(), new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 7 });
+            fht.StartSession();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            fht.StopSession();
+            fht.Dispose();
+            fht = null;
+            log.Close();
+        }
+
+        [Test]
+        public void BlittableDiskWriteScan()
+        {
+            const int totalRecords = 2000;
+            var start = fht.LogTailAddress;
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
+                var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
+                fht.Upsert(ref key1, ref value, Empty.Default, 0);
+            }
+
+            var iter = fht.LogScan(start, fht.LogTailAddress, ScanBufferingMode.SinglePageBuffering);
+
+            int val = 0;
+            while (iter.GetNext(out KeyStruct key, out ValueStruct value))
+            {
+                Assert.IsTrue(key.kfield1 == val);
+                Assert.IsTrue(key.kfield2 == val + 1);
+                Assert.IsTrue(value.vfield1 == val);
+                Assert.IsTrue(value.vfield2 == val + 1);
+                val++;
+            }
+            Assert.IsTrue(totalRecords == val);
+
+            iter = fht.LogScan(start, fht.LogTailAddress, ScanBufferingMode.DoublePageBuffering);
+
+            val = 0;
+            while (iter.GetNext(out KeyStruct key, out ValueStruct value))
+            {
+                Assert.IsTrue(key.kfield1 == val);
+                Assert.IsTrue(key.kfield2 == val + 1);
+                Assert.IsTrue(value.vfield1 == val);
+                Assert.IsTrue(value.vfield2 == val + 1);
+                val++;
+            }
+            Assert.IsTrue(totalRecords == val);
+        }
+    }
+}

--- a/cs/test/GenericLogScanTests.cs
+++ b/cs/test/GenericLogScanTests.cs
@@ -15,7 +15,7 @@ namespace FASTER.test
 {
 
     [TestFixture]
-    internal class ObjectFASTERScanTests
+    internal class GenericFASTERScanTests
     {
         private FasterKV<MyKey, MyValue, MyInput, MyOutput, Empty, MyFunctions> fht;
         private IDevice log, objlog;
@@ -28,7 +28,7 @@ namespace FASTER.test
 
             fht = new FasterKV<MyKey, MyValue, MyInput, MyOutput, Empty, MyFunctions>
                 (128, new MyFunctions(),
-                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 15, PageSizeBits = 10 },
+                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 15, PageSizeBits = 5 },
                 checkpointSettings: new CheckpointSettings { CheckPointType = CheckpointType.FoldOver },
                 serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() }
                 );
@@ -46,7 +46,7 @@ namespace FASTER.test
 
 
         [Test]
-        public void ObjectDiskWriteScan()
+        public void GenericDiskWriteScan()
         {
             const int totalRecords = 2000;
             var start = fht.LogTailAddress;

--- a/cs/test/LogScanTests.cs
+++ b/cs/test/LogScanTests.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using FASTER.core;
+using System.IO;
+using NUnit.Framework;
+
+namespace FASTER.test
+{
+
+    [TestFixture]
+    internal class ObjectFASTERScanTests
+    {
+        private FasterKV<MyKey, MyValue, MyInput, MyOutput, Empty, MyFunctions> fht;
+        private IDevice log, objlog;
+
+        [SetUp]
+        public void Setup()
+        {
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlogscan.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlogscan.obj.log", deleteOnClose: true);
+
+            fht = new FasterKV<MyKey, MyValue, MyInput, MyOutput, Empty, MyFunctions>
+                (128, new MyFunctions(),
+                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 15, PageSizeBits = 10 },
+                checkpointSettings: new CheckpointSettings { CheckPointType = CheckpointType.FoldOver },
+                serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() }
+                );
+            fht.StartSession();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            fht.StopSession();
+            fht.Dispose();
+            fht = null;
+            log.Close();
+        }
+
+
+        [Test]
+        public void ObjectDiskWriteScan()
+        {
+            const int totalRecords = 20000;
+            var start = fht.LogTailAddress;
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var _key = new MyKey { key = i };
+                var _value = new MyValue { value = i };
+                fht.Upsert(ref _key, ref _value, Empty.Default, 0);
+            }
+
+            var iter = fht.LogScan(start, fht.LogTailAddress);
+
+            int val = 0;
+            while (iter.GetNext(out MyKey key, out MyValue value))
+            {
+                Assert.IsTrue(key.key == val);
+                Assert.IsTrue(value.value == val);
+                val++;
+            }
+            Assert.IsTrue(totalRecords == val);
+        }
+    }
+}

--- a/cs/test/LogScanTests.cs
+++ b/cs/test/LogScanTests.cs
@@ -48,7 +48,7 @@ namespace FASTER.test
         [Test]
         public void ObjectDiskWriteScan()
         {
-            const int totalRecords = 20000;
+            const int totalRecords = 2000;
             var start = fht.LogTailAddress;
             for (int i = 0; i < totalRecords; i++)
             {
@@ -57,7 +57,7 @@ namespace FASTER.test
                 fht.Upsert(ref _key, ref _value, Empty.Default, 0);
             }
 
-            var iter = fht.LogScan(start, fht.LogTailAddress);
+            var iter = fht.LogScan(start, fht.LogTailAddress, ScanBufferingMode.SinglePageBuffering);
 
             int val = 0;
             while (iter.GetNext(out MyKey key, out MyValue value))
@@ -67,6 +67,18 @@ namespace FASTER.test
                 val++;
             }
             Assert.IsTrue(totalRecords == val);
+
+            iter = fht.LogScan(start, fht.LogTailAddress, ScanBufferingMode.DoublePageBuffering);
+
+            val = 0;
+            while (iter.GetNext(out MyKey key, out MyValue value))
+            {
+                Assert.IsTrue(key.key == val);
+                Assert.IsTrue(value.value == val);
+                val++;
+            }
+            Assert.IsTrue(totalRecords == val);
+
         }
     }
 }


### PR DESCRIPTION
We are adding the ability to scan all entries in the hybrid log between a given logical address range. Note that this is slightly different from key iteration, which would return only the currently active record versions present in the key-value store. The scan feature allows us to go through the entire log using sequential I/O. One may build an IEnumerable or FIFO queue interface for the log using this basic functionality.