### PR TITLE
Fixing ReadCache test that shifted the Head address but not ReadOnly …

### DIFF
--- a/cs/test/NativeReadCacheTests.cs
+++ b/cs/test/NativeReadCacheTests.cs
@@ -81,7 +81,9 @@ namespace FASTER.test
             }
 
             // Evict the read cache entirely
-            fht.ReadCache.ShiftHeadAddress(fht.ReadCache.GetTailAddress());
+            var tailAddress = fht.ReadCache.GetTailAddress();
+            fht.ReadCache.ShiftReadOnlyAddress(tailAddress);
+            fht.ReadCache.ShiftHeadAddress(tailAddress);
 
             // Read 100 keys - all should be served from disk, populating cache
             for (int i = 1900; i < 2000; i++)


### PR DESCRIPTION
The test was directly shifting the Head address of the ReadCache without shifting the ReadOnly address. This caused the ReadOnly address to be behind the Head address, so the next allocation successfully shifted the ReadOnly address, which marked the page as flushed and open, but did not shift the Head address, so the page was never marked as closed. This resulted in the allocation waiting endlessly for the allocation to complete, since the page was left open.