### PR TITLE
Supporting Deletes in FASTER

### DIFF
--- a/cs/benchmark/Functions.cs
+++ b/cs/benchmark/Functions.cs
@@ -24,6 +24,10 @@ namespace FASTER.benchmark
         {
         }
 
+        public void DeleteCompletionCallback(ref Key key, Empty ctx)
+        {
+        }
+
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
         {
             Debug.WriteLine("Session {0} reports persistence until {1}", sessionId, serialNum);

--- a/cs/playground/ClassCache/Types.cs
+++ b/cs/playground/ClassCache/Types.cs
@@ -157,5 +157,10 @@ namespace ClassCache
         {
             throw new NotImplementedException();
         }
+
+        public void DeleteCompletionCallback(ref CacheKey key, CacheContext ctx)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/cs/playground/ClassSample/Program.cs
+++ b/cs/playground/ClassSample/Program.cs
@@ -86,6 +86,7 @@ namespace ClassSample
         public void ReadCompletionCallback(ref MyKey key, ref MyInput input, ref MyOutput output, MyContext ctx, Status status) { }
         public void UpsertCompletionCallback(ref MyKey key, ref MyValue value, MyContext ctx) { }
         public void RMWCompletionCallback(ref MyKey key, ref MyInput input, MyContext ctx, Status status) { }
+        public void DeleteCompletionCallback(ref MyKey key, MyContext ctx) { }
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum) { }
     }
 

--- a/cs/playground/StructSample/Functions.cs
+++ b/cs/playground/StructSample/Functions.cs
@@ -29,6 +29,7 @@ namespace StructSample
         // Completion callbacks
         public void ReadCompletionCallback(ref long key, ref long input, ref long output, Empty ctx, Status s) { }
         public void UpsertCompletionCallback(ref long key, ref long value, Empty ctx) { }
+        public void DeleteCompletionCallback(ref long key, Empty ctx) { }
         public void RMWCompletionCallback(ref long key, ref long input, Empty ctx, Status s) { }
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum) { }
     }
@@ -67,6 +68,7 @@ namespace StructSample
         // Completion callbacks
         public void ReadCompletionCallback(ref Key key, ref Input input, ref Output output, Empty ctx, Status status) { }
         public void UpsertCompletionCallback(ref Key key, ref Value output, Empty ctx) { }
+        public void DeleteCompletionCallback(ref Key key, Empty ctx) { }
         public void RMWCompletionCallback(ref Key key, ref Input output, Empty ctx, Status status) { }
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum) { }
     }

--- a/cs/playground/StructSampleCore/Functions.cs
+++ b/cs/playground/StructSampleCore/Functions.cs
@@ -29,6 +29,7 @@ namespace StructSampleCore
         // Completion callbacks
         public void ReadCompletionCallback(ref long key, ref long input, ref long output, Empty ctx, Status s) { }
         public void UpsertCompletionCallback(ref long key, ref long value, Empty ctx) { }
+        public void DeleteCompletionCallback(ref long key, Empty ctx) { }
         public void RMWCompletionCallback(ref long key, ref long input, Empty ctx, Status s) { }
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum) { }
     }
@@ -67,6 +68,7 @@ namespace StructSampleCore
         // Completion callbacks
         public void ReadCompletionCallback(ref Key key, ref Input input, ref Output output, Empty ctx, Status status) { }
         public void UpsertCompletionCallback(ref Key key, ref Value output, Empty ctx) { }
+        public void DeleteCompletionCallback(ref Key key, Empty ctx) { }
         public void RMWCompletionCallback(ref Key key, ref Input output, Empty ctx, Status status) { }
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum) { }
     }

--- a/cs/playground/SumStore/SumStoreTypes.cs
+++ b/cs/playground/SumStore/SumStoreTypes.cs
@@ -58,6 +58,10 @@ namespace SumStore
         {
         }
 
+        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
+        {
+        }
+
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
         {
             Console.WriteLine("Session {0} reports persistence until {1}", sessionId, serialNum);

--- a/cs/src/core/Allocator/BlittableScanIterator.cs
+++ b/cs/src/core/Allocator/BlittableScanIterator.cs
@@ -55,11 +55,13 @@ namespace FASTER.core
         /// <summary>
         /// Get next record in iterator
         /// </summary>
+        /// <param name="recordInfo"></param>
         /// <param name="key"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        public bool GetNext(out Key key, out Value value)
+        public bool GetNext(out RecordInfo recordInfo, out Key key, out Value value)
         {
+            recordInfo = default(RecordInfo);
             key = default(Key);
             value = default(Value);
 
@@ -97,12 +99,7 @@ namespace FASTER.core
                     // Read record from cached page memory
                     var _physicalAddress = hlog.GetPhysicalAddress(currentAddress);
 
-                    if (hlog.GetInfo(_physicalAddress).Invalid)
-                    {
-                        currentAddress += hlog.GetRecordSize(_physicalAddress);
-                        continue;
-                    }
-
+                    recordInfo = hlog.GetInfo(_physicalAddress);
                     key = hlog.GetKey(_physicalAddress);
                     value = hlog.GetValue(_physicalAddress);
                     currentAddress += hlog.GetRecordSize(_physicalAddress);
@@ -111,12 +108,7 @@ namespace FASTER.core
 
                 var physicalAddress = frame.GetPhysicalAddress(currentFrame, offset);
 
-                if (hlog.GetInfo(physicalAddress).Invalid)
-                {
-                    currentAddress += hlog.GetRecordSize(physicalAddress);
-                    continue;
-                }
-
+                recordInfo = hlog.GetInfo(physicalAddress);
                 key = hlog.GetKey(physicalAddress);
                 value = hlog.GetValue(physicalAddress);
                 currentAddress += hlog.GetRecordSize(physicalAddress);

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -350,7 +350,7 @@ namespace FASTER.core
                         addr.Add((long)key_address);
                     }
 
-                    if (ValueHasObjects())
+                    if (ValueHasObjects() && !src[i].info.Tombstone)
                     {
                         long pos = ms.Position;
                         valueSerializer.Serialize(ref src[i].value);
@@ -708,7 +708,7 @@ namespace FASTER.core
 
             while (ptr < untilptr)
             {
-                if (!src[ptr/recordSize].info.Invalid)
+                if (!src[ptr / recordSize].info.Invalid)
                 {
                     if (KeyHasObjects())
                     {
@@ -723,7 +723,7 @@ namespace FASTER.core
                         keySerializer.Deserialize(ref src[ptr/recordSize].key);
                     } 
 
-                    if (ValueHasObjects())
+                    if (ValueHasObjects() && !src[ptr / recordSize].info.Tombstone)
                     {
                         var value_addr = GetValueAddressInfo((long)raw + ptr);
                         if (start_addr == -1) start_addr = value_addr->Address;
@@ -788,7 +788,7 @@ namespace FASTER.core
                         addr.Add((long)key_address);
                     }
 
-                    if (ValueHasObjects())
+                    if (ValueHasObjects() && !GetInfo(ptr).Tombstone)
                     {
                         pos = stream.Position;
                         var value_address = GetValueAddressInfo(ptr);
@@ -851,7 +851,7 @@ namespace FASTER.core
                     }
 
 
-                    if (ValueHasObjects())
+                    if (ValueHasObjects() && !src[ptr / recordSize].info.Tombstone)
                     {
                         var value_addr = GetValueAddressInfo((long)raw + ptr);
                         var addr = value_addr->Address;
@@ -913,7 +913,7 @@ namespace FASTER.core
                     endAddress = x->Address + x->Size;
                 }
 
-                if (ValueHasObjects())
+                if (ValueHasObjects() && !GetInfoFromBytePointer(record).Tombstone)
                 {
                     var x = GetValueAddressInfo((long)record);
                     if (startAddress == -1)
@@ -943,7 +943,7 @@ namespace FASTER.core
                 keySerializer.EndDeserialize();
             }
 
-            if (ValueHasObjects())
+            if (ValueHasObjects() && !GetInfoFromBytePointer(record).Tombstone)
             {
                 ctx.value = new Value();
 

--- a/cs/src/core/Allocator/GenericScanIterator.cs
+++ b/cs/src/core/Allocator/GenericScanIterator.cs
@@ -58,11 +58,13 @@ namespace FASTER.core
         /// <summary>
         /// Get next record using iterator
         /// </summary>
+        /// <param name="recordInfo"></param>
         /// <param name="key"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        public bool GetNext(out Key key, out Value value)
+        public bool GetNext(out RecordInfo recordInfo, out Key key, out Value value)
         {
+            recordInfo = default(RecordInfo);
             key = default(Key);
             value = default(Value);
 
@@ -101,16 +103,14 @@ namespace FASTER.core
 
                     var page = currentPage % hlog.BufferSize;
 
-                    if (hlog.values[page][offset].info.Invalid)
-                        continue;
+                    recordInfo = hlog.values[page][offset].info;
                     key = hlog.values[page][offset].key;
                     value = hlog.values[page][offset].value;
                     return true;
                 }
 
                 currentAddress += recordSize;
-                if (frame.GetInfo(currentFrame, offset).Invalid)
-                    continue;
+                recordInfo = frame.GetInfo(currentFrame, offset);
                 key = frame.GetKey(currentFrame, offset);
                 value = frame.GetValue(currentFrame, offset);
                 return true;

--- a/cs/src/core/Allocator/IFasterScanIterator.cs
+++ b/cs/src/core/Allocator/IFasterScanIterator.cs
@@ -31,9 +31,10 @@ namespace FASTER.core
         /// <summary>
         /// Get next record
         /// </summary>
+        /// <param name="recordInfo"></param>
         /// <param name="key"></param>
         /// <param name="value"></param>
         /// <returns>True if record found, false if end of scan</returns>
-        bool GetNext(out Key key, out Value value);
+        bool GetNext(out RecordInfo recordInfo, out Key key, out Value value);
     }
 }

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -413,17 +413,20 @@ namespace FASTER.core
         }
 
         /// <summary>
-        /// Delete hash entry if possible as a best effort
-        /// Entry is deleted if key is in memory and at the head of hash chain
+        /// Delete entry (use tombstone if necessary)
+        /// Hash entry is removed as a best effort (if key is in memory and at 
+        /// the head of hash chain.
         /// Value is set to null (using ConcurrentWrite) if it is in mutable region
         /// </summary>
         /// <param name="key"></param>
+        /// <param name="userContext"></param>
         /// <param name="monotonicSerialNum"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Status DeleteFromMemory(ref Key key, long monotonicSerialNum)
+        public Status Delete(ref Key key, Context userContext, long monotonicSerialNum)
         {
-            var internalStatus = InternalDeleteFromMemory(ref key);
+            var context = default(PendingContext);
+            var internalStatus = InternalDelete(ref key, ref userContext, ref context);
             var status = default(Status);
             if (internalStatus == OperationStatus.SUCCESS || internalStatus == OperationStatus.NOTFOUND)
             {

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -222,6 +222,11 @@ namespace FASTER.core
                                                     ref pendingContext.userContext, 
                                                     ref pendingContext);
                     break;
+                case OperationType.DELETE:
+                    internalStatus = InternalDelete(ref pendingContext.key,
+                                                    ref pendingContext.userContext,
+                                                    ref pendingContext);
+                    break;
                 case OperationType.READ:
                     throw new Exception("Cannot happen!");
             }
@@ -253,6 +258,10 @@ namespace FASTER.core
                     case OperationType.UPSERT:
                         functions.UpsertCompletionCallback(ref pendingContext.key,
                                                  ref pendingContext.value,
+                                                 pendingContext.userContext);
+                        break;
+                    case OperationType.DELETE:
+                        functions.DeleteCompletionCallback(ref pendingContext.key,
                                                  pendingContext.userContext);
                         break;
                     default:

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -166,7 +166,7 @@ namespace FASTER.core
             var iter2 = fht.Log.Scan(untilAddress, fht.Log.SafeReadOnlyAddress);
             while (iter2.GetNext(out Key key, out Value value))
             {
-                tempKv.DeleteFromMemory(ref key, 0);
+                tempKv.Delete(ref key, default(Context), 0);
             }
             iter2.Dispose();
 
@@ -197,6 +197,7 @@ namespace FASTER.core
             public void SingleReader(ref Key key, ref Input input, ref Value value, ref Output dst) { }
             public void SingleWriter(ref Key key, ref Value src, ref Value dst) { dst = src; }
             public void UpsertCompletionCallback(ref Key key, ref Value value, Context ctx) { }
+            public void DeleteCompletionCallback(ref Key key, Context ctx) { }
         }
     }
 }

--- a/cs/src/core/Index/Interfaces/FunctionsBase.cs
+++ b/cs/src/core/Index/Interfaces/FunctionsBase.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+#pragma warning disable 1591
+
+using System;
+
+namespace FASTER.core
+{
+    /// <summary>
+    /// Default empty functions base class to make it easy for users to provide
+    /// their own implementation
+    /// </summary>
+    /// <typeparam name="Key"></typeparam>
+    /// <typeparam name="Value"></typeparam>
+    /// <typeparam name="Input"></typeparam>
+    /// <typeparam name="Output"></typeparam>
+    /// <typeparam name="Context"></typeparam>
+    public abstract class FunctionsBase<Key, Value, Input, Output, Context> : IFunctions<Key, Value, Input, Output, Context>
+    {
+        public virtual void ConcurrentReader(ref Key key, ref Input input, ref Value value, ref Output dst) { }
+        public virtual void SingleReader(ref Key key, ref Input input, ref Value value, ref Output dst) { }
+
+        public virtual void ConcurrentWriter(ref Key key, ref Value src, ref Value dst) => dst = src;
+        public virtual void SingleWriter(ref Key key, ref Value src, ref Value dst) => dst = src;
+
+        public virtual void InitialUpdater(ref Key key, ref Input input, ref Value value) { }
+        public virtual void CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue) { }
+        public virtual void InPlaceUpdater(ref Key key, ref Input input, ref Value value) { }
+
+        public virtual void ReadCompletionCallback(ref Key key, ref Input input, ref Output output, Context ctx, Status status) { }
+        public virtual void RMWCompletionCallback(ref Key key, ref Input input, Context ctx, Status status) { }
+        public virtual void UpsertCompletionCallback(ref Key key, ref Value value, Context ctx) { }
+        public virtual void DeleteCompletionCallback(ref Key key, Context ctx) { }
+        public virtual void CheckpointCompletionCallback(Guid sessionId, long serialNum) { }
+    }
+
+    /// <summary>
+    /// Default empty functions base class to make it easy for users to provide
+    /// their own implementation
+    /// </summary>
+    /// <typeparam name="Key"></typeparam>
+    /// <typeparam name="Value"></typeparam>
+    /// <typeparam name="Context"></typeparam>
+    public class SimpleFunctions<Key, Value, Context> : FunctionsBase<Key, Value, Value, Value, Context>
+    {
+        private readonly Func<Value, Value, Value> merger;
+        public SimpleFunctions() => merger = (l, r) => l;
+        public SimpleFunctions(Func<Value, Value, Value> merger) => this.merger = merger;
+
+        public override void ConcurrentReader(ref Key key, ref Value input, ref Value value, ref Value dst) => dst = value;
+        public override void SingleReader(ref Key key, ref Value input, ref Value value, ref Value dst) => dst = value;
+
+        public override void ConcurrentWriter(ref Key key, ref Value src, ref Value dst) => dst = src;
+        public override void SingleWriter(ref Key key, ref Value src, ref Value dst) => dst = src;
+
+        public override void InitialUpdater(ref Key key, ref Value input, ref Value value) => value = input;
+        public override void CopyUpdater(ref Key key, ref Value input, ref Value oldValue, ref Value newValue) => newValue = merger(input, oldValue);
+        public override void InPlaceUpdater(ref Key key, ref Value input, ref Value value) => value = merger(input, value);
+
+        public override void ReadCompletionCallback(ref Key key, ref Value input, ref Value output, Context ctx, Status status) { }
+        public override void RMWCompletionCallback(ref Key key, ref Value input, Context ctx, Status status) { }
+        public override void UpsertCompletionCallback(ref Key key, ref Value value, Context ctx) { }
+        public override void DeleteCompletionCallback(ref Key key, Context ctx) { }
+        public override void CheckpointCompletionCallback(Guid sessionId, long serialNum) { }
+    }
+
+    public class SimpleFunctions<Key, Value> : SimpleFunctions<Key, Value, Empty>
+    {
+        public SimpleFunctions() : base() { }
+        public SimpleFunctions(Func<Value, Value, Value> merger) : base(merger) { }
+    }
+}

--- a/cs/src/core/Index/Interfaces/IFunctions.cs
+++ b/cs/src/core/Index/Interfaces/IFunctions.cs
@@ -40,6 +40,13 @@ namespace FASTER.core
         void RMWCompletionCallback(ref Key key, ref Input input, Context ctx, Status status);
 
         /// <summary>
+        /// Delete completion
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="ctx"></param>
+        void DeleteCompletionCallback(ref Key key, Context ctx);
+
+        /// <summary>
         /// Checkpoint completion callback (called per client session)
         /// </summary>
         /// <param name="sessionId">Session ID reporting persistence</param>

--- a/cs/test/BasicFASTERTests.cs
+++ b/cs/test/BasicFASTERTests.cs
@@ -88,7 +88,7 @@ namespace FASTER.test
 
             long tail = fht.Log.TailAddress;
 
-            fht.DeleteFromMemory(ref key1, 0);
+            fht.Delete(ref key1, Empty.Default, 0);
 
             status = fht.Read(ref key1, ref input, ref output, Empty.Default, 0);
 
@@ -144,7 +144,7 @@ namespace FASTER.test
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = 14 };
                 var value = new ValueStruct { vfield1 = i, vfield2 = 24 };
 
-                fht.DeleteFromMemory(ref key1, 0);
+                fht.Delete(ref key1, Empty.Default, 0);
             }
 
             for (int i = 0; i < 10 * count; i++)

--- a/cs/test/BlittableLogScanTests.cs
+++ b/cs/test/BlittableLogScanTests.cs
@@ -54,7 +54,7 @@ namespace FASTER.test
             var iter = fht.Log.Scan(start, fht.Log.TailAddress, ScanBufferingMode.SinglePageBuffering);
 
             int val = 0;
-            while (iter.GetNext(out KeyStruct key, out ValueStruct value))
+            while (iter.GetNext(out RecordInfo recordInfo, out KeyStruct key, out ValueStruct value))
             {
                 Assert.IsTrue(key.kfield1 == val);
                 Assert.IsTrue(key.kfield2 == val + 1);
@@ -67,7 +67,7 @@ namespace FASTER.test
             iter = fht.Log.Scan(start, fht.Log.TailAddress, ScanBufferingMode.DoublePageBuffering);
 
             val = 0;
-            while (iter.GetNext(out KeyStruct key, out ValueStruct value))
+            while (iter.GetNext(out RecordInfo recordInfo, out KeyStruct key, out ValueStruct value))
             {
                 Assert.IsTrue(key.kfield1 == val);
                 Assert.IsTrue(key.kfield2 == val + 1);

--- a/cs/test/GenericDiskDeleteTests.cs
+++ b/cs/test/GenericDiskDeleteTests.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using FASTER.core;
+using System.IO;
+using NUnit.Framework;
+
+namespace FASTER.test
+{
+
+    [TestFixture]
+    internal class GenericDiskDeleteTests
+    {
+        private FasterKV<MyKey, MyValue, MyInput, MyOutput, int, MyFunctionsDelete> fht;
+        private IDevice log, objlog;
+
+        [SetUp]
+        public void Setup()
+        {
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlogscan.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\hlogscan.obj.log", deleteOnClose: true);
+
+            fht = new FasterKV<MyKey, MyValue, MyInput, MyOutput, int, MyFunctionsDelete>
+                (128, new MyFunctionsDelete(),
+                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 15, PageSizeBits = 9 },
+                checkpointSettings: new CheckpointSettings { CheckPointType = CheckpointType.FoldOver },
+                serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() }
+                );
+            fht.StartSession();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            fht.StopSession();
+            fht.Dispose();
+            fht = null;
+            log.Close();
+        }
+
+
+        [Test]
+        public void GenericDiskDeleteTest1()
+        {
+            const int totalRecords = 2000;
+            var start = fht.Log.TailAddress;
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var _key = new MyKey { key = i };
+                var _value = new MyValue { value = i };
+                fht.Upsert(ref _key, ref _value, 0, 0);
+            }
+
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var input = new MyInput();
+                var output = new MyOutput();
+                var key1 = new MyKey { key = i };
+                var value = new MyValue { value = i };
+
+                if (fht.Read(ref key1, ref input, ref output, 0, 0) == Status.PENDING)
+                {
+                    fht.CompletePending(true);
+                }
+                else
+                {
+                    Assert.IsTrue(output.value.value == value.value);
+                    Assert.IsTrue(output.value.value == value.value);
+                }
+            }
+
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var input = new MyInput();
+                var output = new MyOutput();
+                var key1 = new MyKey { key = i };
+                var value = new MyValue { value = i };
+
+                fht.Delete(ref key1, 0, 0);
+            }
+
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var input = new MyInput();
+                var output = new MyOutput();
+                var key1 = new MyKey { key = i };
+                var value = new MyValue { value = i };
+
+                var status = fht.Read(ref key1, ref input, ref output, 1, 0);
+                
+                if (status == Status.PENDING)
+                {
+                    fht.CompletePending(true);
+                }
+                else
+                {
+                    Assert.IsTrue(status == Status.NOTFOUND);
+                }
+            }
+
+            
+            using (var iter = fht.Log.Scan(start, fht.Log.TailAddress, ScanBufferingMode.SinglePageBuffering))
+            {
+                int val = 0;
+                while (iter.GetNext(out RecordInfo recordInfo, out MyKey key, out MyValue value))
+                {
+                    if (recordInfo.Tombstone)
+                        val++;
+                }
+                Assert.IsTrue(totalRecords == val);
+            }
+            
+        }
+    }
+}

--- a/cs/test/GenericLogScanTests.cs
+++ b/cs/test/GenericLogScanTests.cs
@@ -42,6 +42,7 @@ namespace FASTER.test
             fht.Dispose();
             fht = null;
             log.Close();
+            objlog.Close();
         }
 
 

--- a/cs/test/GenericLogScanTests.cs
+++ b/cs/test/GenericLogScanTests.cs
@@ -58,28 +58,30 @@ namespace FASTER.test
                 if (i % 100 == 0) fht.Log.FlushAndEvict(true);
             }
             fht.Log.FlushAndEvict(true);
-            var iter = fht.Log.Scan(start, fht.Log.TailAddress, ScanBufferingMode.SinglePageBuffering);
-
-            int val = 0;
-            while (iter.GetNext(out MyKey key, out MyValue value))
+            using (var iter = fht.Log.Scan(start, fht.Log.TailAddress, ScanBufferingMode.SinglePageBuffering))
             {
-                Assert.IsTrue(key.key == val);
-                Assert.IsTrue(value.value == val);
-                val++;
+
+                int val = 0;
+                while (iter.GetNext(out RecordInfo recordInfo, out MyKey key, out MyValue value))
+                {
+                    Assert.IsTrue(key.key == val);
+                    Assert.IsTrue(value.value == val);
+                    val++;
+                }
+                Assert.IsTrue(totalRecords == val);
             }
-            Assert.IsTrue(totalRecords == val);
 
-            iter = fht.Log.Scan(start, fht.Log.TailAddress, ScanBufferingMode.DoublePageBuffering);
-
-            val = 0;
-            while (iter.GetNext(out MyKey key, out MyValue value))
+            using (var iter = fht.Log.Scan(start, fht.Log.TailAddress, ScanBufferingMode.DoublePageBuffering))
             {
-                Assert.IsTrue(key.key == val);
-                Assert.IsTrue(value.value == val);
-                val++;
+                int val = 0;
+                while (iter.GetNext(out RecordInfo recordInfo, out MyKey key, out MyValue value))
+                {
+                    Assert.IsTrue(key.key == val);
+                    Assert.IsTrue(value.value == val);
+                    val++;
+                }
+                Assert.IsTrue(totalRecords == val);
             }
-            Assert.IsTrue(totalRecords == val);
-
         }
     }
 }

--- a/cs/test/ObjectRecoveryTestTypes.cs
+++ b/cs/test/ObjectRecoveryTestTypes.cs
@@ -88,6 +88,10 @@ namespace FASTER.test.recovery.objectstore
         {
         }
 
+        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
+        {
+        }
+
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
         {
             Console.WriteLine("Session {0} reports persistence until {1}", sessionId, serialNum);

--- a/cs/test/ObjectTestTypes.cs
+++ b/cs/test/ObjectTestTypes.cs
@@ -158,7 +158,7 @@ namespace FASTER.test
 
         public void ConcurrentWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
         {
-            dst.value = src.value;
+            dst = src;
         }
 
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
@@ -180,7 +180,10 @@ namespace FASTER.test
 
         public void RMWCompletionCallback(ref MyKey key, ref MyInput input, int ctx, Status status)
         {
-            Assert.IsTrue(status == Status.OK);
+            if (ctx == 0)
+                Assert.IsTrue(status == Status.OK);
+            else if (ctx == 1)
+                Assert.IsTrue(status == Status.NOTFOUND);
         }
 
         public void UpsertCompletionCallback(ref MyKey key, ref MyValue value, int ctx)

--- a/cs/test/ObjectTestTypes.cs
+++ b/cs/test/ObjectTestTypes.cs
@@ -134,6 +134,74 @@ namespace FASTER.test
         }
     }
 
+    public class MyFunctionsDelete : IFunctions<MyKey, MyValue, MyInput, MyOutput, int>
+    {
+        public void InitialUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
+        {
+            value = new MyValue { value = input.value };
+        }
+
+        public void InPlaceUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
+        {
+            value.value += input.value;
+        }
+
+        public void CopyUpdater(ref MyKey key, ref MyInput input, ref MyValue oldValue, ref MyValue newValue)
+        {
+            newValue = new MyValue { value = oldValue.value + input.value };
+        }
+
+        public void ConcurrentReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst)
+        {
+            dst.value = value;
+        }
+
+        public void ConcurrentWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
+        {
+            dst.value = src.value;
+        }
+
+        public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
+        {
+        }
+
+        public void ReadCompletionCallback(ref MyKey key, ref MyInput input, ref MyOutput output, int ctx, Status status)
+        {
+            if (ctx == 0)
+            {
+                Assert.IsTrue(status == Status.OK);
+                Assert.IsTrue(key.key == output.value.value);
+            }
+            else if (ctx == 1)
+            {
+                Assert.IsTrue(status == Status.NOTFOUND);
+            }
+        }
+
+        public void RMWCompletionCallback(ref MyKey key, ref MyInput input, int ctx, Status status)
+        {
+            Assert.IsTrue(status == Status.OK);
+        }
+
+        public void UpsertCompletionCallback(ref MyKey key, ref MyValue value, int ctx)
+        {
+        }
+
+        public void DeleteCompletionCallback(ref MyKey key, int ctx)
+        {
+        }
+
+        public void SingleReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst)
+        {
+            dst.value = value;
+        }
+
+        public void SingleWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
+        {
+            dst = src;
+        }
+    }
+
     public class MixedFunctions : IFunctions<int, MyValue, MyInput, MyOutput, Empty>
     {
         public void InitialUpdater(ref int key, ref MyInput input, ref MyValue value)

--- a/cs/test/ObjectTestTypes.cs
+++ b/cs/test/ObjectTestTypes.cs
@@ -119,6 +119,10 @@ namespace FASTER.test
         {
         }
 
+        public void DeleteCompletionCallback(ref MyKey key, Empty ctx)
+        {
+        }
+
         public void SingleReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst)
         {
             dst.value = value;
@@ -170,6 +174,10 @@ namespace FASTER.test
         }
 
         public void UpsertCompletionCallback(ref int key, ref MyValue value, Empty ctx)
+        {
+        }
+
+        public void DeleteCompletionCallback(ref int key, Empty ctx)
         {
         }
 
@@ -240,6 +248,10 @@ namespace FASTER.test
 
 
         public void UpsertCompletionCallback(ref MyKey key, ref MyLargeValue value, Empty ctx)
+        {
+        }
+
+        public void DeleteCompletionCallback(ref MyKey key, Empty ctx)
         {
         }
 

--- a/cs/test/RecoverContinueTests.cs
+++ b/cs/test/RecoverContinueTests.cs
@@ -186,6 +186,10 @@ namespace FASTER.test.recovery.sumstore.recover_continue
         {
         }
 
+        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
+        {
+        }
+
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
         {
             Console.WriteLine("Session {0} reports persistence until {1}", sessionId, serialNum);

--- a/cs/test/RecoveryTestTypes.cs
+++ b/cs/test/RecoveryTestTypes.cs
@@ -58,6 +58,10 @@ namespace FASTER.test.recovery.sumstore
         {
         }
 
+        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
+        {
+        }
+
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
         {
             Console.WriteLine("Session {0} reports persistence until {1}", sessionId, serialNum);

--- a/cs/test/SimpleRecoveryTest.cs
+++ b/cs/test/SimpleRecoveryTest.cs
@@ -167,6 +167,10 @@ namespace FASTER.test.recovery.sumstore.simple
         {
         }
 
+        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
+        {
+        }
+
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
         {
             Console.WriteLine("Session {0} reports persistence until {1}", sessionId, serialNum);

--- a/cs/test/TestTypes.cs
+++ b/cs/test/TestTypes.cs
@@ -65,6 +65,10 @@ namespace FASTER.test
         {
         }
 
+        public void DeleteCompletionCallback(ref KeyStruct key, Empty ctx)
+        {
+        }
+
         public void CheckpointCompletionCallback(Guid sessionId, long serialNum)
         {
             Debug.WriteLine("Session {0} reports persistence until {1}", sessionId, serialNum);


### PR DESCRIPTION
We are adding native support for the record **Delete** operation in FASTER:

* If the record is in the mutable region, it will be marked with the tombstone bit in header, and value will be overwritten with default.
* If the record is in memory and is pointed to directly by the hash index, we elide the record from the hash chain using a CAS on the index entry to the previous record. The elided record is marked with both a tombstone and an invalid bit in this case.
* If the record is in read-only or earlier region, we will add a new tombstone record to the end of the hash chain to identify the deleted record.

Note that from the perspective of recovery and CPR, deletes behave similarly to Upserts.

This checkin will replace the prior experimental method of `DeleteFromMemory`.