### PR TITLE
[WIP] FASTER Log Compaction

### DIFF
--- a/cs/FASTER.sln
+++ b/cs/FASTER.sln
@@ -29,6 +29,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StructSampleCore", "playgro
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClassSample", "playground\ClassSample\ClassSample.csproj", "{18B6FB88-202F-4DAD-A582-17E1CEB873EC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PeriodicCompaction", "playground\PeriodicCompaction\PeriodicCompaction.csproj", "{079F8DF4-96D4-41AC-AD04-308FDF70E371}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +103,12 @@ Global
 		{18B6FB88-202F-4DAD-A582-17E1CEB873EC}.Release|Any CPU.Build.0 = Release|x64
 		{18B6FB88-202F-4DAD-A582-17E1CEB873EC}.Release|x64.ActiveCfg = Release|x64
 		{18B6FB88-202F-4DAD-A582-17E1CEB873EC}.Release|x64.Build.0 = Release|x64
+		{079F8DF4-96D4-41AC-AD04-308FDF70E371}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{079F8DF4-96D4-41AC-AD04-308FDF70E371}.Debug|x64.ActiveCfg = Debug|x64
+		{079F8DF4-96D4-41AC-AD04-308FDF70E371}.Debug|x64.Build.0 = Debug|x64
+		{079F8DF4-96D4-41AC-AD04-308FDF70E371}.Release|Any CPU.ActiveCfg = Release|x64
+		{079F8DF4-96D4-41AC-AD04-308FDF70E371}.Release|x64.ActiveCfg = Release|x64
+		{079F8DF4-96D4-41AC-AD04-308FDF70E371}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -115,6 +123,7 @@ Global
 		{494703CF-C1C9-4800-B994-EF3974EB051D} = {E6026D6A-01C5-4582-B2C1-64751490DABE}
 		{D938612F-4B99-409E-953E-28A3A027B0E3} = {E6026D6A-01C5-4582-B2C1-64751490DABE}
 		{18B6FB88-202F-4DAD-A582-17E1CEB873EC} = {E6026D6A-01C5-4582-B2C1-64751490DABE}
+		{079F8DF4-96D4-41AC-AD04-308FDF70E371} = {E6026D6A-01C5-4582-B2C1-64751490DABE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A0750637-2CCB-4139-B25E-F2CE740DCFAC}

--- a/cs/benchmark/Functions.cs
+++ b/cs/benchmark/Functions.cs
@@ -24,6 +24,10 @@ namespace FASTER.benchmark
         {
         }
 
+        public void DeleteCompletionCallback(ref Key key, Empty ctx)
+        {
+        }
+
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
         {
             Debug.WriteLine("Session {0} reports persistence until {1}", sessionId, serialNum);

--- a/cs/playground/ClassCache/Types.cs
+++ b/cs/playground/ClassCache/Types.cs
@@ -157,5 +157,10 @@ namespace ClassCache
         {
             throw new NotImplementedException();
         }
+
+        public void DeleteCompletionCallback(ref CacheKey key, CacheContext ctx)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/cs/playground/ClassSample/Program.cs
+++ b/cs/playground/ClassSample/Program.cs
@@ -86,6 +86,7 @@ namespace ClassSample
         public void ReadCompletionCallback(ref MyKey key, ref MyInput input, ref MyOutput output, MyContext ctx, Status status) { }
         public void UpsertCompletionCallback(ref MyKey key, ref MyValue value, MyContext ctx) { }
         public void RMWCompletionCallback(ref MyKey key, ref MyInput input, MyContext ctx, Status status) { }
+        public void DeleteCompletionCallback(ref MyKey key, MyContext ctx) { }
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum) { }
     }
 

--- a/cs/playground/PeriodicCompaction/PeriodicCompaction.csproj
+++ b/cs/playground/PeriodicCompaction/PeriodicCompaction.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetFramework>net46</TargetFramework>
+    <Platforms>x64</Platforms>
+    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\core\FASTER.core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/cs/playground/PeriodicCompaction/Types.cs
+++ b/cs/playground/PeriodicCompaction/Types.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using FASTER.core;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PeriodicCompaction
+{
+    public class CacheKey : IFasterEqualityComparer<CacheKey>
+    {
+        public long key;
+
+        public CacheKey() { }
+
+        public CacheKey(long first)
+        {
+            key = first;
+        }
+
+        public long GetHashCode64(ref CacheKey key)
+        {
+            return Utility.GetHashCode(key.key);
+        }
+        public bool Equals(ref CacheKey k1, ref CacheKey k2)
+        {
+            return k1.key == k2.key;
+        }
+    }
+
+    public class CacheKeySerializer : BinaryObjectSerializer<CacheKey>
+    {
+        public override void Deserialize(ref CacheKey obj)
+        {
+            obj.key = reader.ReadInt64();
+        }
+
+        public override void Serialize(ref CacheKey obj)
+        {
+            writer.Write(obj.key);
+        }
+    }
+
+    public class CacheValue
+    {
+        public long value;
+
+        public CacheValue() { }
+
+        public CacheValue(long first)
+        {
+            value = first;
+        }
+    }
+
+    public class CacheValueSerializer : BinaryObjectSerializer<CacheValue>
+    {
+        public override void Deserialize(ref CacheValue obj)
+        {
+            obj.value = reader.ReadInt64();
+        }
+
+        public override void Serialize(ref CacheValue obj)
+        {
+            writer.Write(obj.value);
+        }
+    }
+
+    public struct CacheInput
+    {
+    }
+
+    public struct CacheOutput
+    {
+        public CacheValue value;
+    }
+
+    public struct CacheContext
+    {
+        public int type;
+        public long ticks;
+    }
+
+    public class CacheFunctions : IFunctions<CacheKey, CacheValue, CacheInput, CacheOutput, CacheContext>
+    {
+        public void ConcurrentReader(ref CacheKey key, ref CacheInput input, ref CacheValue value, ref CacheOutput dst)
+        {
+            dst.value = value;
+        }
+
+        public void ConcurrentWriter(ref CacheKey key, ref CacheValue src, ref CacheValue dst)
+        {
+            dst = src;
+        }
+
+        public void CopyUpdater(ref CacheKey key, ref CacheInput input, ref CacheValue oldValue, ref CacheValue newValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void InitialUpdater(ref CacheKey key, ref CacheInput input, ref CacheValue value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void InPlaceUpdater(ref CacheKey key, ref CacheInput input, ref CacheValue value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ReadCompletionCallback(ref CacheKey key, ref CacheInput input, ref CacheOutput output, CacheContext ctx, Status status)
+        {
+            if (ctx.type == 0)
+            {
+                if (output.value.value != key.key)
+                    throw new Exception("Read error!");
+            }
+            else
+            {
+                long ticks = DateTime.Now.Ticks - ctx.ticks;
+
+                if (status == Status.NOTFOUND)
+                    Console.WriteLine("Async: Value not found, latency = {0}ms", new TimeSpan(ticks).TotalMilliseconds);
+
+                if (output.value.value != key.key)
+                    Console.WriteLine("Async: Incorrect value {0} found, latency = {1}ms", output.value.value, new TimeSpan(ticks).TotalMilliseconds);
+                else
+                    Console.WriteLine("Async: Correct value {0} found, latency = {1}ms", output.value.value, new TimeSpan(ticks).TotalMilliseconds);
+            }
+        }
+
+        public void RMWCompletionCallback(ref CacheKey key, ref CacheInput input, CacheContext ctx, Status status)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SingleReader(ref CacheKey key, ref CacheInput input, ref CacheValue value, ref CacheOutput dst)
+        {
+            dst.value = value;
+        }
+
+        public void SingleWriter(ref CacheKey key, ref CacheValue src, ref CacheValue dst)
+        {
+            dst = src;
+        }
+
+        public void UpsertCompletionCallback(ref CacheKey key, ref CacheValue value, CacheContext ctx)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void DeleteCompletionCallback(ref CacheKey key, CacheContext ctx)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/cs/playground/StructSample/Functions.cs
+++ b/cs/playground/StructSample/Functions.cs
@@ -29,6 +29,7 @@ namespace StructSample
         // Completion callbacks
         public void ReadCompletionCallback(ref long key, ref long input, ref long output, Empty ctx, Status s) { }
         public void UpsertCompletionCallback(ref long key, ref long value, Empty ctx) { }
+        public void DeleteCompletionCallback(ref long key, Empty ctx) { }
         public void RMWCompletionCallback(ref long key, ref long input, Empty ctx, Status s) { }
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum) { }
     }
@@ -67,6 +68,7 @@ namespace StructSample
         // Completion callbacks
         public void ReadCompletionCallback(ref Key key, ref Input input, ref Output output, Empty ctx, Status status) { }
         public void UpsertCompletionCallback(ref Key key, ref Value output, Empty ctx) { }
+        public void DeleteCompletionCallback(ref Key key, Empty ctx) { }
         public void RMWCompletionCallback(ref Key key, ref Input output, Empty ctx, Status status) { }
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum) { }
     }

--- a/cs/playground/StructSampleCore/Functions.cs
+++ b/cs/playground/StructSampleCore/Functions.cs
@@ -29,6 +29,7 @@ namespace StructSampleCore
         // Completion callbacks
         public void ReadCompletionCallback(ref long key, ref long input, ref long output, Empty ctx, Status s) { }
         public void UpsertCompletionCallback(ref long key, ref long value, Empty ctx) { }
+        public void DeleteCompletionCallback(ref long key, Empty ctx) { }
         public void RMWCompletionCallback(ref long key, ref long input, Empty ctx, Status s) { }
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum) { }
     }
@@ -67,6 +68,7 @@ namespace StructSampleCore
         // Completion callbacks
         public void ReadCompletionCallback(ref Key key, ref Input input, ref Output output, Empty ctx, Status status) { }
         public void UpsertCompletionCallback(ref Key key, ref Value output, Empty ctx) { }
+        public void DeleteCompletionCallback(ref Key key, Empty ctx) { }
         public void RMWCompletionCallback(ref Key key, ref Input output, Empty ctx, Status status) { }
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum) { }
     }

--- a/cs/playground/SumStore/SumStoreTypes.cs
+++ b/cs/playground/SumStore/SumStoreTypes.cs
@@ -58,6 +58,10 @@ namespace SumStore
         {
         }
 
+        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
+        {
+        }
+
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
         {
             Console.WriteLine("Session {0} reports persistence until {1}", sessionId, serialNum);

--- a/cs/src/core/Allocator/BlittableFrame.cs
+++ b/cs/src/core/Allocator/BlittableFrame.cs
@@ -53,7 +53,8 @@ namespace FASTER.core
         {
             for (int i = 0; i < frameSize; i++)
             {
-                handles[i].Free();
+                if (handles[i] != default(GCHandle))
+                    handles[i].Free();
                 frame[i] = null;
                 pointers[i] = 0;
             }

--- a/cs/src/core/Allocator/BlittableScanIterator.cs
+++ b/cs/src/core/Allocator/BlittableScanIterator.cs
@@ -55,11 +55,13 @@ namespace FASTER.core
         /// <summary>
         /// Get next record in iterator
         /// </summary>
+        /// <param name="recordInfo"></param>
         /// <param name="key"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        public bool GetNext(out Key key, out Value value)
+        public bool GetNext(out RecordInfo recordInfo, out Key key, out Value value)
         {
+            recordInfo = default(RecordInfo);
             key = default(Key);
             value = default(Value);
 
@@ -97,12 +99,7 @@ namespace FASTER.core
                     // Read record from cached page memory
                     var _physicalAddress = hlog.GetPhysicalAddress(currentAddress);
 
-                    if (hlog.GetInfo(_physicalAddress).Invalid)
-                    {
-                        currentAddress += hlog.GetRecordSize(_physicalAddress);
-                        continue;
-                    }
-
+                    recordInfo = hlog.GetInfo(_physicalAddress);
                     key = hlog.GetKey(_physicalAddress);
                     value = hlog.GetValue(_physicalAddress);
                     currentAddress += hlog.GetRecordSize(_physicalAddress);
@@ -111,12 +108,7 @@ namespace FASTER.core
 
                 var physicalAddress = frame.GetPhysicalAddress(currentFrame, offset);
 
-                if (hlog.GetInfo(physicalAddress).Invalid)
-                {
-                    currentAddress += hlog.GetRecordSize(physicalAddress);
-                    continue;
-                }
-
+                recordInfo = hlog.GetInfo(physicalAddress);
                 key = hlog.GetKey(physicalAddress);
                 value = hlog.GetValue(physicalAddress);
                 currentAddress += hlog.GetRecordSize(physicalAddress);

--- a/cs/src/core/Allocator/BlittableScanIterator.cs
+++ b/cs/src/core/Allocator/BlittableScanIterator.cs
@@ -21,7 +21,12 @@ namespace FASTER.core
         private readonly CountdownEvent[] loaded;
 
         private bool first = true;
-        private long currentAddress;
+        private long currentAddress, nextAddress;
+
+        /// <summary>
+        /// Current address
+        /// </summary>
+        public long CurrentAddress => currentAddress;
 
         /// <summary>
         /// Constructor
@@ -35,7 +40,8 @@ namespace FASTER.core
             this.hlog = hlog;
             this.beginAddress = beginAddress;
             this.endAddress = endAddress;
-            currentAddress = beginAddress;
+            currentAddress = -1;
+            nextAddress = beginAddress;
 
             if (scanBufferingMode == ScanBufferingMode.SinglePageBuffering)
                 frameSize = 1;
@@ -46,11 +52,11 @@ namespace FASTER.core
             loaded = new CountdownEvent[frameSize];
 
             // Only load addresses flushed to disk
-            if (currentAddress < hlog.HeadAddress)
+            if (nextAddress < hlog.HeadAddress)
             {
-                var frameNumber = (currentAddress >> hlog.LogPageSizeBits) % frameSize;
+                var frameNumber = (nextAddress >> hlog.LogPageSizeBits) % frameSize;
                 hlog.AsyncReadPagesFromDeviceToFrame
-                    (currentAddress >> hlog.LogPageSizeBits,
+                    (nextAddress >> hlog.LogPageSizeBits,
                     1, AsyncReadPagesCallback, Empty.Default,
                     frame, out loaded[frameNumber]);
             }
@@ -69,6 +75,7 @@ namespace FASTER.core
             key = default(Key);
             value = default(Value);
 
+            currentAddress = nextAddress;
             while (true)
             {
                 // Check for boundary conditions
@@ -103,19 +110,31 @@ namespace FASTER.core
                     // Read record from cached page memory
                     var _physicalAddress = hlog.GetPhysicalAddress(currentAddress);
 
+                    if (hlog.GetInfo(_physicalAddress).Invalid)
+                    {
+                        currentAddress += hlog.GetRecordSize(_physicalAddress);
+                        continue;
+                    }
+
                     recordInfo = hlog.GetInfo(_physicalAddress);
                     key = hlog.GetKey(_physicalAddress);
                     value = hlog.GetValue(_physicalAddress);
-                    currentAddress += hlog.GetRecordSize(_physicalAddress);
+                    nextAddress = currentAddress + hlog.GetRecordSize(_physicalAddress);
                     return true;
                 }
 
                 var physicalAddress = frame.GetPhysicalAddress(currentFrame, offset);
 
+                if (hlog.GetInfo(physicalAddress).Invalid)
+                {
+                    currentAddress += hlog.GetRecordSize(physicalAddress);
+                    continue;
+                }
+
                 recordInfo = hlog.GetInfo(physicalAddress);
                 key = hlog.GetKey(physicalAddress);
                 value = hlog.GetValue(physicalAddress);
-                currentAddress += hlog.GetRecordSize(physicalAddress);
+                nextAddress = currentAddress + hlog.GetRecordSize(physicalAddress);
                 return true;
             }
         }

--- a/cs/src/core/Allocator/BlittableScanIterator.cs
+++ b/cs/src/core/Allocator/BlittableScanIterator.cs
@@ -45,11 +45,15 @@ namespace FASTER.core
             frame = new BlittableFrame(frameSize, hlog.PageSize, hlog.GetDeviceSectorSize());
             loaded = new CountdownEvent[frameSize];
 
-            var frameNumber = (currentAddress >> hlog.LogPageSizeBits) % frameSize;
-            hlog.AsyncReadPagesFromDeviceToFrame
-                (currentAddress >> hlog.LogPageSizeBits,
-                1, AsyncReadPagesCallback, Empty.Default,
-                frame, out loaded[frameNumber]);
+            // Only load addresses flushed to disk
+            if (currentAddress < hlog.HeadAddress)
+            {
+                var frameNumber = (currentAddress >> hlog.LogPageSizeBits) % frameSize;
+                hlog.AsyncReadPagesFromDeviceToFrame
+                    (currentAddress >> hlog.LogPageSizeBits,
+                    1, AsyncReadPagesCallback, Empty.Default,
+                    frame, out loaded[frameNumber]);
+            }
         }
 
         /// <summary>

--- a/cs/src/core/Allocator/BlittableScanIterator.cs
+++ b/cs/src/core/Allocator/BlittableScanIterator.cs
@@ -97,6 +97,12 @@ namespace FASTER.core
                     // Read record from cached page memory
                     var _physicalAddress = hlog.GetPhysicalAddress(currentAddress);
 
+                    if (hlog.GetInfo(_physicalAddress).Invalid)
+                    {
+                        currentAddress += hlog.GetRecordSize(_physicalAddress);
+                        continue;
+                    }
+
                     key = hlog.GetKey(_physicalAddress);
                     value = hlog.GetValue(_physicalAddress);
                     currentAddress += hlog.GetRecordSize(_physicalAddress);
@@ -104,6 +110,13 @@ namespace FASTER.core
                 }
 
                 var physicalAddress = frame.GetPhysicalAddress(currentFrame, offset);
+
+                if (hlog.GetInfo(physicalAddress).Invalid)
+                {
+                    currentAddress += hlog.GetRecordSize(physicalAddress);
+                    continue;
+                }
+
                 key = hlog.GetKey(physicalAddress);
                 value = hlog.GetValue(physicalAddress);
                 currentAddress += hlog.GetRecordSize(physicalAddress);

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -46,12 +46,12 @@ namespace FASTER.core
         {
             SerializerSettings = serializerSettings;
 
-            if (default(Key) == null && ((SerializerSettings == null) || (SerializerSettings.keySerializer == null)))
+            if (default(Key) == null && (settings.LogDevice as NullDevice == null) && ((SerializerSettings == null) || (SerializerSettings.keySerializer == null)))
             {
                 throw new Exception("Key is a class, but no serializer specified via SerializerSettings");
             }
 
-            if (default(Value) == null && ((SerializerSettings == null) || (SerializerSettings.valueSerializer == null)))
+            if (default(Value) == null && (settings.LogDevice as NullDevice == null) && ((SerializerSettings == null) || (SerializerSettings.valueSerializer == null)))
             {
                 throw new Exception("Value is a class, but no serializer specified via SerializerSettings");
             }
@@ -61,7 +61,7 @@ namespace FASTER.core
 
             objectLogDevice = settings.ObjectLogDevice;
 
-            if (KeyHasObjects() || ValueHasObjects())
+            if ((settings.LogDevice as NullDevice == null) && (KeyHasObjects() || ValueHasObjects()))
             {
                 if (objectLogDevice == null)
                     throw new Exception("Objects in key/value, but object log not provided during creation of FASTER instance");

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -350,7 +350,7 @@ namespace FASTER.core
                         addr.Add((long)key_address);
                     }
 
-                    if (ValueHasObjects())
+                    if (ValueHasObjects() && !src[i].info.Tombstone)
                     {
                         long pos = ms.Position;
                         valueSerializer.Serialize(ref src[i].value);
@@ -708,7 +708,7 @@ namespace FASTER.core
 
             while (ptr < untilptr)
             {
-                if (!src[ptr/recordSize].info.Invalid)
+                if (!src[ptr / recordSize].info.Invalid)
                 {
                     if (KeyHasObjects())
                     {
@@ -723,7 +723,7 @@ namespace FASTER.core
                         keySerializer.Deserialize(ref src[ptr/recordSize].key);
                     } 
 
-                    if (ValueHasObjects())
+                    if (ValueHasObjects() && !src[ptr / recordSize].info.Tombstone)
                     {
                         var value_addr = GetValueAddressInfo((long)raw + ptr);
                         if (start_addr == -1) start_addr = value_addr->Address;
@@ -788,7 +788,7 @@ namespace FASTER.core
                         addr.Add((long)key_address);
                     }
 
-                    if (ValueHasObjects())
+                    if (ValueHasObjects() && !GetInfo(ptr).Tombstone)
                     {
                         pos = stream.Position;
                         var value_address = GetValueAddressInfo(ptr);
@@ -851,7 +851,7 @@ namespace FASTER.core
                     }
 
 
-                    if (ValueHasObjects())
+                    if (ValueHasObjects() && !src[ptr / recordSize].info.Tombstone)
                     {
                         var value_addr = GetValueAddressInfo((long)raw + ptr);
                         var addr = value_addr->Address;
@@ -913,7 +913,7 @@ namespace FASTER.core
                     endAddress = x->Address + x->Size;
                 }
 
-                if (ValueHasObjects())
+                if (ValueHasObjects() && !GetInfoFromBytePointer(record).Tombstone)
                 {
                     var x = GetValueAddressInfo((long)record);
                     if (startAddress == -1)
@@ -943,7 +943,7 @@ namespace FASTER.core
                 keySerializer.EndDeserialize();
             }
 
-            if (ValueHasObjects())
+            if (ValueHasObjects() && !GetInfoFromBytePointer(record).Tombstone)
             {
                 ctx.value = new Value();
 

--- a/cs/src/core/Allocator/GenericFrame.cs
+++ b/cs/src/core/Allocator/GenericFrame.cs
@@ -47,6 +47,11 @@ namespace FASTER.core
             return ref frame[frameNumber][offset].value;
         }
 
+        public ref RecordInfo GetInfo(long frameNumber, long offset)
+        {
+            return ref frame[frameNumber][offset].info;
+        }
+
         public ref Record<Key, Value>[] GetPage(long frameNumber)
         {
             return ref frame[frameNumber];

--- a/cs/src/core/Allocator/GenericScanIterator.cs
+++ b/cs/src/core/Allocator/GenericScanIterator.cs
@@ -100,12 +100,17 @@ namespace FASTER.core
                     currentAddress += recordSize;
 
                     var page = currentPage % hlog.BufferSize;
+
+                    if (hlog.values[page][offset].info.Invalid)
+                        continue;
                     key = hlog.values[page][offset].key;
                     value = hlog.values[page][offset].value;
                     return true;
                 }
 
                 currentAddress += recordSize;
+                if (frame.GetInfo(currentFrame, offset).Invalid)
+                    continue;
                 key = frame.GetKey(currentFrame, offset);
                 value = frame.GetValue(currentFrame, offset);
                 return true;

--- a/cs/src/core/Allocator/GenericScanIterator.cs
+++ b/cs/src/core/Allocator/GenericScanIterator.cs
@@ -58,11 +58,13 @@ namespace FASTER.core
         /// <summary>
         /// Get next record using iterator
         /// </summary>
+        /// <param name="recordInfo"></param>
         /// <param name="key"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        public bool GetNext(out Key key, out Value value)
+        public bool GetNext(out RecordInfo recordInfo, out Key key, out Value value)
         {
+            recordInfo = default(RecordInfo);
             key = default(Key);
             value = default(Value);
 
@@ -101,16 +103,14 @@ namespace FASTER.core
 
                     var page = currentPage % hlog.BufferSize;
 
-                    if (hlog.values[page][offset].info.Invalid)
-                        continue;
+                    recordInfo = hlog.values[page][offset].info;
                     key = hlog.values[page][offset].key;
                     value = hlog.values[page][offset].value;
                     return true;
                 }
 
                 currentAddress += recordSize;
-                if (frame.GetInfo(currentFrame, offset).Invalid)
-                    continue;
+                recordInfo = frame.GetInfo(currentFrame, offset);
                 key = frame.GetKey(currentFrame, offset);
                 value = frame.GetValue(currentFrame, offset);
                 return true;

--- a/cs/src/core/Allocator/GenericScanIterator.cs
+++ b/cs/src/core/Allocator/GenericScanIterator.cs
@@ -48,11 +48,15 @@ namespace FASTER.core
             frame = new GenericFrame<Key, Value>(frameSize, hlog.PageSize);
             loaded = new CountdownEvent[frameSize];
 
-            var frameNumber = (currentAddress >> hlog.LogPageSizeBits) % frameSize;
-            hlog.AsyncReadPagesFromDeviceToFrame
-                (currentAddress >> hlog.LogPageSizeBits,
-                1, AsyncReadPagesCallback, Empty.Default,
-                frame, out loaded[frameNumber]);
+            // Only load addresses flushed to disk
+            if (currentAddress < hlog.HeadAddress)
+            {
+                var frameNumber = (currentAddress >> hlog.LogPageSizeBits) % frameSize;
+                hlog.AsyncReadPagesFromDeviceToFrame
+                    (currentAddress >> hlog.LogPageSizeBits,
+                    1, AsyncReadPagesCallback, Empty.Default,
+                    frame, out loaded[frameNumber]);
+            }
         }
 
         /// <summary>

--- a/cs/src/core/Allocator/GenericScanIterator.cs
+++ b/cs/src/core/Allocator/GenericScanIterator.cs
@@ -152,6 +152,9 @@ namespace FASTER.core
         /// </summary>
         public void Dispose()
         {
+            for (int i = 0; i < frameSize; i++)
+                loaded[i]?.Wait();
+
             frame.Dispose();
         }
 

--- a/cs/src/core/Allocator/IFasterScanIterator.cs
+++ b/cs/src/core/Allocator/IFasterScanIterator.cs
@@ -31,9 +31,10 @@ namespace FASTER.core
         /// <summary>
         /// Get next record
         /// </summary>
+        /// <param name="recordInfo"></param>
         /// <param name="key"></param>
         /// <param name="value"></param>
         /// <returns>True if record found, false if end of scan</returns>
-        bool GetNext(out Key key, out Value value);
+        bool GetNext(out RecordInfo recordInfo, out Key key, out Value value);
     }
 }

--- a/cs/src/core/Allocator/IFasterScanIterator.cs
+++ b/cs/src/core/Allocator/IFasterScanIterator.cs
@@ -36,5 +36,10 @@ namespace FASTER.core
         /// <param name="value"></param>
         /// <returns>True if record found, false if end of scan</returns>
         bool GetNext(out RecordInfo recordInfo, out Key key, out Value value);
+
+        /// <summary>
+        /// Current address
+        /// </summary>
+        long CurrentAddress { get; }
     }
 }

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -413,17 +413,20 @@ namespace FASTER.core
         }
 
         /// <summary>
-        /// Delete hash entry if possible as a best effort
-        /// Entry is deleted if key is in memory and at the head of hash chain
+        /// Delete entry (use tombstone if necessary)
+        /// Hash entry is removed as a best effort (if key is in memory and at 
+        /// the head of hash chain.
         /// Value is set to null (using ConcurrentWrite) if it is in mutable region
         /// </summary>
         /// <param name="key"></param>
+        /// <param name="userContext"></param>
         /// <param name="monotonicSerialNum"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Status DeleteFromMemory(ref Key key, long monotonicSerialNum)
+        public Status Delete(ref Key key, Context userContext, long monotonicSerialNum)
         {
-            var internalStatus = InternalDeleteFromMemory(ref key);
+            var context = default(PendingContext);
+            var internalStatus = InternalDelete(ref key, ref userContext, ref context);
             var status = default(Status);
             if (internalStatus == OperationStatus.SUCCESS || internalStatus == OperationStatus.NOTFOUND)
             {

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -29,6 +29,16 @@ namespace FASTER.core
         public long EntryCount => GetEntryCount();
 
         /// <summary>
+        /// Size of index in #cache lines (64 bytes each)
+        /// </summary>
+        public long IndexSize => state[resizeInfo.version].size;
+
+        /// <summary>
+        /// Comparer used by FASTER
+        /// </summary>
+        public IFasterEqualityComparer<Key> Comparer => comparer;
+
+        /// <summary>
         /// Hybrid log used by this FASTER instance
         /// </summary>
         public LogAccessor<Key, Value, Input, Output, Context> Log { get; }

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -267,8 +267,6 @@ namespace FASTER.core
 
         internal ResizeInfo resizeInfo;
 
-        internal long currentSize;
-
         /// <summary>
         /// Constructor
         /// </summary>

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -1376,6 +1376,8 @@ namespace FASTER.core
 
             if (logicalAddress >= hlog.ReadOnlyAddress)
             {
+                // Invalidate record
+                hlog.GetInfo(physicalAddress).Invalid = true;
                 Value v = default(Value);
                 functions.ConcurrentWriter(ref hlog.GetKey(physicalAddress), ref v, ref hlog.GetValue(physicalAddress));
             }

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -1537,10 +1537,10 @@ namespace FASTER.core
 
                     if (entry.word == Interlocked.CompareExchange(ref bucket->bucket_entries[slot], updatedEntry.word, entry.word))
                     {
-                        // If possible, apply both tombstone and invalid bits to the record
-                        // We apply invalid bit as the record is not part of any hash chain now
+                        // Apply tombstone bit to the record
                         hlog.GetInfo(physicalAddress).Tombstone = true;
-                        hlog.GetInfo(physicalAddress).Invalid = true;
+
+                        // Write default value
                         Value v = default(Value);
                         functions.ConcurrentWriter(ref hlog.GetKey(physicalAddress), ref v, ref hlog.GetValue(physicalAddress));
 

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -1522,12 +1522,12 @@ namespace FASTER.core
 
             // Record is in memory, try to update hash chain and completely elide record
             // only if previous address points to invalid address
-            if (logicalAddress >= hlog.HeadAddress)
+            if (logicalAddress >= hlog.ReadOnlyAddress)
             {
                 if (entry.Address == logicalAddress && hlog.GetInfo(physicalAddress).PreviousAddress < hlog.BeginAddress)
                 {
                     var updatedEntry = default(HashBucketEntry);
-                    updatedEntry.Tag = tag;
+                    updatedEntry.Tag = 0;
                     if (hlog.GetInfo(physicalAddress).PreviousAddress == Constants.kTempInvalidAddress)
                         updatedEntry.Address = Constants.kInvalidAddress;
                     else
@@ -1539,13 +1539,11 @@ namespace FASTER.core
                     {
                         // If possible, apply both tombstone and invalid bits to the record
                         // We apply invalid bit as the record is not part of any hash chain now
-                        if (logicalAddress >= hlog.ReadOnlyAddress)
-                        {
-                            hlog.GetInfo(physicalAddress).Tombstone = true;
-                            hlog.GetInfo(physicalAddress).Invalid = true;
-                            Value v = default(Value);
-                            functions.ConcurrentWriter(ref hlog.GetKey(physicalAddress), ref v, ref hlog.GetValue(physicalAddress));
-                        }
+                        hlog.GetInfo(physicalAddress).Tombstone = true;
+                        hlog.GetInfo(physicalAddress).Invalid = true;
+                        Value v = default(Value);
+                        functions.ConcurrentWriter(ref hlog.GetKey(physicalAddress), ref v, ref hlog.GetValue(physicalAddress));
+
                         status = OperationStatus.SUCCESS;
                         goto LatchRelease; // Release shared latch (if acquired)
                     }

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -222,6 +222,11 @@ namespace FASTER.core
                                                     ref pendingContext.userContext, 
                                                     ref pendingContext);
                     break;
+                case OperationType.DELETE:
+                    internalStatus = InternalDelete(ref pendingContext.key,
+                                                    ref pendingContext.userContext,
+                                                    ref pendingContext);
+                    break;
                 case OperationType.READ:
                     throw new Exception("Cannot happen!");
             }
@@ -253,6 +258,10 @@ namespace FASTER.core
                     case OperationType.UPSERT:
                         functions.UpsertCompletionCallback(ref pendingContext.key,
                                                  ref pendingContext.value,
+                                                 pendingContext.userContext);
+                        break;
+                    case OperationType.DELETE:
+                        functions.DeleteCompletionCallback(ref pendingContext.key,
                                                  pendingContext.userContext);
                         break;
                     default:

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -161,10 +161,14 @@ namespace FASTER.core
             {
                 if (!recordInfo.Invalid && !recordInfo.Tombstone)
                     tempKv.Upsert(ref key, ref value, default(Context), 0);
+
+                if (recordInfo.Tombstone)
+                    tempKv.Delete(ref key, default(Context), 0);
             }
             iter1.Dispose();
 
-            var iter2 = fht.Log.Scan(untilAddress, fht.Log.SafeReadOnlyAddress);
+            // TODO: Scan only until SafeReadOnlyAddress
+            var iter2 = fht.Log.Scan(untilAddress, fht.Log.TailAddress);
             while (iter2.GetNext(out RecordInfo recordInfo, out Key key, out Value value))
             {
                 if (!recordInfo.Invalid)
@@ -172,8 +176,8 @@ namespace FASTER.core
             }
             iter2.Dispose();
 
-            // TODO: make sure the key wasn't already inserted
-            // between SafeReadOnlyAddress and TailAddress
+            // TODO: make sure key wasn't inserted between SafeReadOnlyAddress and TailAddress
+
             var iter3 = tempKv.Log.Scan(tempKv.Log.BeginAddress, tempKv.Log.TailAddress);
             while (iter3.GetNext(out RecordInfo recordInfo, out Key key, out Value value))
             {

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -163,11 +163,10 @@ namespace FASTER.core
             {
                 while (iter1.GetNext(out RecordInfo recordInfo, out Key key, out Value value))
                 {
-                    if (!recordInfo.Invalid && !recordInfo.Tombstone)
-                        tempKv.Upsert(ref key, ref value, default(Context), 0);
-
                     if (recordInfo.Tombstone)
                         tempKv.Delete(ref key, default(Context), 0);
+                    else
+                        tempKv.Upsert(ref key, ref value, default(Context), 0);
 
                     if (++cnt % 1000 == 0)
                         fht.Refresh();
@@ -185,7 +184,7 @@ namespace FASTER.core
             {
                 while (iter3.GetNext(out RecordInfo recordInfo, out Key key, out Value value))
                 {
-                    if (!recordInfo.Invalid && !recordInfo.Tombstone)
+                    if (!recordInfo.Tombstone)
                     {
                         if (fht.ContainsKeyInMemory(ref key, scanUntil) == Status.NOTFOUND)
                             fht.Upsert(ref key, ref value, default(Context), 0);
@@ -216,8 +215,7 @@ namespace FASTER.core
                 {
                     while (iter2.GetNext(out RecordInfo recordInfo, out Key key, out Value value))
                     {
-                        if (!recordInfo.Invalid)
-                            tempKv.Delete(ref key, default(Context), 0);
+                        tempKv.Delete(ref key, default(Context), 0);
 
                         if (++cnt % 1000 == 0)
                             fht.Refresh();

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -166,7 +166,7 @@ namespace FASTER.core
             var iter2 = fht.Log.Scan(untilAddress, fht.Log.SafeReadOnlyAddress);
             while (iter2.GetNext(out Key key, out Value value))
             {
-                tempKv.DeleteFromMemory(ref key, 0);
+                tempKv.Delete(ref key, default(Context), 0);
             }
             iter2.Dispose();
 
@@ -197,6 +197,7 @@ namespace FASTER.core
             public void SingleReader(ref Key key, ref Input input, ref Value value, ref Output dst) { }
             public void SingleWriter(ref Key key, ref Value src, ref Value dst) { dst = src; }
             public void UpsertCompletionCallback(ref Key key, ref Value value, Context ctx) { }
+            public void DeleteCompletionCallback(ref Key key, Context ctx) { }
         }
     }
 }

--- a/cs/src/core/Index/Interfaces/FunctionsBase.cs
+++ b/cs/src/core/Index/Interfaces/FunctionsBase.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+#pragma warning disable 1591
+
+using System;
+
+namespace FASTER.core
+{
+    /// <summary>
+    /// Default empty functions base class to make it easy for users to provide
+    /// their own implementation
+    /// </summary>
+    /// <typeparam name="Key"></typeparam>
+    /// <typeparam name="Value"></typeparam>
+    /// <typeparam name="Input"></typeparam>
+    /// <typeparam name="Output"></typeparam>
+    /// <typeparam name="Context"></typeparam>
+    public abstract class FunctionsBase<Key, Value, Input, Output, Context> : IFunctions<Key, Value, Input, Output, Context>
+    {
+        public virtual void ConcurrentReader(ref Key key, ref Input input, ref Value value, ref Output dst) { }
+        public virtual void SingleReader(ref Key key, ref Input input, ref Value value, ref Output dst) { }
+
+        public virtual void ConcurrentWriter(ref Key key, ref Value src, ref Value dst) => dst = src;
+        public virtual void SingleWriter(ref Key key, ref Value src, ref Value dst) => dst = src;
+
+        public virtual void InitialUpdater(ref Key key, ref Input input, ref Value value) { }
+        public virtual void CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue) { }
+        public virtual void InPlaceUpdater(ref Key key, ref Input input, ref Value value) { }
+
+        public virtual void ReadCompletionCallback(ref Key key, ref Input input, ref Output output, Context ctx, Status status) { }
+        public virtual void RMWCompletionCallback(ref Key key, ref Input input, Context ctx, Status status) { }
+        public virtual void UpsertCompletionCallback(ref Key key, ref Value value, Context ctx) { }
+        public virtual void DeleteCompletionCallback(ref Key key, Context ctx) { }
+        public virtual void CheckpointCompletionCallback(Guid sessionId, long serialNum) { }
+    }
+
+    /// <summary>
+    /// Default empty functions base class to make it easy for users to provide
+    /// their own implementation
+    /// </summary>
+    /// <typeparam name="Key"></typeparam>
+    /// <typeparam name="Value"></typeparam>
+    /// <typeparam name="Context"></typeparam>
+    public class SimpleFunctions<Key, Value, Context> : FunctionsBase<Key, Value, Value, Value, Context>
+    {
+        private readonly Func<Value, Value, Value> merger;
+        public SimpleFunctions() => merger = (l, r) => l;
+        public SimpleFunctions(Func<Value, Value, Value> merger) => this.merger = merger;
+
+        public override void ConcurrentReader(ref Key key, ref Value input, ref Value value, ref Value dst) => dst = value;
+        public override void SingleReader(ref Key key, ref Value input, ref Value value, ref Value dst) => dst = value;
+
+        public override void ConcurrentWriter(ref Key key, ref Value src, ref Value dst) => dst = src;
+        public override void SingleWriter(ref Key key, ref Value src, ref Value dst) => dst = src;
+
+        public override void InitialUpdater(ref Key key, ref Value input, ref Value value) => value = input;
+        public override void CopyUpdater(ref Key key, ref Value input, ref Value oldValue, ref Value newValue) => newValue = merger(input, oldValue);
+        public override void InPlaceUpdater(ref Key key, ref Value input, ref Value value) => value = merger(input, value);
+
+        public override void ReadCompletionCallback(ref Key key, ref Value input, ref Value output, Context ctx, Status status) { }
+        public override void RMWCompletionCallback(ref Key key, ref Value input, Context ctx, Status status) { }
+        public override void UpsertCompletionCallback(ref Key key, ref Value value, Context ctx) { }
+        public override void DeleteCompletionCallback(ref Key key, Context ctx) { }
+        public override void CheckpointCompletionCallback(Guid sessionId, long serialNum) { }
+    }
+
+    public class SimpleFunctions<Key, Value> : SimpleFunctions<Key, Value, Empty>
+    {
+        public SimpleFunctions() : base() { }
+        public SimpleFunctions(Func<Value, Value, Value> merger) : base(merger) { }
+    }
+}

--- a/cs/src/core/Index/Interfaces/IFasterKV.cs
+++ b/cs/src/core/Index/Interfaces/IFasterKV.cs
@@ -152,6 +152,16 @@ namespace FASTER.core
         long EntryCount { get; }
 
         /// <summary>
+        /// Get size of index in #cache lines (64 bytes each)
+        /// </summary>
+        long IndexSize { get; }
+
+        /// <summary>
+        /// Get comparer used by this instance of FASTER
+        /// </summary>
+        IFasterEqualityComparer<Key> Comparer { get; }
+
+        /// <summary>
         /// Dump distribution of #entries in hash table, to console
         /// </summary>
         void DumpDistribution();

--- a/cs/src/core/Index/Interfaces/IFasterKV.cs
+++ b/cs/src/core/Index/Interfaces/IFasterKV.cs
@@ -167,6 +167,17 @@ namespace FASTER.core
         void DumpDistribution();
 
         /// <summary>
+        /// Experimental feature
+        /// Check if FASTER contains key in memory (between HeadAddress 
+        /// and tail), or between the specified fromAddress (after 
+        /// HeadAddress) and tail
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="fromAddress"></param>
+        /// <returns></returns>
+        Status ContainsKeyInMemory(ref Key key, long fromAddress = -1);
+
+        /// <summary>
         /// Get accessor for FASTER hybrid log
         /// </summary>
         LogAccessor<Key, Value, Input, Output, Context> Log { get; }

--- a/cs/src/core/Index/Interfaces/IFunctions.cs
+++ b/cs/src/core/Index/Interfaces/IFunctions.cs
@@ -40,6 +40,13 @@ namespace FASTER.core
         void RMWCompletionCallback(ref Key key, ref Input input, Context ctx, Status status);
 
         /// <summary>
+        /// Delete completion
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="ctx"></param>
+        void DeleteCompletionCallback(ref Key key, Context ctx);
+
+        /// <summary>
         /// Checkpoint completion callback (called per client session)
         /// </summary>
         /// <param name="sessionId">Session ID reporting persistence</param>

--- a/cs/test/BasicDiskFASTERTests.cs
+++ b/cs/test/BasicDiskFASTERTests.cs
@@ -23,7 +23,7 @@ namespace FASTER.test
         [SetUp]
         public void Setup()
         {
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hybridlog_native.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\BasicDiskFASTERTests.log", deleteOnClose: true);
             fht = new FasterKV<KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty, Functions>
                 (1L<<20, new Functions(), new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 10 });
             fht.StartSession();

--- a/cs/test/BasicFASTERTests.cs
+++ b/cs/test/BasicFASTERTests.cs
@@ -88,7 +88,7 @@ namespace FASTER.test
 
             long tail = fht.Log.TailAddress;
 
-            fht.DeleteFromMemory(ref key1, 0);
+            fht.Delete(ref key1, Empty.Default, 0);
 
             status = fht.Read(ref key1, ref input, ref output, Empty.Default, 0);
 
@@ -144,7 +144,7 @@ namespace FASTER.test
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = 14 };
                 var value = new ValueStruct { vfield1 = i, vfield2 = 24 };
 
-                fht.DeleteFromMemory(ref key1, 0);
+                fht.Delete(ref key1, Empty.Default, 0);
             }
 
             for (int i = 0; i < 10 * count; i++)

--- a/cs/test/BlittableLogCompactionTests.cs
+++ b/cs/test/BlittableLogCompactionTests.cs
@@ -23,7 +23,7 @@ namespace FASTER.test
         [SetUp]
         public void Setup()
         {
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog4.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\BlittableLogCompactionTests.log", deleteOnClose: true);
             fht = new FasterKV<KeyStruct, ValueStruct, InputStruct, OutputStruct, int, FunctionsCompaction>
                 (1L << 20, new FunctionsCompaction(), new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 7 });
             fht.StartSession();

--- a/cs/test/BlittableLogCompactionTests.cs
+++ b/cs/test/BlittableLogCompactionTests.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using FASTER.core;
+using System.IO;
+using NUnit.Framework;
+
+namespace FASTER.test
+{
+
+    [TestFixture]
+    internal class BlittableLogCompactionTests
+    {
+        private FasterKV<KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty, Functions> fht;
+        private IDevice log;
+
+        [SetUp]
+        public void Setup()
+        {
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog4.log", deleteOnClose: true);
+            fht = new FasterKV<KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty, Functions>
+                (1L << 20, new Functions(), new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 7 });
+            fht.StartSession();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            fht.StopSession();
+            fht.Dispose();
+            fht = null;
+            log.Close();
+        }
+
+        [Test]
+        public void BlittableLogCompactionTest1()
+        {
+            InputStruct input = default(InputStruct);
+
+            const int totalRecords = 2000;
+            var start = fht.Log.TailAddress;
+            long compactUntil = 0;
+
+            for (int i = 0; i < totalRecords; i++)
+            {
+                if (i == 1000)
+                    compactUntil = fht.Log.TailAddress;
+
+                var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
+                var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
+                fht.Upsert(ref key1, ref value, Empty.Default, 0);
+            }
+
+            fht.Log.Compact(compactUntil);
+            Assert.IsTrue(fht.Log.BeginAddress == compactUntil);
+
+            // Read 2000 keys - all should be present
+            for (int i = 0; i < totalRecords; i++)
+            {
+                OutputStruct output = default(OutputStruct);
+                var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
+                var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
+
+                var status = fht.Read(ref key1, ref input, ref output, Empty.Default, 0);
+                if (status == Status.PENDING)
+                    fht.CompletePending(true);
+                else
+                {
+                    Assert.IsTrue(status == Status.OK);
+                    Assert.IsTrue(output.value.vfield1 == value.vfield1);
+                    Assert.IsTrue(output.value.vfield2 == value.vfield2);
+                }
+            }
+        }
+
+
+        [Test]
+        public void BlittableLogCompactionTest2()
+        {
+            InputStruct input = default(InputStruct);
+
+            const int totalRecords = 2000;
+            var start = fht.Log.TailAddress;
+            long compactUntil = 0;
+
+            for (int i = 0; i < totalRecords; i++)
+            {
+                if (i == 1000)
+                    compactUntil = fht.Log.TailAddress;
+
+                var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
+                var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
+                fht.Upsert(ref key1, ref value, Empty.Default, 0);
+            }
+
+            // Put fresh entries for 1000 records
+            for (int i = 0; i < 1000; i++)
+            {
+                var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
+                var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
+                fht.Upsert(ref key1, ref value, Empty.Default, 0);
+            }
+
+            fht.Log.Flush(true);
+
+            var tail = fht.Log.TailAddress;
+            fht.Log.Compact(compactUntil);
+            Assert.IsTrue(fht.Log.BeginAddress == compactUntil);
+            Assert.IsTrue(fht.Log.TailAddress == tail);
+
+            // Read 2000 keys - all should be present
+            for (int i = 0; i < totalRecords; i++)
+            {
+                OutputStruct output = default(OutputStruct);
+                var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
+                var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
+
+                var status = fht.Read(ref key1, ref input, ref output, Empty.Default, 0);
+                if (status == Status.PENDING)
+                    fht.CompletePending(true);
+                else
+                {
+                    Assert.IsTrue(status == Status.OK);
+                    Assert.IsTrue(output.value.vfield1 == value.vfield1);
+                    Assert.IsTrue(output.value.vfield2 == value.vfield2);
+                }
+            }
+        }
+    }
+}

--- a/cs/test/BlittableLogScanTests.cs
+++ b/cs/test/BlittableLogScanTests.cs
@@ -23,7 +23,7 @@ namespace FASTER.test
         [SetUp]
         public void Setup()
         {
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog4.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\BlittableFASTERScanTests.log", deleteOnClose: true);
             fht = new FasterKV<KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty, Functions>
                 (1L << 20, new Functions(), new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 7 });
             fht.StartSession();

--- a/cs/test/BlittableLogScanTests.cs
+++ b/cs/test/BlittableLogScanTests.cs
@@ -54,7 +54,7 @@ namespace FASTER.test
             var iter = fht.Log.Scan(start, fht.Log.TailAddress, ScanBufferingMode.SinglePageBuffering);
 
             int val = 0;
-            while (iter.GetNext(out KeyStruct key, out ValueStruct value))
+            while (iter.GetNext(out RecordInfo recordInfo, out KeyStruct key, out ValueStruct value))
             {
                 Assert.IsTrue(key.kfield1 == val);
                 Assert.IsTrue(key.kfield2 == val + 1);
@@ -67,7 +67,7 @@ namespace FASTER.test
             iter = fht.Log.Scan(start, fht.Log.TailAddress, ScanBufferingMode.DoublePageBuffering);
 
             val = 0;
-            while (iter.GetNext(out KeyStruct key, out ValueStruct value))
+            while (iter.GetNext(out RecordInfo recordInfo, out KeyStruct key, out ValueStruct value))
             {
                 Assert.IsTrue(key.kfield1 == val);
                 Assert.IsTrue(key.kfield2 == val + 1);

--- a/cs/test/ComponentRecoveryTests.cs
+++ b/cs/test/ComponentRecoveryTests.cs
@@ -20,7 +20,7 @@ namespace FASTER.test.recovery
         {
             int seed = 123;
             var rand1 = new Random(seed);
-            var device = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\test_ofb.dat", deleteOnClose: true);
+            var device = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\MallocFixedPageSizeRecoveryTest.dat", deleteOnClose: true);
             var allocator = new MallocFixedPageSize<HashBucket>();
 
             //do something
@@ -70,8 +70,8 @@ namespace FASTER.test.recovery
             int size = 1 << 16;
             long numAdds = 1 << 18;
 
-            IDevice ht_device = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\ht.dat", deleteOnClose: true);
-            IDevice ofb_device = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\ofb.dat", deleteOnClose: true);
+            IDevice ht_device = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\TestFuzzyIndexRecoveryht.dat", deleteOnClose: true);
+            IDevice ofb_device = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\TestFuzzyIndexRecoveryofb.dat", deleteOnClose: true);
 
             var hash_table1 = new FasterBase();
             hash_table1.Initialize(size, 512);

--- a/cs/test/FullRecoveryTests.cs
+++ b/cs/test/FullRecoveryTests.cs
@@ -30,7 +30,7 @@ namespace FASTER.test.recovery.sumstore
         {
             if (test_path == null)
             {
-                test_path = Path.GetTempPath() + Path.GetRandomFileName();
+                test_path = TestContext.CurrentContext.TestDirectory + "\\" + Path.GetRandomFileName();
                 if (!Directory.Exists(test_path))
                     Directory.CreateDirectory(test_path);
             }

--- a/cs/test/FullRecoveryTests.cs
+++ b/cs/test/FullRecoveryTests.cs
@@ -35,7 +35,7 @@ namespace FASTER.test.recovery.sumstore
                     Directory.CreateDirectory(test_path);
             }
 
-            log = Devices.CreateLogDevice(test_path + "\\hlog");
+            log = Devices.CreateLogDevice(test_path + "\\FullRecoveryTests.log");
 
             fht = new FasterKV<AdId, NumClicks, Input, Output, Empty, Functions>
                 (keySpace, new Functions(), 

--- a/cs/test/GenericDiskDeleteTests.cs
+++ b/cs/test/GenericDiskDeleteTests.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using FASTER.core;
+using System.IO;
+using NUnit.Framework;
+
+namespace FASTER.test
+{
+
+    [TestFixture]
+    internal class GenericDiskDeleteTests
+    {
+        private FasterKV<MyKey, MyValue, MyInput, MyOutput, int, MyFunctionsDelete> fht;
+        private IDevice log, objlog;
+
+        [SetUp]
+        public void Setup()
+        {
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlogscan.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlogscan.obj.log", deleteOnClose: true);
+
+            fht = new FasterKV<MyKey, MyValue, MyInput, MyOutput, int, MyFunctionsDelete>
+                (128, new MyFunctionsDelete(),
+                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 15, PageSizeBits = 9 },
+                checkpointSettings: new CheckpointSettings { CheckPointType = CheckpointType.FoldOver },
+                serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() }
+                );
+            fht.StartSession();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            fht.StopSession();
+            fht.Dispose();
+            fht = null;
+            log.Close();
+        }
+
+
+        [Test]
+        public void GenericDiskDeleteTest1()
+        {
+            const int totalRecords = 2000;
+            var start = fht.Log.TailAddress;
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var _key = new MyKey { key = i };
+                var _value = new MyValue { value = i };
+                fht.Upsert(ref _key, ref _value, 0, 0);
+            }
+
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var input = new MyInput();
+                var output = new MyOutput();
+                var key1 = new MyKey { key = i };
+                var value = new MyValue { value = i };
+
+                if (fht.Read(ref key1, ref input, ref output, 0, 0) == Status.PENDING)
+                {
+                    fht.CompletePending(true);
+                }
+                else
+                {
+                    Assert.IsTrue(output.value.value == value.value);
+                    Assert.IsTrue(output.value.value == value.value);
+                }
+            }
+
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var input = new MyInput();
+                var output = new MyOutput();
+                var key1 = new MyKey { key = i };
+                var value = new MyValue { value = i };
+
+                fht.Delete(ref key1, 0, 0);
+            }
+
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var input = new MyInput();
+                var output = new MyOutput();
+                var key1 = new MyKey { key = i };
+                var value = new MyValue { value = i };
+
+                var status = fht.Read(ref key1, ref input, ref output, 1, 0);
+                
+                if (status == Status.PENDING)
+                {
+                    fht.CompletePending(true);
+                }
+                else
+                {
+                    Assert.IsTrue(status == Status.NOTFOUND);
+                }
+            }
+
+            
+            using (var iter = fht.Log.Scan(start, fht.Log.TailAddress, ScanBufferingMode.SinglePageBuffering))
+            {
+                int val = 0;
+                while (iter.GetNext(out RecordInfo recordInfo, out MyKey key, out MyValue value))
+                {
+                    if (recordInfo.Tombstone)
+                        val++;
+                }
+                Assert.IsTrue(totalRecords == val);
+            }
+            
+        }
+    }
+}

--- a/cs/test/GenericDiskDeleteTests.cs
+++ b/cs/test/GenericDiskDeleteTests.cs
@@ -23,8 +23,8 @@ namespace FASTER.test
         [SetUp]
         public void Setup()
         {
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlogscan.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlogscan.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\GenericDiskDeleteTests.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\GenericDiskDeleteTests.obj.log", deleteOnClose: true);
 
             fht = new FasterKV<MyKey, MyValue, MyInput, MyOutput, int, MyFunctionsDelete>
                 (128, new MyFunctionsDelete(),

--- a/cs/test/GenericLogCompactionTests.cs
+++ b/cs/test/GenericLogCompactionTests.cs
@@ -1,0 +1,200 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using FASTER.core;
+using System.IO;
+using NUnit.Framework;
+
+namespace FASTER.test
+{
+
+    [TestFixture]
+    internal class GenericLogCompactionTests
+    {
+        private FasterKV<MyKey, MyValue, MyInput, MyOutput, int, MyFunctionsDelete> fht;
+        private IDevice log, objlog;
+
+        [SetUp]
+        public void Setup()
+        {
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlogscan.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlogscan.obj.log", deleteOnClose: true);
+
+            fht = new FasterKV<MyKey, MyValue, MyInput, MyOutput, int, MyFunctionsDelete>
+                (128, new MyFunctionsDelete(),
+                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 14, PageSizeBits = 9 },
+                checkpointSettings: new CheckpointSettings { CheckPointType = CheckpointType.FoldOver },
+                serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() }
+                );
+            fht.StartSession();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            fht.StopSession();
+            fht.Dispose();
+            fht = null;
+            log.Close();
+            objlog.Close();
+        }
+
+        [Test]
+        public void GenericLogCompactionTest1()
+        {
+            MyInput input = new MyInput();
+
+            const int totalRecords = 2000;
+            var start = fht.Log.TailAddress;
+            long compactUntil = 0;
+
+            for (int i = 0; i < totalRecords; i++)
+            {
+                if (i == 1000)
+                    compactUntil = fht.Log.TailAddress;
+
+                var key1 = new MyKey { key = i };
+                var value = new MyValue { value = i };
+                fht.Upsert(ref key1, ref value, 0, 0);
+            }
+
+            fht.Log.Compact(compactUntil);
+            Assert.IsTrue(fht.Log.BeginAddress == compactUntil);
+
+            // Read 2000 keys - all should be present
+            for (int i = 0; i < totalRecords; i++)
+            {
+                MyOutput output = new MyOutput();
+
+                var key1 = new MyKey { key = i };
+                var value = new MyValue { value = i };
+
+                var status = fht.Read(ref key1, ref input, ref output, 0, 0);
+                if (status == Status.PENDING)
+                    fht.CompletePending(true);
+                else
+                {
+                    Assert.IsTrue(status == Status.OK);
+                    Assert.IsTrue(output.value.value == value.value);
+                }
+            }
+        }
+
+
+        [Test]
+        public void GenericLogCompactionTest2()
+        {
+            MyInput input = new MyInput();
+
+            const int totalRecords = 2000;
+            var start = fht.Log.TailAddress;
+            long compactUntil = 0;
+
+            for (int i = 0; i < totalRecords; i++)
+            {
+                if (i == 1000)
+                    compactUntil = fht.Log.TailAddress;
+
+                var key1 = new MyKey { key = i };
+                var value = new MyValue { value = i };
+                fht.Upsert(ref key1, ref value, 0, 0);
+            }
+
+            // Put fresh entries for 1000 records
+            for (int i = 0; i < 1000; i++)
+            {
+                var key1 = new MyKey { key = i };
+                var value = new MyValue { value = i };
+                fht.Upsert(ref key1, ref value, 0, 0);
+            }
+
+            fht.Log.Flush(true);
+
+            var tail = fht.Log.TailAddress;
+            fht.Log.Compact(compactUntil);
+            Assert.IsTrue(fht.Log.BeginAddress == compactUntil);
+            Assert.IsTrue(fht.Log.TailAddress == tail);
+
+            // Read 2000 keys - all should be present
+            for (int i = 0; i < totalRecords; i++)
+            {
+                MyOutput output = new MyOutput();
+                var key1 = new MyKey { key = i };
+                var value = new MyValue { value = i };
+
+                var status = fht.Read(ref key1, ref input, ref output, 0, 0);
+                if (status == Status.PENDING)
+                    fht.CompletePending(true);
+                else
+                {
+                    Assert.IsTrue(status == Status.OK);
+                    Assert.IsTrue(output.value.value == value.value);
+                }
+            }
+        }
+
+
+        [Test]
+        public void GenericLogCompactionTest3()
+        {
+            MyInput input = new MyInput();
+
+            const int totalRecords = 2000;
+            var start = fht.Log.TailAddress;
+            long compactUntil = 0;
+
+            for (int i = 0; i < totalRecords; i++)
+            {
+                if (i == totalRecords / 2)
+                    compactUntil = fht.Log.TailAddress;
+
+                var key1 = new MyKey { key = i };
+                var value = new MyValue { value = i };
+                fht.Upsert(ref key1, ref value, 0, 0);
+
+                if (i % 8 == 0)
+                {
+                    int j = i / 4;
+                    key1 = new MyKey { key = j };
+                    fht.Delete(ref key1, 0, 0);
+                }
+            }
+
+            var tail = fht.Log.TailAddress;
+            fht.Log.Compact(compactUntil);
+            Assert.IsTrue(fht.Log.BeginAddress == compactUntil);
+
+            // Read 2000 keys - all should be present
+            for (int i = 0; i < totalRecords; i++)
+            {
+                MyOutput output = new MyOutput();
+                var key1 = new MyKey { key = i };
+                var value = new MyValue { value = i };
+
+                int ctx = ((i < 500) && (i % 2 == 0)) ? 1 : 0;
+
+                var status = fht.Read(ref key1, ref input, ref output, ctx, 0);
+                if (status == Status.PENDING)
+                    fht.CompletePending(true);
+                else
+                {
+                    if (ctx == 0)
+                    {
+                        Assert.IsTrue(status == Status.OK);
+                        Assert.IsTrue(output.value.value == value.value);
+                    }
+                    else
+                    {
+                        Assert.IsTrue(status == Status.NOTFOUND);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/cs/test/GenericLogCompactionTests.cs
+++ b/cs/test/GenericLogCompactionTests.cs
@@ -23,8 +23,8 @@ namespace FASTER.test
         [SetUp]
         public void Setup()
         {
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlogscan.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlogscan.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\GenericLogCompactionTests.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\GenericLogCompactionTests.obj.log", deleteOnClose: true);
 
             fht = new FasterKV<MyKey, MyValue, MyInput, MyOutput, int, MyFunctionsDelete>
                 (128, new MyFunctionsDelete(),

--- a/cs/test/GenericLogScanTests.cs
+++ b/cs/test/GenericLogScanTests.cs
@@ -42,6 +42,7 @@ namespace FASTER.test
             fht.Dispose();
             fht = null;
             log.Close();
+            objlog.Close();
         }
 
 

--- a/cs/test/GenericLogScanTests.cs
+++ b/cs/test/GenericLogScanTests.cs
@@ -58,28 +58,30 @@ namespace FASTER.test
                 if (i % 100 == 0) fht.Log.FlushAndEvict(true);
             }
             fht.Log.FlushAndEvict(true);
-            var iter = fht.Log.Scan(start, fht.Log.TailAddress, ScanBufferingMode.SinglePageBuffering);
-
-            int val = 0;
-            while (iter.GetNext(out MyKey key, out MyValue value))
+            using (var iter = fht.Log.Scan(start, fht.Log.TailAddress, ScanBufferingMode.SinglePageBuffering))
             {
-                Assert.IsTrue(key.key == val);
-                Assert.IsTrue(value.value == val);
-                val++;
+
+                int val = 0;
+                while (iter.GetNext(out RecordInfo recordInfo, out MyKey key, out MyValue value))
+                {
+                    Assert.IsTrue(key.key == val);
+                    Assert.IsTrue(value.value == val);
+                    val++;
+                }
+                Assert.IsTrue(totalRecords == val);
             }
-            Assert.IsTrue(totalRecords == val);
 
-            iter = fht.Log.Scan(start, fht.Log.TailAddress, ScanBufferingMode.DoublePageBuffering);
-
-            val = 0;
-            while (iter.GetNext(out MyKey key, out MyValue value))
+            using (var iter = fht.Log.Scan(start, fht.Log.TailAddress, ScanBufferingMode.DoublePageBuffering))
             {
-                Assert.IsTrue(key.key == val);
-                Assert.IsTrue(value.value == val);
-                val++;
+                int val = 0;
+                while (iter.GetNext(out RecordInfo recordInfo, out MyKey key, out MyValue value))
+                {
+                    Assert.IsTrue(key.key == val);
+                    Assert.IsTrue(value.value == val);
+                    val++;
+                }
+                Assert.IsTrue(totalRecords == val);
             }
-            Assert.IsTrue(totalRecords == val);
-
         }
     }
 }

--- a/cs/test/GenericLogScanTests.cs
+++ b/cs/test/GenericLogScanTests.cs
@@ -23,8 +23,8 @@ namespace FASTER.test
         [SetUp]
         public void Setup()
         {
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlogscan.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlogscan.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\GenericFASTERScanTests.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\GenericFASTERScanTests.obj.log", deleteOnClose: true);
 
             fht = new FasterKV<MyKey, MyValue, MyInput, MyOutput, Empty, MyFunctions>
                 (128, new MyFunctions(),

--- a/cs/test/LargeObjectTests.cs
+++ b/cs/test/LargeObjectTests.cs
@@ -27,22 +27,22 @@ namespace FASTER.test.largeobjects
             MyInput input = default(MyInput);
             MyLargeOutput output = new MyLargeOutput();
 
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\LargeObjectTest1.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\LargeObjectTest1.obj.log", deleteOnClose: true);
 
-            Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints");
+            Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints1");
 
             fht1 = new FasterKV<MyKey, MyLargeValue, MyInput, MyLargeOutput, Empty, MyLargeFunctions>
                 (128, new MyLargeFunctions(),
                 new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 21, MemorySizeBits = 26 },
-                new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.Snapshot },
+                new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints1", CheckPointType = CheckpointType.Snapshot },
                 new SerializerSettings<MyKey, MyLargeValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyLargeValueSerializer() }
                 );
 
             fht2 = new FasterKV<MyKey, MyLargeValue, MyInput, MyLargeOutput, Empty, MyLargeFunctions>
                 (128, new MyLargeFunctions(),
                 new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 21, MemorySizeBits = 26 },
-                new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.Snapshot },
+                new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints1", CheckPointType = CheckpointType.Snapshot },
                 new SerializerSettings<MyKey, MyLargeValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyLargeValueSerializer() }
                 );
 
@@ -84,7 +84,7 @@ namespace FASTER.test.largeobjects
 
             log.Close();
             objlog.Close();
-            new DirectoryInfo(TestContext.CurrentContext.TestDirectory + "\\checkpoints").Delete(true);
+            new DirectoryInfo(TestContext.CurrentContext.TestDirectory + "\\checkpoints1").Delete(true);
         }
 
         [Test]
@@ -93,22 +93,22 @@ namespace FASTER.test.largeobjects
             MyInput input = default(MyInput);
             MyLargeOutput output = new MyLargeOutput();
 
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\LargeObjectTest2.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\LargeObjectTest2.obj.log", deleteOnClose: true);
 
-            Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints");
+            Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints2");
 
             fht1 = new FasterKV<MyKey, MyLargeValue, MyInput, MyLargeOutput, Empty, MyLargeFunctions>
                 (128, new MyLargeFunctions(),
                 new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 21, MemorySizeBits = 26 },
-                new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.FoldOver },
+                new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints2", CheckPointType = CheckpointType.FoldOver },
                 new SerializerSettings<MyKey, MyLargeValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyLargeValueSerializer() }
                 );
 
             fht2 = new FasterKV<MyKey, MyLargeValue, MyInput, MyLargeOutput, Empty, MyLargeFunctions>
                 (128, new MyLargeFunctions(),
                 new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, PageSizeBits = 21, MemorySizeBits = 26 },
-                new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.FoldOver },
+                new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints2", CheckPointType = CheckpointType.FoldOver },
                 new SerializerSettings<MyKey, MyLargeValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyLargeValueSerializer() }
                 );
 
@@ -150,7 +150,7 @@ namespace FASTER.test.largeobjects
 
             log.Close();
             objlog.Close();
-            new DirectoryInfo(TestContext.CurrentContext.TestDirectory + "\\checkpoints").Delete(true);
+            new DirectoryInfo(TestContext.CurrentContext.TestDirectory + "\\checkpoints2").Delete(true);
         }
     }
 }

--- a/cs/test/MiscFASTERTests.cs
+++ b/cs/test/MiscFASTERTests.cs
@@ -23,8 +23,8 @@ namespace FASTER.test
         [SetUp]
         public void Setup()
         {
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog2.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog2.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\MiscFASTERTests.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\MiscFASTERTests.obj.log", deleteOnClose: true);
 
             fht = new FasterKV<int, MyValue, MyInput, MyOutput, Empty, MixedFunctions>
                 (128, new MixedFunctions(),

--- a/cs/test/NativeReadCacheTests.cs
+++ b/cs/test/NativeReadCacheTests.cs
@@ -24,7 +24,7 @@ namespace FASTER.test
         public void Setup()
         {
             var readCacheSettings = new ReadCacheSettings { MemorySizeBits = 15, PageSizeBits = 10 };
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hybridlog_native.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\NativeReadCacheTests.log", deleteOnClose: true);
             fht = new FasterKV<KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty, Functions>
                 (1L<<20, new Functions(), new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 10, ReadCacheSettings = readCacheSettings });
             fht.StartSession();

--- a/cs/test/ObjectFASTERTests.cs
+++ b/cs/test/ObjectFASTERTests.cs
@@ -23,8 +23,8 @@ namespace FASTER.test
         [SetUp]
         public void Setup()
         {
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog2.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog2.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\ObjectFASTERTests.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\ObjectFASTERTests.obj.log", deleteOnClose: true);
 
             fht = new FasterKV<MyKey, MyValue, MyInput, MyOutput, Empty, MyFunctions>
                 (128, new MyFunctions(),

--- a/cs/test/ObjectReadCacheTests.cs
+++ b/cs/test/ObjectReadCacheTests.cs
@@ -24,8 +24,8 @@ namespace FASTER.test
         public void Setup()
         {
             var readCacheSettings = new ReadCacheSettings { MemorySizeBits = 15, PageSizeBits = 10 };
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog22.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog22.obj.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\ObjectReadCacheTests.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\ObjectReadCacheTests.obj.log", deleteOnClose: true);
 
             fht = new FasterKV<MyKey, MyValue, MyInput, MyOutput, Empty, MyFunctions>
                 (128, new MyFunctions(),

--- a/cs/test/ObjectRecoveryTest.cs
+++ b/cs/test/ObjectRecoveryTest.cs
@@ -40,8 +40,8 @@ namespace FASTER.test.recovery.objectstore
                     Directory.CreateDirectory(test_path);
             }
 
-            log = Devices.CreateLogDevice(test_path + "\\ort1hlog.log", false);
-            objlog = Devices.CreateLogDevice(test_path + "\\ort1hlog.obj.log", false);
+            log = Devices.CreateLogDevice(test_path + "\\ObjectRecoveryTests.log", false);
+            objlog = Devices.CreateLogDevice(test_path + "\\ObjectRecoveryTests.obj.log", false);
 
             fht = new FasterKV<AdId, NumClicks, Input, Output, Empty, Functions>
                 (

--- a/cs/test/ObjectRecoveryTest.cs
+++ b/cs/test/ObjectRecoveryTest.cs
@@ -35,7 +35,7 @@ namespace FASTER.test.recovery.objectstore
         {
             if (test_path == null)
             {
-                test_path = Path.GetTempPath() + Path.GetRandomFileName();
+                test_path = TestContext.CurrentContext.TestDirectory + "\\" + Path.GetRandomFileName();
                 if (!Directory.Exists(test_path))
                     Directory.CreateDirectory(test_path);
             }

--- a/cs/test/ObjectRecoveryTestTypes.cs
+++ b/cs/test/ObjectRecoveryTestTypes.cs
@@ -88,6 +88,10 @@ namespace FASTER.test.recovery.objectstore
         {
         }
 
+        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
+        {
+        }
+
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
         {
             Console.WriteLine("Session {0} reports persistence until {1}", sessionId, serialNum);

--- a/cs/test/ObjectTestTypes.cs
+++ b/cs/test/ObjectTestTypes.cs
@@ -158,7 +158,7 @@ namespace FASTER.test
 
         public void ConcurrentWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
         {
-            dst.value = src.value;
+            dst = src;
         }
 
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
@@ -180,7 +180,10 @@ namespace FASTER.test
 
         public void RMWCompletionCallback(ref MyKey key, ref MyInput input, int ctx, Status status)
         {
-            Assert.IsTrue(status == Status.OK);
+            if (ctx == 0)
+                Assert.IsTrue(status == Status.OK);
+            else if (ctx == 1)
+                Assert.IsTrue(status == Status.NOTFOUND);
         }
 
         public void UpsertCompletionCallback(ref MyKey key, ref MyValue value, int ctx)

--- a/cs/test/ObjectTestTypes.cs
+++ b/cs/test/ObjectTestTypes.cs
@@ -134,6 +134,74 @@ namespace FASTER.test
         }
     }
 
+    public class MyFunctionsDelete : IFunctions<MyKey, MyValue, MyInput, MyOutput, int>
+    {
+        public void InitialUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
+        {
+            value = new MyValue { value = input.value };
+        }
+
+        public void InPlaceUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
+        {
+            value.value += input.value;
+        }
+
+        public void CopyUpdater(ref MyKey key, ref MyInput input, ref MyValue oldValue, ref MyValue newValue)
+        {
+            newValue = new MyValue { value = oldValue.value + input.value };
+        }
+
+        public void ConcurrentReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst)
+        {
+            dst.value = value;
+        }
+
+        public void ConcurrentWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
+        {
+            dst.value = src.value;
+        }
+
+        public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
+        {
+        }
+
+        public void ReadCompletionCallback(ref MyKey key, ref MyInput input, ref MyOutput output, int ctx, Status status)
+        {
+            if (ctx == 0)
+            {
+                Assert.IsTrue(status == Status.OK);
+                Assert.IsTrue(key.key == output.value.value);
+            }
+            else if (ctx == 1)
+            {
+                Assert.IsTrue(status == Status.NOTFOUND);
+            }
+        }
+
+        public void RMWCompletionCallback(ref MyKey key, ref MyInput input, int ctx, Status status)
+        {
+            Assert.IsTrue(status == Status.OK);
+        }
+
+        public void UpsertCompletionCallback(ref MyKey key, ref MyValue value, int ctx)
+        {
+        }
+
+        public void DeleteCompletionCallback(ref MyKey key, int ctx)
+        {
+        }
+
+        public void SingleReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst)
+        {
+            dst.value = value;
+        }
+
+        public void SingleWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
+        {
+            dst = src;
+        }
+    }
+
     public class MixedFunctions : IFunctions<int, MyValue, MyInput, MyOutput, Empty>
     {
         public void InitialUpdater(ref int key, ref MyInput input, ref MyValue value)

--- a/cs/test/ObjectTestTypes.cs
+++ b/cs/test/ObjectTestTypes.cs
@@ -119,6 +119,10 @@ namespace FASTER.test
         {
         }
 
+        public void DeleteCompletionCallback(ref MyKey key, Empty ctx)
+        {
+        }
+
         public void SingleReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst)
         {
             dst.value = value;
@@ -170,6 +174,10 @@ namespace FASTER.test
         }
 
         public void UpsertCompletionCallback(ref int key, ref MyValue value, Empty ctx)
+        {
+        }
+
+        public void DeleteCompletionCallback(ref int key, Empty ctx)
         {
         }
 
@@ -240,6 +248,10 @@ namespace FASTER.test
 
 
         public void UpsertCompletionCallback(ref MyKey key, ref MyLargeValue value, Empty ctx)
+        {
+        }
+
+        public void DeleteCompletionCallback(ref MyKey key, Empty ctx)
         {
         }
 

--- a/cs/test/RecoverContinueTests.cs
+++ b/cs/test/RecoverContinueTests.cs
@@ -186,6 +186,10 @@ namespace FASTER.test.recovery.sumstore.recover_continue
         {
         }
 
+        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
+        {
+        }
+
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
         {
             Console.WriteLine("Session {0} reports persistence until {1}", sessionId, serialNum);

--- a/cs/test/RecoverContinueTests.cs
+++ b/cs/test/RecoverContinueTests.cs
@@ -25,28 +25,28 @@ namespace FASTER.test.recovery.sumstore.recover_continue
         [SetUp]
         public void Setup()
         {
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog", deleteOnClose: true);
-            Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints");
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\RecoverContinueTests.log", deleteOnClose: true);
+            Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints3");
 
             fht1 = new FasterKV
                 <AdId, NumClicks, Input, Output, Empty, SimpleFunctions>
                 (128, new SimpleFunctions(),
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.Snapshot }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints3", CheckPointType = CheckpointType.Snapshot }
                 );
 
             fht2 = new FasterKV
                 <AdId, NumClicks, Input, Output, Empty, SimpleFunctions>
                 (128, new SimpleFunctions(),
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.Snapshot }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints3", CheckPointType = CheckpointType.Snapshot }
                 );
 
             fht3 = new FasterKV
                 <AdId, NumClicks, Input, Output, Empty, SimpleFunctions>
                 (128, new SimpleFunctions(),
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.Snapshot }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints3", CheckPointType = CheckpointType.Snapshot }
                 );
 
             numOps = 5000;
@@ -62,7 +62,7 @@ namespace FASTER.test.recovery.sumstore.recover_continue
             fht2 = null;
             fht3 = null;
             log.Close();
-            Directory.Delete(TestContext.CurrentContext.TestDirectory + "\\checkpoints", true);
+            Directory.Delete(TestContext.CurrentContext.TestDirectory + "\\checkpoints3", true);
         }
 
         public static void DeleteDirectory(string path)

--- a/cs/test/RecoveryTestTypes.cs
+++ b/cs/test/RecoveryTestTypes.cs
@@ -58,6 +58,10 @@ namespace FASTER.test.recovery.sumstore
         {
         }
 
+        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
+        {
+        }
+
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
         {
             Console.WriteLine("Session {0} reports persistence until {1}", sessionId, serialNum);

--- a/cs/test/SimpleRecoveryTest.cs
+++ b/cs/test/SimpleRecoveryTest.cs
@@ -167,6 +167,10 @@ namespace FASTER.test.recovery.sumstore.simple
         {
         }
 
+        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
+        {
+        }
+
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
         {
             Console.WriteLine("Session {0} reports persistence until {1}", sessionId, serialNum);

--- a/cs/test/SimpleRecoveryTest.cs
+++ b/cs/test/SimpleRecoveryTest.cs
@@ -25,22 +25,22 @@ namespace FASTER.test.recovery.sumstore.simple
         [Test]
         public void SimpleRecoveryTest1()
         {
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\SimpleRecoveryTest1.log", deleteOnClose: true);
 
-            Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints");
+            Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints4");
 
             fht1 = new FasterKV
                 <AdId, NumClicks, Input, Output, Empty, SimpleFunctions>
                 (128, new SimpleFunctions(),
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.Snapshot }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints4", CheckPointType = CheckpointType.Snapshot }
                 );
 
             fht2 = new FasterKV
                 <AdId, NumClicks, Input, Output, Empty, SimpleFunctions>
                 (128, new SimpleFunctions(),
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.Snapshot }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints4", CheckPointType = CheckpointType.Snapshot }
                 );
 
 
@@ -83,28 +83,28 @@ namespace FASTER.test.recovery.sumstore.simple
             log.Close();
             fht1.Dispose();
             fht2.Dispose();
-            new DirectoryInfo(TestContext.CurrentContext.TestDirectory + "\\checkpoints").Delete(true);
+            new DirectoryInfo(TestContext.CurrentContext.TestDirectory + "\\checkpoints4").Delete(true);
         }
 
         [Test]
         public void SimpleRecoveryTest2()
         {
-            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlog", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\SimpleRecoveryTest2.log", deleteOnClose: true);
 
-            Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints");
+            Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints5");
 
             fht1 = new FasterKV
                 <AdId, NumClicks, Input, Output, Empty, SimpleFunctions>
                 (128, new SimpleFunctions(),
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.FoldOver }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints5", CheckPointType = CheckpointType.FoldOver }
                 );
 
             fht2 = new FasterKV
                 <AdId, NumClicks, Input, Output, Empty, SimpleFunctions>
                 (128, new SimpleFunctions(),
                 logSettings: new LogSettings { LogDevice = log, MutableFraction = 0.1, MemorySizeBits = 29 },
-                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints", CheckPointType = CheckpointType.FoldOver }
+                checkpointSettings: new CheckpointSettings { CheckpointDir = TestContext.CurrentContext.TestDirectory + "\\checkpoints5", CheckPointType = CheckpointType.FoldOver }
                 );
 
 
@@ -147,7 +147,7 @@ namespace FASTER.test.recovery.sumstore.simple
             log.Close();
             fht1.Dispose();
             fht2.Dispose();
-            new DirectoryInfo(TestContext.CurrentContext.TestDirectory + "\\checkpoints").Delete(true);
+            new DirectoryInfo(TestContext.CurrentContext.TestDirectory + "\\checkpoints5").Delete(true);
         }
     }
 

--- a/cs/test/TestTypes.cs
+++ b/cs/test/TestTypes.cs
@@ -65,6 +65,10 @@ namespace FASTER.test
         {
         }
 
+        public void DeleteCompletionCallback(ref KeyStruct key, Empty ctx)
+        {
+        }
+
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
         {
             Debug.WriteLine("Session {0} reports persistence until {1}", sessionId, serialNum);

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -58,6 +58,7 @@ Completed items are included to provide the context and progress of the work.
 * [ ] Individual key delete support at data structure level (users can already implement individual deletes at payload level, and FASTER already supports bulk deletes via truncation from head of log)
 * [ ] Support iteration over all and only live key-value pairs (different from log scan)
 * [ ] Handle log logical addresses greater than 48 bit (up to 64 bit)
+* [ ] Expose other data structures, starting with a FIFO FasterQueue
 
 ## Release Notes
 


### PR DESCRIPTION
Until now, the only way to clean up the log has been via log truncation (using `ShiftBeginAddress`), which has the model that older keys expire when they fall off the head of the log (if they have not been updated after that point).

Log compaction introduces the ability to scan the head of the log, until the specified address, for the keys that will get deleted in that range. Then, it scans the rest of the log to check which keys are live. Live keys are then copied over to the tail of the log, resulting in compaction by eliminating deleted or subsequently updated keys.

Log compaction will be exposed via an API call on FASTER as follows:
```cs
   fht.Log.Compact(compactUntil)
```

Our first iteration of the feature is single threaded, so that log compaction can be run as a background process. We will not support parallel instantiation of multiple log compaction threads. Log compaction is blocking, i.e., it returns after compaction until the specified address is complete, and `BeginAddress` has been shifted to `compactUntil`.

Also refer to issue https://github.com/Microsoft/FASTER/issues/70.

Not yet ready for merge or review, but adding @gunaprsd and @peterfreiling for comments.