### PR TITLE
Changes Specific to Unix System

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://travis-ci.org/Microsoft/FASTER.svg?branch=master)](https://travis-ci.org/Microsoft/FASTER)
 [![Gitter](https://badges.gitter.im/Microsoft/FASTER.svg)](https://gitter.im/Microsoft/FASTER?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
+> This is a fork of https://github.com/Microsoft/FASTER. Main responsiblity of this repository is making sure that "FASTER" is available in .Net Core with full cross platform capabilities. Additionaly we migh include some code refactorings, but we will make sure this fork will not change anything fundamental.
+
 # Introduction
 
 Managing large application state easily and with high performance is one of the hardest problems

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -137,73 +137,78 @@ namespace FASTER.core
         public string GetIndexCheckpointFolder(Guid token = default(Guid))
         {
             if (token != default(Guid))
-                return String.Format("{0}\\{1}\\{2}", checkpointDir, index_base_folder, token);
-            else 
-                return String.Format("{0}\\{1}", checkpointDir, index_base_folder);
+                return GetMergedFolderPath(checkpointDir, index_base_folder);
+            else
+                return GetMergedFolderPath(checkpointDir, index_base_folder);
         }
         public string GetHybridLogCheckpointFolder(Guid token = default(Guid))
         {
             if (token != default(Guid))
-                return String.Format("{0}\\{1}\\{2}", checkpointDir, cpr_base_folder, token);
+                return GetMergedFolderPath(checkpointDir, cpr_base_folder, token.ToString());
             else
-                return String.Format("{0}\\{1}", checkpointDir, cpr_base_folder);
+                return GetMergedFolderPath(checkpointDir, cpr_base_folder);
         }
         public string GetIndexCheckpointMetaFileName(Guid token)
         {
-            return String.Format("{0}\\{1}\\{2}\\{3}.dat",
-                                    checkpointDir,
+            return GetMergedFolderPath(checkpointDir,
                                     index_base_folder,
-                                    token,
+                                    token.ToString(),
                                     index_meta_file);
         }
         public string GetPrimaryHashTableFileName(Guid token)
         {
-            return String.Format("{0}\\{1}\\{2}\\{3}.dat",
-                                    checkpointDir,
+            return GetMergedFolderPath(checkpointDir,
                                     index_base_folder,
-                                    token,
+                                    token.ToString(),
                                     hash_table_file);
         }
         public string GetOverflowBucketsFileName(Guid token)
         {
-            return String.Format("{0}\\{1}\\{2}\\{3}.dat",
-                                    checkpointDir,
+            return GetMergedFolderPath(checkpointDir,
                                     index_base_folder,
-                                    token,
+                                    token.ToString(),
                                     overflow_buckets_file);
         }
         public string GetHybridLogCheckpointMetaFileName(Guid token)
         {
-            return String.Format("{0}\\{1}\\{2}\\{3}.dat",
-                                    checkpointDir,
+            return GetMergedFolderPath(checkpointDir,
                                     cpr_base_folder,
-                                    token,
+                                    token.ToString(),
                                     cpr_meta_file);
         }
         public string GetHybridLogCheckpointContextFileName(Guid checkpointToken, Guid sessionToken)
         {
-            return String.Format("{0}\\{1}\\{2}\\{3}.dat",
-                                    checkpointDir,
+            return GetMergedFolderPath(checkpointDir,
                                     cpr_base_folder,
-                                    checkpointToken,
-                                    sessionToken);
+                                    checkpointToken.ToString(),
+                                    sessionToken.ToString());
         }
         public string GetHybridLogCheckpointFileName(Guid token)
         {
-            return String.Format("{0}\\{1}\\{2}\\{3}.log",
-                                    checkpointDir,
+            return GetMergedFolderPath(checkpointDir,
                                     cpr_base_folder,
-                                    token,
+                                    token.ToString(),
                                     snapshot_file);
         }
 
         public string GetHybridLogObjectCheckpointFileName(Guid token)
         {
-            return String.Format("{0}\\{1}\\{2}\\{3}.obj.log",
-                                    checkpointDir,
+            return GetMergedFolderPath(checkpointDir,
                                     cpr_base_folder,
-                                    token,
+                                    token.ToString(),
                                     snapshot_file);
+        }
+
+        public static string GetMergedFolderPath(params String[] paths)
+        {
+            String fullPath = paths[0];
+
+            for (int i = 1; i < paths.Length; i++)
+            {
+                fullPath += Path.DirectorySeparatorChar + paths[i];
+            }
+
+            return fullPath;
         }
     }
 
@@ -267,7 +272,7 @@ namespace FASTER.core
             flushedLogicalAddress = 0;
             startLogicalAddress = 0;
             finalLogicalAddress = 0;
-            guids = new Guid[LightEpoch.kTableSize+1];
+            guids = new Guid[LightEpoch.kTableSize + 1];
             continueTokens = new Dictionary<Guid, long>();
             objectLogSegmentOffsets = null;
         }
@@ -359,7 +364,7 @@ namespace FASTER.core
                 }
             }
 
-            if(continueTokens.Count == num_threads)
+            if (continueTokens.Count == num_threads)
             {
                 return true;
             }
@@ -390,7 +395,7 @@ namespace FASTER.core
             writer.WriteLine(startLogicalAddress);
             writer.WriteLine(finalLogicalAddress);
             writer.WriteLine(numThreads);
-            for(int i = 0; i < numThreads; i++)
+            for (int i = 0; i < numThreads; i++)
             {
                 writer.WriteLine(guids[i]);
             }
@@ -419,7 +424,7 @@ namespace FASTER.core
             Debug.WriteLine("Final Logical Address: {0}", finalLogicalAddress);
             Debug.WriteLine("Num sessions recovered: {0}", numThreads);
             Debug.WriteLine("Recovered sessions: ");
-            foreach(var sessionInfo in continueTokens)
+            foreach (var sessionInfo in continueTokens)
             {
                 Debug.WriteLine("{0}: {1}", sessionInfo.Key, sessionInfo.Value);
             }
@@ -519,7 +524,7 @@ namespace FASTER.core
         {
             Debug.WriteLine("******** Index Checkpoint Info for {0} ********", token);
             Debug.WriteLine("Table Size: {0}", table_size);
-            Debug.WriteLine("Main Table Size (in GB): {0}", ((double)num_ht_bytes)/1000.0 / 1000.0 / 1000.0);
+            Debug.WriteLine("Main Table Size (in GB): {0}", ((double)num_ht_bytes) / 1000.0 / 1000.0 / 1000.0);
             Debug.WriteLine("Overflow Table Size (in GB): {0}", ((double)num_ofb_bytes) / 1000.0 / 1000.0 / 1000.0);
             Debug.WriteLine("Num Buckets: {0}", num_buckets);
             Debug.WriteLine("Start Logical Address: {0}", startLogicalAddress);

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -137,10 +137,11 @@ namespace FASTER.core
         public string GetIndexCheckpointFolder(Guid token = default(Guid))
         {
             if (token != default(Guid))
-                return GetMergedFolderPath(checkpointDir, index_base_folder);
+                return GetMergedFolderPath(checkpointDir, index_base_folder, token.ToString());
             else
                 return GetMergedFolderPath(checkpointDir, index_base_folder);
         }
+
         public string GetHybridLogCheckpointFolder(Guid token = default(Guid))
         {
             if (token != default(Guid))
@@ -148,47 +149,59 @@ namespace FASTER.core
             else
                 return GetMergedFolderPath(checkpointDir, cpr_base_folder);
         }
+
         public string GetIndexCheckpointMetaFileName(Guid token)
         {
             return GetMergedFolderPath(checkpointDir,
                                     index_base_folder,
                                     token.ToString(),
-                                    index_meta_file);
+                                    index_meta_file,
+                                    ".dat");
         }
+
         public string GetPrimaryHashTableFileName(Guid token)
         {
             return GetMergedFolderPath(checkpointDir,
                                     index_base_folder,
                                     token.ToString(),
-                                    hash_table_file);
+                                    hash_table_file,
+                                    ".dat");
         }
+
         public string GetOverflowBucketsFileName(Guid token)
         {
             return GetMergedFolderPath(checkpointDir,
                                     index_base_folder,
                                     token.ToString(),
-                                    overflow_buckets_file);
+                                    overflow_buckets_file,
+                                    ".dat");
         }
+
         public string GetHybridLogCheckpointMetaFileName(Guid token)
         {
             return GetMergedFolderPath(checkpointDir,
                                     cpr_base_folder,
                                     token.ToString(),
-                                    cpr_meta_file);
+                                    cpr_meta_file,
+                                    ".dat");
         }
+
         public string GetHybridLogCheckpointContextFileName(Guid checkpointToken, Guid sessionToken)
         {
             return GetMergedFolderPath(checkpointDir,
                                     cpr_base_folder,
                                     checkpointToken.ToString(),
-                                    sessionToken.ToString());
+                                    sessionToken.ToString(),
+                                    ".dat");
         }
+
         public string GetHybridLogCheckpointFileName(Guid token)
         {
             return GetMergedFolderPath(checkpointDir,
                                     cpr_base_folder,
                                     token.ToString(),
-                                    snapshot_file);
+                                    snapshot_file,
+                                    ".dat");
         }
 
         public string GetHybridLogObjectCheckpointFileName(Guid token)
@@ -196,7 +209,8 @@ namespace FASTER.core
             return GetMergedFolderPath(checkpointDir,
                                     cpr_base_folder,
                                     token.ToString(),
-                                    snapshot_file);
+                                    snapshot_file,
+                                    ".obj.dat");
         }
 
         public static string GetMergedFolderPath(params String[] paths)
@@ -205,7 +219,14 @@ namespace FASTER.core
 
             for (int i = 1; i < paths.Length; i++)
             {
-                fullPath += Path.DirectorySeparatorChar + paths[i];
+                if (i == paths.Length - 1 && paths[i].Contains("."))
+                {
+                    fullPath += paths[i];
+                }
+                else
+                {
+                    fullPath += Path.DirectorySeparatorChar + paths[i];
+                }
             }
 
             return fullPath;

--- a/cs/src/core/Index/FASTER/Checkpoint.cs
+++ b/cs/src/core/Index/FASTER/Checkpoint.cs
@@ -738,7 +738,7 @@ namespace FASTER.core
         private void WriteHybridLogCheckpointCompleteFile()
         {
             string completed_filename = directoryConfiguration.GetHybridLogCheckpointFolder(_hybridLogCheckpointToken);
-            completed_filename += "\\completed.dat";
+            completed_filename += Path.DirectorySeparatorChar + "completed.dat";
             using (var file = new StreamWriter(completed_filename, false))
             {
                 file.WriteLine();
@@ -770,7 +770,7 @@ namespace FASTER.core
         private void WriteIndexCheckpointCompleteFile()
         {
             string completed_filename = directoryConfiguration.GetIndexCheckpointFolder(_indexCheckpointToken);
-            completed_filename += "\\completed.dat";
+            completed_filename += Path.DirectorySeparatorChar + "completed.dat";
             using (var file = new StreamWriter(completed_filename, false))
             {
                 file.WriteLine();

--- a/cs/src/core/Index/FASTER/Recovery.cs
+++ b/cs/src/core/Index/FASTER/Recovery.cs
@@ -65,7 +65,7 @@ namespace FASTER.core
             foreach(var dir in dirs)
             {
                 // Remove incomplete checkpoints
-                if(!File.Exists(dir.FullName + "\\completed.dat"))
+                if(!File.Exists(dir.FullName + Path.DirectorySeparatorChar + "completed.dat")) 
                 {
                     Directory.Delete(dir.FullName, true);
                 }
@@ -82,7 +82,7 @@ namespace FASTER.core
             foreach (var dir in dirs)
             {
                 // Remove incomplete checkpoints
-                if (!File.Exists(dir.FullName + "\\completed.dat"))
+                if (!File.Exists(dir.FullName + Path.DirectorySeparatorChar + "completed.dat"))
                 {
                     Directory.Delete(dir.FullName, true);
                 }
@@ -103,12 +103,12 @@ namespace FASTER.core
                 case CheckpointType.INDEX_ONLY:
                     {
                         var dir = new DirectoryInfo(directoryConfiguration.GetIndexCheckpointFolder(token));
-                        return File.Exists(dir.FullName + "\\completed.dat");
+                        return File.Exists(dir.FullName + Path.DirectorySeparatorChar + "completed.dat");
                     }
                 case CheckpointType.HYBRID_LOG_ONLY:
                     {
                         var dir = new DirectoryInfo(directoryConfiguration.GetHybridLogCheckpointFolder(token));
-                        return File.Exists(dir.FullName + "\\completed.dat");
+                        return File.Exists(dir.FullName + Path.DirectorySeparatorChar + "completed.dat");
                     }
                 case CheckpointType.FULL:
                     {


### PR DESCRIPTION
All changes are related to Directory Seperator charector, Windows slash is converted to unix compatible code using `Path.DirectorySeparatorChar` which is platform specific.

I would like to contribute in .Net Core support,  Mac OS  and Linux areas. Like converting playground area to unix compatible code etc.