### PR TITLE
Ensuring ReadOnlyLagAddress does not exceed HeadOffsetLagAddress

### DIFF
--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -446,9 +446,9 @@ namespace FASTER.core
             HeadOffsetLagSize = BufferSize - HeadOffsetLagNumPages;
             HeadOffsetLagAddress = (long)HeadOffsetLagSize << LogPageSizeBits;
 
-            // ReadOnlyOffset lag (from tail)
+            // ReadOnlyOffset lag (from tail). This should not exceed HeadOffset lag.
             LogMutableFraction = settings.MutableFraction;
-            ReadOnlyLagAddress = (long)(LogMutableFraction * BufferSize) << LogPageSizeBits;
+            ReadOnlyLagAddress = Math.Min((long)(LogMutableFraction * BufferSize) << LogPageSizeBits, HeadOffsetLagAddress);
 
             // Segment size
             LogSegmentSizeBits = settings.SegmentSizeBits;


### PR DESCRIPTION
Due to HeadOffsetLagNumPages, ReadOnlyLagAddress can be greater than HeadOffsetLagAddress. This change ensures this does not happen.