### PR TITLE
Removing statics from codebase

### DIFF
--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -248,7 +248,7 @@ namespace FASTER.benchmark
 
 
             idx_ = 0;
-            store.DumpDistribution();
+            Console.WriteLine(store.DumpDistribution());
 
             Console.WriteLine("Executing experiment.");
 

--- a/cs/playground/SumStore/RecoveryTest.cs
+++ b/cs/playground/SumStore/RecoveryTest.cs
@@ -19,7 +19,6 @@ namespace SumStore
         const long completePendingInterval = 1 << 12;
         const int checkpointInterval = 10 * 1000;
         readonly int threadCount;
-        readonly int numActiveThreads;
         FasterKV<AdId, NumClicks, Input, Output, Empty, Functions> fht;
 
         BlockingCollection<Input[]> inputArrays;
@@ -27,7 +26,6 @@ namespace SumStore
         public RecoveryTest(int threadCount)
         {
             this.threadCount = threadCount;
-            numActiveThreads = 0;
 
             // Create FASTER index
             var log = Devices.CreateLogDevice("logs\\hlog");

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -1411,7 +1411,7 @@ namespace FASTER.core
             {
                 while (numPendingReads > 120)
                 {
-                    Thread.SpinWait(100);
+                    Thread.Yield();
                     epoch.ProtectAndDrain();
                 }
             }

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -61,6 +61,7 @@ namespace FASTER.core
         /// Epoch information
         /// </summary>
         protected readonly LightEpoch epoch;
+        private readonly bool toDisposeEpoch;
 
         /// <summary>
         /// Comparer
@@ -435,7 +436,13 @@ namespace FASTER.core
         public AllocatorBase(LogSettings settings, IFasterEqualityComparer<Key> comparer, LightEpoch epoch)
         {
             this.comparer = comparer;
-            this.epoch = epoch ?? new LightEpoch();
+            if (epoch == null)
+            {
+                epoch = new LightEpoch();
+                toDisposeEpoch = true;
+            }
+            else
+                this.epoch = epoch;
 
             settings.LogDevice.Initialize(1L << settings.SegmentSizeBits);
             settings.ObjectLogDevice?.Initialize(1L << settings.SegmentSizeBits);
@@ -523,6 +530,9 @@ namespace FASTER.core
             SafeHeadAddress = 0;
             HeadAddress = 0;
             BeginAddress = 1;
+
+            if (toDisposeEpoch)
+                epoch.Dispose();
         }
 
         /// <summary>

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -61,7 +61,7 @@ namespace FASTER.core
         /// Epoch information
         /// </summary>
         protected readonly LightEpoch epoch;
-        private readonly bool toDisposeEpoch;
+        private readonly bool ownedEpoch;
 
         /// <summary>
         /// Comparer
@@ -438,8 +438,8 @@ namespace FASTER.core
             this.comparer = comparer;
             if (epoch == null)
             {
-                epoch = new LightEpoch();
-                toDisposeEpoch = true;
+                this.epoch = new LightEpoch();
+                ownedEpoch = true;
             }
             else
                 this.epoch = epoch;
@@ -516,6 +516,24 @@ namespace FASTER.core
         }
 
         /// <summary>
+        /// Acquire thread
+        /// </summary>
+        public void Acquire()
+        {
+            if (ownedEpoch)
+                epoch.Acquire();
+        }
+
+        /// <summary>
+        /// Release thread
+        /// </summary>
+        public void Release()
+        {
+            if (ownedEpoch)
+                epoch.Release();
+        }
+
+        /// <summary>
         /// Dispose allocator
         /// </summary>
         public virtual void Dispose()
@@ -531,7 +549,7 @@ namespace FASTER.core
             HeadAddress = 0;
             BeginAddress = 1;
 
-            if (toDisposeEpoch)
+            if (ownedEpoch)
                 epoch.Dispose();
         }
 

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -206,9 +206,9 @@ namespace FASTER.core
         #endregion
 
         /// <summary>
-        /// Read buffer pool
+        /// Buffer pool
         /// </summary>
-        protected SectorAlignedBufferPool readBufferPool;
+        protected SectorAlignedBufferPool bufferPool;
 
         /// <summary>
         /// Read cache
@@ -492,7 +492,7 @@ namespace FASTER.core
             Debug.Assert(firstValidAddress <= PageSize);
             Debug.Assert(PageSize >= GetRecordSize(0));
 
-            readBufferPool = SectorAlignedBufferPool.GetPool(1, sectorSize);
+            bufferPool = new SectorAlignedBufferPool(1, sectorSize);
 
             long tailPage = firstValidAddress >> LogPageSizeBits;
             int tailPageIndex = (int)(tailPage % BufferSize);
@@ -551,6 +551,7 @@ namespace FASTER.core
 
             if (ownedEpoch)
                 epoch.Dispose();
+            bufferPool.Free();
         }
 
         /// <summary>
@@ -1152,7 +1153,7 @@ namespace FASTER.core
             uint alignedReadLength = (uint)((long)fileOffset + numBytes - (long)alignedFileOffset);
             alignedReadLength = (uint)((alignedReadLength + (sectorSize - 1)) & ~(sectorSize - 1));
 
-            var record = readBufferPool.Get((int)alignedReadLength);
+            var record = bufferPool.Get((int)alignedReadLength);
             record.valid_offset = (int)(fileOffset - alignedFileOffset);
             record.available_bytes = (int)(alignedReadLength - (fileOffset - alignedFileOffset));
             record.required_bytes = numBytes;

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -1407,14 +1407,13 @@ namespace FASTER.core
                               AsyncIOContext<Key, Value> context,
                               SectorAlignedMemory result = default(SectorAlignedMemory))
         {
-            while (numPendingReads > 120)
+            if (epoch.IsProtected()) // Do not spin for unprotected IO threads
             {
-                Thread.SpinWait(100);
-
-                // Do not protect if we are not already protected
-                // E.g., we are in an IO thread
-                if (epoch.IsProtected())
+                while (numPendingReads > 120)
+                {
+                    Thread.SpinWait(100);
                     epoch.ProtectAndDrain();
+                }
             }
             Interlocked.Increment(ref numPendingReads);
 

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -60,7 +60,7 @@ namespace FASTER.core
         /// <summary>
         /// Epoch information
         /// </summary>
-        protected LightEpoch epoch;
+        protected readonly LightEpoch epoch;
 
         /// <summary>
         /// Comparer
@@ -415,8 +415,9 @@ namespace FASTER.core
         /// <param name="settings"></param>
         /// <param name="comparer"></param>
         /// <param name="evictCallback"></param>
-        public AllocatorBase(LogSettings settings, IFasterEqualityComparer<Key> comparer, Action<long, long> evictCallback) 
-            : this(settings, comparer)
+        /// <param name="epoch"></param>
+        public AllocatorBase(LogSettings settings, IFasterEqualityComparer<Key> comparer, Action<long, long> evictCallback, LightEpoch epoch)
+            : this(settings, comparer, epoch)
         {
             if (evictCallback != null)
             {
@@ -430,9 +431,12 @@ namespace FASTER.core
         /// </summary>
         /// <param name="settings"></param>
         /// <param name="comparer"></param>
-        public AllocatorBase(LogSettings settings, IFasterEqualityComparer<Key> comparer)
+        /// <param name="epoch"></param>
+        public AllocatorBase(LogSettings settings, IFasterEqualityComparer<Key> comparer, LightEpoch epoch)
         {
             this.comparer = comparer;
+            this.epoch = epoch ?? new LightEpoch();
+
             settings.LogDevice.Initialize(1L << settings.SegmentSizeBits);
             settings.ObjectLogDevice?.Initialize(1L << settings.SegmentSizeBits);
 

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -202,7 +202,7 @@ namespace FASTER.core
         /// <summary>
         /// Number of pending reads
         /// </summary>
-        private static int numPendingReads = 0;
+        private int numPendingReads = 0;
         #endregion
 
         /// <summary>

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -31,14 +31,12 @@ namespace FASTER.core
         private static readonly int keySize = Utility.GetSize(default(Key));
         private static readonly int valueSize = Utility.GetSize(default(Value));
 
-        public BlittableAllocator(LogSettings settings, IFasterEqualityComparer<Key> comparer, Action<long, long> evictCallback = null)
-            : base(settings, comparer, evictCallback)
+        public BlittableAllocator(LogSettings settings, IFasterEqualityComparer<Key> comparer, Action<long, long> evictCallback = null, LightEpoch epoch = null)
+            : base(settings, comparer, evictCallback, epoch)
         {
             values = new byte[BufferSize][];
             handles = new GCHandle[BufferSize];
             pointers = new long[BufferSize];
-
-            epoch = LightEpoch.Instance;
 
             ptrHandle = GCHandle.Alloc(pointers, GCHandleType.Pinned);
             nativePointers = (long*)ptrHandle.AddrOfPinnedObject();

--- a/cs/src/core/Allocator/BlittableScanIterator.cs
+++ b/cs/src/core/Allocator/BlittableScanIterator.cs
@@ -61,7 +61,7 @@ namespace FASTER.core
                 var frameNumber = (nextAddress >> hlog.LogPageSizeBits) % frameSize;
                 hlog.AsyncReadPagesFromDeviceToFrame
                     (nextAddress >> hlog.LogPageSizeBits,
-                    1, AsyncReadPagesCallback, Empty.Default,
+                    1, endAddress, AsyncReadPagesCallback, Empty.Default,
                     frame, out loaded[frameNumber]);
             }
         }
@@ -160,7 +160,7 @@ namespace FASTER.core
                 {
                     if (!first)
                     {
-                        hlog.AsyncReadPagesFromDeviceToFrame(currentAddress >> hlog.LogPageSizeBits, 1, AsyncReadPagesCallback, Empty.Default, frame, out loaded[currentFrame]);
+                        hlog.AsyncReadPagesFromDeviceToFrame(currentAddress >> hlog.LogPageSizeBits, 1, endAddress, AsyncReadPagesCallback, Empty.Default, frame, out loaded[currentFrame]);
                     }
                 }
                 else
@@ -169,7 +169,7 @@ namespace FASTER.core
                     if ((endPage > currentPage) &&
                         ((endPage > currentPage + 1) || ((endAddress & hlog.PageSizeMask) != 0)))
                     {
-                        hlog.AsyncReadPagesFromDeviceToFrame(1 + (currentAddress >> hlog.LogPageSizeBits), 1, AsyncReadPagesCallback, Empty.Default, frame, out loaded[(currentPage + 1) % frameSize]);
+                        hlog.AsyncReadPagesFromDeviceToFrame(1 + (currentAddress >> hlog.LogPageSizeBits), 1, endAddress, AsyncReadPagesCallback, Empty.Default, frame, out loaded[(currentPage + 1) % frameSize]);
                     }
                 }
                 first = false;

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -41,8 +41,8 @@ namespace FASTER.core
         private static readonly int recordSize = Utility.GetSize(default(Record<Key, Value>));
         private readonly SerializerSettings<Key, Value> SerializerSettings;
 
-        public GenericAllocator(LogSettings settings, SerializerSettings<Key, Value> serializerSettings, IFasterEqualityComparer<Key> comparer, Action<long, long> evictCallback = null)
-            : base(settings, comparer, evictCallback)
+        public GenericAllocator(LogSettings settings, SerializerSettings<Key, Value> serializerSettings, IFasterEqualityComparer<Key> comparer, Action<long, long> evictCallback = null, LightEpoch epoch = null)
+            : base(settings, comparer, evictCallback, epoch)
         {
             SerializerSettings = serializerSettings;
 
@@ -67,7 +67,6 @@ namespace FASTER.core
                     throw new Exception("Objects in key/value, but object log not provided during creation of FASTER instance");
             }
 
-            epoch = LightEpoch.Instance;
             ioBufferPool = SectorAlignedBufferPool.GetPool(1, sectorSize);
         }
 

--- a/cs/src/core/Allocator/GenericScanIterator.cs
+++ b/cs/src/core/Allocator/GenericScanIterator.cs
@@ -64,7 +64,7 @@ namespace FASTER.core
                 var frameNumber = (nextAddress >> hlog.LogPageSizeBits) % frameSize;
                 hlog.AsyncReadPagesFromDeviceToFrame
                     (nextAddress >> hlog.LogPageSizeBits,
-                    1, AsyncReadPagesCallback, Empty.Default,
+                    1, endAddress, AsyncReadPagesCallback, Empty.Default,
                     frame, out loaded[frameNumber]);
             }
         }
@@ -148,7 +148,7 @@ namespace FASTER.core
                 {
                     if (!first)
                     {
-                        hlog.AsyncReadPagesFromDeviceToFrame(currentAddress >> hlog.LogPageSizeBits, 1, AsyncReadPagesCallback, Empty.Default, frame, out loaded[currentFrame]);
+                        hlog.AsyncReadPagesFromDeviceToFrame(currentAddress >> hlog.LogPageSizeBits, 1, endAddress, AsyncReadPagesCallback, Empty.Default, frame, out loaded[currentFrame]);
                     }
                 }
                 else
@@ -157,7 +157,7 @@ namespace FASTER.core
                     if ((endPage > currentPage) &&
                         ((endPage > currentPage + 1) || ((endAddress & hlog.PageSizeMask) != 0)))
                     {
-                        hlog.AsyncReadPagesFromDeviceToFrame(1 + (currentAddress >> hlog.LogPageSizeBits), 1, AsyncReadPagesCallback, Empty.Default, frame, out loaded[(currentPage + 1) % frameSize]);
+                        hlog.AsyncReadPagesFromDeviceToFrame(1 + (currentAddress >> hlog.LogPageSizeBits), 1, endAddress, AsyncReadPagesCallback, Empty.Default, frame, out loaded[(currentPage + 1) % frameSize]);
                     }
                 }
                 first = false;

--- a/cs/src/core/Allocator/MallocFixedPageSize.cs
+++ b/cs/src/core/Allocator/MallocFixedPageSize.cs
@@ -47,6 +47,8 @@ namespace FASTER.core
 
         private CountdownEvent checkpointEvent;
 
+        private readonly LightEpoch epoch;
+
         [ThreadStatic]
         private static Queue<FreeItem> freeList;
 
@@ -54,8 +56,11 @@ namespace FASTER.core
         /// Create new instance
         /// </summary>
         /// <param name="returnPhysicalAddress"></param>
-        public MallocFixedPageSize(bool returnPhysicalAddress = false)
+        /// <param name="epoch"></param>
+        public MallocFixedPageSize(bool returnPhysicalAddress = false, LightEpoch epoch = null)
         {
+            this.epoch = epoch ?? new LightEpoch();
+
             values[0] = new T[PageSize];
 
 #if !(CALLOC)
@@ -298,7 +303,7 @@ namespace FASTER.core
             }
             if (freeList.Count > 0)
             {
-                if (freeList.Peek().removal_epoch <= LightEpoch.Instance.SafeToReclaimEpoch)
+                if (freeList.Peek().removal_epoch <= epoch.SafeToReclaimEpoch)
                     return freeList.Dequeue().removed_item;
 
                 //if (freeList.Count % 64 == 0)

--- a/cs/src/core/Device/ManagedLocalStorageDevice.cs
+++ b/cs/src/core/Device/ManagedLocalStorageDevice.cs
@@ -30,7 +30,7 @@ namespace FASTER.core
         public ManagedLocalStorageDevice(string filename, bool preallocateFile = false, bool deleteOnClose = false)
             : base(filename, GetSectorSize(filename))
         {
-            pool = SectorAlignedBufferPool.GetPool(1, 1);
+            pool = new SectorAlignedBufferPool(1, 1);
 
             this.preallocateFile = preallocateFile;
             this.deleteOnClose = deleteOnClose;
@@ -162,6 +162,7 @@ namespace FASTER.core
         {
             foreach (var logHandle in logHandles.Values)
                 logHandle.Dispose();
+            pool.Free();
         }
 
 

--- a/cs/src/core/Epochs/FastThreadLocal.cs
+++ b/cs/src/core/Epochs/FastThreadLocal.cs
@@ -42,6 +42,8 @@ namespace FASTER.core
 
         public void DisposeThread()
         {
+            Value = default(T);
+
             // Dispose values only if there are no other
             // instances active for this thread
             for (int i = 0; i < kMaxInstances; i++)

--- a/cs/src/core/Epochs/FastThreadLocal.cs
+++ b/cs/src/core/Epochs/FastThreadLocal.cs
@@ -19,7 +19,7 @@ namespace FASTER.core
         private static T[] values;
 
         private readonly int id;
-        private static int[] instances = new int[kMaxInstances];
+        private static readonly int[] instances = new int[kMaxInstances];
 
         public FastThreadLocal()
         {

--- a/cs/src/core/Epochs/FastThreadLocal.cs
+++ b/cs/src/core/Epochs/FastThreadLocal.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Threading;
+
+namespace FASTER.core
+{
+    /// <summary>
+    /// Fast implementation of instance-thread-local variables
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal class FastThreadLocal<T>
+    {
+        // Max instances supported
+        private const int kMaxInstances = 128;
+
+        [ThreadStatic]
+        private static T[] values;
+
+        private readonly int id;
+        private static int[] instances = new int[kMaxInstances];
+
+        public FastThreadLocal()
+        {
+            for (int i = 0; i < kMaxInstances; i++)
+            {
+                if (0 == Interlocked.CompareExchange(ref instances[i], 1, 0))
+                {
+                    id = i;
+                    return;
+                }
+            }
+            throw new Exception("Unsupported number of simultaneous instances");
+        }
+
+        public void InitializeThread()
+        {
+            if (values == null)
+                values = new T[kMaxInstances];
+        }
+
+        public void DisposeThread()
+        {
+            // Dispose values only if there are no other
+            // instances active for this thread
+            for (int i = 0; i < kMaxInstances; i++)
+            {
+                if ((instances[i] == 1) && (i != id))
+                    return;
+            }
+            values = null;
+        }
+
+        /// <summary>
+        /// Dispose instance for all threads
+        /// </summary>
+        public void Dispose()
+        {
+            instances[id] = 0;
+        }
+
+        public T Value
+        {
+            get { return values[id]; }
+            set { values[id] = value; }
+        }
+    }
+}

--- a/cs/src/core/Epochs/FastThreadLocal.cs
+++ b/cs/src/core/Epochs/FastThreadLocal.cs
@@ -64,8 +64,10 @@ namespace FASTER.core
 
         public T Value
         {
-            get { return values[id]; }
-            set { values[id] = value; }
+            get => values[id];
+            set => values[id] = value;
         }
+
+        public bool IsInitializedForThread => values != null;
     }
 }

--- a/cs/src/core/Epochs/LightEpoch.cs
+++ b/cs/src/core/Epochs/LightEpoch.cs
@@ -121,7 +121,7 @@ namespace FASTER.core
         /// <returns>Result of the check</returns>
         public bool IsProtected()
         {
-            return kInvalidIndex != threadEntryIndex.Value;
+            return threadEntryIndex.IsInitializedForThread && kInvalidIndex != threadEntryIndex.Value;
         }
 
         /// <summary>

--- a/cs/src/core/Index/FASTER/Checkpoint.cs
+++ b/cs/src/core/Index/FASTER/Checkpoint.cs
@@ -472,7 +472,7 @@ namespace FASTER.core
 
                             if (!ctx.markers[EpochPhaseIdx.InProgress])
                             {
-                                prevThreadCtx = threadCtx;
+                                prevThreadCtx.Value = threadCtx.Value;
 
                                 InitLocalContext(prevThreadCtx.Value.guid);
 

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -67,11 +67,8 @@ namespace FASTER.core
 
         private SafeConcurrentDictionary<Guid, long> _recoveredSessions;
 
-        [ThreadStatic]
-        private static FasterExecutionContext prevThreadCtx = default(FasterExecutionContext);
-
-        [ThreadStatic]
-        private static FasterExecutionContext threadCtx = default(FasterExecutionContext);
+        private FastThreadLocal<FasterExecutionContext> prevThreadCtx;
+        private FastThreadLocal<FasterExecutionContext> threadCtx;
 
 
         /// <summary>
@@ -85,6 +82,9 @@ namespace FASTER.core
         /// <param name="serializerSettings">Serializer settings</param>
         public FasterKV(long size, Functions functions, LogSettings logSettings, CheckpointSettings checkpointSettings = null, SerializerSettings<Key, Value> serializerSettings = null, IFasterEqualityComparer<Key> comparer = null)
         {
+            threadCtx = new FastThreadLocal<FasterExecutionContext>();
+            prevThreadCtx = new FastThreadLocal<FasterExecutionContext>();
+
             if (comparer != null)
                 this.comparer = comparer;
             else
@@ -353,9 +353,9 @@ namespace FASTER.core
             }
             else
             {
-                status = HandleOperationStatus(threadCtx, context, internalStatus);
+                status = HandleOperationStatus(threadCtx.Value, context, internalStatus);
             }
-            threadCtx.serialNum = monotonicSerialNum;
+            threadCtx.Value.serialNum = monotonicSerialNum;
             return status;
         }
 
@@ -380,9 +380,9 @@ namespace FASTER.core
             }
             else
             {
-                status = HandleOperationStatus(threadCtx, context, internalStatus);
+                status = HandleOperationStatus(threadCtx.Value, context, internalStatus);
             }
-            threadCtx.serialNum = monotonicSerialNum;
+            threadCtx.Value.serialNum = monotonicSerialNum;
             return status;
         }
 
@@ -406,9 +406,9 @@ namespace FASTER.core
             }
             else
             {
-                status = HandleOperationStatus(threadCtx, context, internalStatus);
+                status = HandleOperationStatus(threadCtx.Value, context, internalStatus);
             }
-            threadCtx.serialNum = monotonicSerialNum;
+            threadCtx.Value.serialNum = monotonicSerialNum;
             return status;
         }
 
@@ -432,7 +432,7 @@ namespace FASTER.core
             {
                 status = (Status)internalStatus;
             }
-            threadCtx.serialNum = monotonicSerialNum;
+            threadCtx.Value.serialNum = monotonicSerialNum;
             return status;
         }
 

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -451,6 +451,8 @@ namespace FASTER.core
         public void Dispose()
         {
             base.Free();
+            threadCtx.Dispose();
+            prevThreadCtx.Dispose();
             hlog.Dispose();
         }
     }

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -117,7 +117,7 @@ namespace FASTER.core
 
             if (Utility.IsBlittable<Key>() && Utility.IsBlittable<Value>())
             {
-                hlog = new BlittableAllocator<Key, Value>(logSettings, this.comparer);
+                hlog = new BlittableAllocator<Key, Value>(logSettings, this.comparer, null, epoch);
                 Log = new LogAccessor<Key, Value, Input, Output, Context>(this, hlog);
                 if (UseReadCache)
                 {
@@ -127,14 +127,14 @@ namespace FASTER.core
                             MemorySizeBits = logSettings.ReadCacheSettings.MemorySizeBits,
                             SegmentSizeBits = logSettings.ReadCacheSettings.MemorySizeBits,
                             MutableFraction = logSettings.ReadCacheSettings.SecondChanceFraction
-                        }, this.comparer, ReadCacheEvict);
+                        }, this.comparer, ReadCacheEvict, epoch);
                     readcache.Initialize();
                     ReadCache = new LogAccessor<Key, Value, Input, Output, Context>(this, readcache);
                 }
             }
             else
             {
-                hlog = new GenericAllocator<Key, Value>(logSettings, serializerSettings, this.comparer);
+                hlog = new GenericAllocator<Key, Value>(logSettings, serializerSettings, this.comparer, null, epoch);
                 Log = new LogAccessor<Key, Value, Input, Output, Context>(this, hlog);
                 if (UseReadCache)
                 {
@@ -145,7 +145,7 @@ namespace FASTER.core
                             MemorySizeBits = logSettings.ReadCacheSettings.MemorySizeBits,
                             SegmentSizeBits = logSettings.ReadCacheSettings.MemorySizeBits,
                             MutableFraction = logSettings.ReadCacheSettings.SecondChanceFraction
-                        }, serializerSettings, this.comparer, ReadCacheEvict);
+                        }, serializerSettings, this.comparer, ReadCacheEvict, epoch);
                     readcache.Initialize();
                     ReadCache = new LogAccessor<Key, Value, Input, Output, Context>(this, readcache);
                 }

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -733,7 +733,7 @@ namespace FASTER.core
         /// 
         /// </summary>
         /// <param name="version"></param>
-        protected virtual void _DumpDistribution(int version)
+        protected virtual string _DumpDistribution(int version)
         {
             var table_size_ = state[version].size;
             var ptable_ = state[version].tableAligned;
@@ -768,23 +768,25 @@ namespace FASTER.core
                 histogram[cnt]++;
             }
 
-            Console.WriteLine("Number of hash buckets: {0}", table_size_);
-            Console.WriteLine("Total distinct hash-table entry count: {0}", total_record_count);
-            Console.WriteLine("Average #entries per hash bucket: {0:0.00}", total_record_count / (double)table_size_);
-            Console.WriteLine("Histogram of #entries per bucket: ");
-
+            var distribution =
+                $"Number of hash buckets: {{{table_size_}}}\n" +
+                $"Total distinct hash-table entry count: {{{total_record_count}}}\n" +
+                $"Average #entries per hash bucket: {{{total_record_count / (double)table_size_:0.00}}}\n" +
+                $"Histogram of #entries per bucket:\n";
             foreach (var kvp in histogram.OrderBy(e => e.Key))
             {
-                Console.WriteLine(kvp.Key.ToString() + ": " + kvp.Value.ToString(CultureInfo.InvariantCulture));
+                distribution += $"  {kvp.Key} : {kvp.Value}\n";
             }
+
+            return distribution;
         }
 
         /// <summary>
         /// Dumps the distribution of each non-empty bucket in the hash table.
         /// </summary>
-        public void DumpDistribution()
+        public string DumpDistribution()
         {
-            _DumpDistribution(resizeInfo.version);
+            return _DumpDistribution(resizeInfo.version);
         }
 
     }

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -283,6 +283,7 @@ namespace FASTER.core
             Free(0);
             Free(1);
             overflowBucketsAllocator.Dispose();
+            epoch.Dispose();
             return Status.OK;
         }
 

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -282,8 +282,8 @@ namespace FASTER.core
         {
             Free(0);
             Free(1);
-            overflowBucketsAllocator.Dispose();
             epoch.Dispose();
+            overflowBucketsAllocator.Dispose();
             return Status.OK;
         }
 

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -251,7 +251,7 @@ namespace FASTER.core
         internal long minTableSize = 16;
 
         // Allocator for the hash buckets
-        internal MallocFixedPageSize<HashBucket> overflowBucketsAllocator = new MallocFixedPageSize<HashBucket>();
+        internal readonly MallocFixedPageSize<HashBucket> overflowBucketsAllocator;
 
         // An array of size two, that contains the old and new versions of the hash-table
         internal InternalHashTable[] state = new InternalHashTable[2];
@@ -274,7 +274,8 @@ namespace FASTER.core
         /// </summary>
         public FasterBase()
         {
-            epoch = LightEpoch.Instance;
+            epoch = new LightEpoch();
+            overflowBucketsAllocator = new MallocFixedPageSize<HashBucket>(false, epoch);
         }
 
         internal Status Free()

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -18,6 +18,7 @@ namespace FASTER.core
     {
         internal Guid InternalAcquire()
         {
+            epoch.Acquire();
             Phase phase = _systemState.phase;
             if (phase != Phase.REST)
             {
@@ -31,6 +32,7 @@ namespace FASTER.core
 
         internal long InternalContinue(Guid guid)
         {
+            epoch.Acquire();
             if (_recoveredSessions != null)
             {
                 if (_recoveredSessions.TryGetValue(guid, out long serialNum))

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -119,24 +119,26 @@ namespace FASTER.core
 
         internal void InitLocalContext(Guid token)
         {
-            threadCtx.Value =
-            new FasterExecutionContext
-            {
-                phase = Phase.REST,
-                version = _systemState.version,
-                markers = new bool[8],
-                serialNum = 0,
-                totalPending = 0,
-                guid = token,
-                retryRequests = new Queue<PendingContext>(),
-                readyResponses = new BlockingCollection<AsyncIOContext<Key, Value>>(),
-                ioPendingRequests = new Dictionary<long, PendingContext>()
-            };
+            var ctx = 
+                new FasterExecutionContext
+                {
+                    phase = Phase.REST,
+                    version = _systemState.version,
+                    markers = new bool[8],
+                    serialNum = 0,
+                    totalPending = 0,
+                    guid = token,
+                    retryRequests = new Queue<PendingContext>(),
+                    readyResponses = new BlockingCollection<AsyncIOContext<Key, Value>>(),
+                    ioPendingRequests = new Dictionary<long, PendingContext>()
+                };
 
             for(int i = 0; i < 8; i++)
             {
-                threadCtx.Value.markers[i] = false;
+                ctx.markers[i] = false;
             }
+
+            threadCtx.Value = ctx;
         }
 
         internal bool InternalCompletePending(bool wait = false)

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -19,6 +19,7 @@ namespace FASTER.core
         internal Guid InternalAcquire()
         {
             epoch.Acquire();
+            overflowBucketsAllocator.Acquire();
             threadCtx.InitializeThread();
             prevThreadCtx.InitializeThread();
             Phase phase = _systemState.phase;
@@ -35,6 +36,7 @@ namespace FASTER.core
         internal long InternalContinue(Guid guid)
         {
             epoch.Acquire();
+            overflowBucketsAllocator.Acquire();
             threadCtx.InitializeThread();
             prevThreadCtx.InitializeThread();
             if (_recoveredSessions != null)
@@ -115,6 +117,7 @@ namespace FASTER.core
             threadCtx.DisposeThread();
             prevThreadCtx.DisposeThread();
             epoch.Release();
+            overflowBucketsAllocator.Release();
         }
 
         internal void InitLocalContext(Guid token)

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -19,20 +19,24 @@ namespace FASTER.core
         internal Guid InternalAcquire()
         {
             epoch.Acquire();
+            threadCtx.InitializeThread();
+            prevThreadCtx.InitializeThread();
             Phase phase = _systemState.phase;
             if (phase != Phase.REST)
             {
                 throw new Exception("Can acquire only in REST phase!");
             }
             Guid guid = Guid.NewGuid();
-            InitLocalContext(ref threadCtx, guid);
+            InitLocalContext(guid);
             InternalRefresh();
-            return threadCtx.guid;
+            return threadCtx.Value.guid;
         }
 
         internal long InternalContinue(Guid guid)
         {
             epoch.Acquire();
+            threadCtx.InitializeThread();
+            prevThreadCtx.InitializeThread();
             if (_recoveredSessions != null)
             {
                 if (_recoveredSessions.TryGetValue(guid, out long serialNum))
@@ -50,8 +54,8 @@ namespace FASTER.core
                             {
                                 // We have atomically removed session details. 
                                 // No one else can continue this session
-                                InitLocalContext(ref threadCtx, guid);
-                                threadCtx.serialNum = serialNum;
+                                InitLocalContext(guid);
+                                threadCtx.Value.serialNum = serialNum;
                                 InternalRefresh();
                             }
                             else
@@ -83,7 +87,7 @@ namespace FASTER.core
 
             // We check if we are in normal mode
             var newPhaseInfo = SystemState.Copy(ref _systemState);
-            if (threadCtx.phase == Phase.REST && newPhaseInfo.phase == Phase.REST)
+            if (threadCtx.Value.phase == Phase.REST && newPhaseInfo.phase == Phase.REST)
             {
                 return;
             }
@@ -91,7 +95,7 @@ namespace FASTER.core
             // Moving to non-checkpointing phases
             if (newPhaseInfo.phase == Phase.GC || newPhaseInfo.phase == Phase.PREPARE_GROW || newPhaseInfo.phase == Phase.IN_PROGRESS_GROW)
             {
-                threadCtx.phase = newPhaseInfo.phase;
+                threadCtx.Value.phase = newPhaseInfo.phase;
                 return;
             }
 
@@ -100,22 +104,23 @@ namespace FASTER.core
 
         internal void InternalRelease()
         {
-            Debug.Assert(threadCtx.retryRequests.Count == 0 &&
-                    threadCtx.ioPendingRequests.Count == 0);
-            if (prevThreadCtx != default(FasterExecutionContext))
+            Debug.Assert(threadCtx.Value.retryRequests.Count == 0 &&
+                    threadCtx.Value.ioPendingRequests.Count == 0);
+            if (prevThreadCtx.Value != default(FasterExecutionContext))
             {
-                Debug.Assert(prevThreadCtx.retryRequests.Count == 0 &&
-                    prevThreadCtx.ioPendingRequests.Count == 0);
+                Debug.Assert(prevThreadCtx.Value.retryRequests.Count == 0 &&
+                    prevThreadCtx.Value.ioPendingRequests.Count == 0);
             }
-            Debug.Assert(threadCtx.phase == Phase.REST);
-            prevThreadCtx = null;
-            threadCtx = null;
+            Debug.Assert(threadCtx.Value.phase == Phase.REST);
+            threadCtx.DisposeThread();
+            prevThreadCtx.DisposeThread();
             epoch.Release();
         }
 
-        internal void InitLocalContext(ref FasterExecutionContext context, Guid token)
+        internal void InitLocalContext(Guid token)
         {
-            context = new FasterExecutionContext
+            threadCtx.Value =
+            new FasterExecutionContext
             {
                 phase = Phase.REST,
                 version = _systemState.version,
@@ -130,7 +135,7 @@ namespace FASTER.core
 
             for(int i = 0; i < 8; i++)
             {
-                context.markers[i] = false;
+                threadCtx.Value.markers[i] = false;
             }
         }
 
@@ -141,30 +146,30 @@ namespace FASTER.core
                 bool done = true;
 
                 #region Previous pending requests
-                if (threadCtx.phase == Phase.IN_PROGRESS
+                if (threadCtx.Value.phase == Phase.IN_PROGRESS
                     ||
-                    threadCtx.phase == Phase.WAIT_PENDING)
+                    threadCtx.Value.phase == Phase.WAIT_PENDING)
                 {
-                    CompleteIOPendingRequests(prevThreadCtx);
+                    CompleteIOPendingRequests(prevThreadCtx.Value);
                     Refresh();
-                    CompleteRetryRequests(prevThreadCtx);
+                    CompleteRetryRequests(prevThreadCtx.Value);
 
-                    done &= (prevThreadCtx.ioPendingRequests.Count == 0);
-                    done &= (prevThreadCtx.retryRequests.Count == 0);
+                    done &= (prevThreadCtx.Value.ioPendingRequests.Count == 0);
+                    done &= (prevThreadCtx.Value.retryRequests.Count == 0);
                 }
                 #endregion
 
-                if (!(threadCtx.phase == Phase.IN_PROGRESS
+                if (!(threadCtx.Value.phase == Phase.IN_PROGRESS
                       || 
-                      threadCtx.phase == Phase.WAIT_PENDING))
+                      threadCtx.Value.phase == Phase.WAIT_PENDING))
                 {
-                    CompleteIOPendingRequests(threadCtx);
+                    CompleteIOPendingRequests(threadCtx.Value);
                 }
                 InternalRefresh();
-                CompleteRetryRequests(threadCtx);
+                CompleteRetryRequests(threadCtx.Value);
 
-                done &= (threadCtx.ioPendingRequests.Count == 0);
-                done &= (threadCtx.retryRequests.Count == 0);
+                done &= (threadCtx.Value.ioPendingRequests.Count == 0);
+                done &= (threadCtx.Value.retryRequests.Count == 0);
 
                 if (done)
                 {
@@ -204,9 +209,9 @@ namespace FASTER.core
 
             #region Entry latch operation
             var handleLatches = false;
-            if ((ctx.version < threadCtx.version) // Thread has already shifted to (v+1)
+            if ((ctx.version < threadCtx.Value.version) // Thread has already shifted to (v+1)
                 ||
-                (threadCtx.phase == Phase.PREPARE)) // Thread still in version v, but acquired shared-latch 
+                (threadCtx.Value.phase == Phase.PREPARE)) // Thread still in version v, but acquired shared-latch 
             {
                 handleLatches = true;
             }
@@ -278,9 +283,9 @@ namespace FASTER.core
                                     AsyncIOContext<Key, Value> request)
         {
             var handleLatches = false;
-            if ((ctx.version < threadCtx.version) // Thread has already shifted to (v+1)
+            if ((ctx.version < threadCtx.Value.version) // Thread has already shifted to (v+1)
                 ||
-                (threadCtx.phase == Phase.PREPARE)) // Thread still in version v, but acquired shared-latch 
+                (threadCtx.Value.phase == Phase.PREPARE)) // Thread still in version v, but acquired shared-latch 
             {
                 handleLatches = true;
             }

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -169,7 +169,10 @@ namespace FASTER.core
                         tempKv.Upsert(ref key, ref value, default(Context), 0);
 
                     if (++cnt % 1000 == 0)
+                    {
                         fht.Refresh();
+                        tempKv.Refresh();
+                    }
                 }
             }
 
@@ -190,8 +193,10 @@ namespace FASTER.core
                             fht.Upsert(ref key, ref value, default(Context), 0);
                     }
                     if (++cnt % 1000 == 0)
+                    {
                         fht.Refresh();
-
+                        tempKv.Refresh();
+                    }
                     if (scanUntil < fht.Log.SafeReadOnlyAddress)
                     {
                         LogScanForValidity(ref untilAddress, ref scanUntil, ref tempKv);
@@ -218,7 +223,10 @@ namespace FASTER.core
                         tempKv.Delete(ref key, default(Context), 0);
 
                         if (++cnt % 1000 == 0)
+                        {
                             fht.Refresh();
+                            tempKv.Refresh();
+                        }
                     }
                 }
                 fht.Refresh();

--- a/cs/src/core/Index/Interfaces/IFasterKV.cs
+++ b/cs/src/core/Index/Interfaces/IFasterKV.cs
@@ -162,9 +162,9 @@ namespace FASTER.core
         IFasterEqualityComparer<Key> Comparer { get; }
 
         /// <summary>
-        /// Dump distribution of #entries in hash table, to console
+        /// Dump distribution of #entries in hash table
         /// </summary>
-        void DumpDistribution();
+        string DumpDistribution();
 
         /// <summary>
         /// Experimental feature

--- a/cs/src/core/Utilities/BufferPool.cs
+++ b/cs/src/core/Utilities/BufferPool.cs
@@ -172,9 +172,11 @@ namespace FASTER.core
                 return page;
             }
 
-            page = new SectorAlignedMemory();
-            page.level = index;
-            page.buffer = new byte[sectorSize * (1 << index)];
+            page = new SectorAlignedMemory
+            {
+                level = index,
+                buffer = new byte[sectorSize * (1 << index)]
+            };
             page.handle = GCHandle.Alloc(page.buffer, GCHandleType.Pinned);
             page.aligned_pointer = (byte*)(((long)page.handle.AddrOfPinnedObject() + (sectorSize - 1)) & ~(sectorSize - 1));
             page.offset = (int) ((long)page.aligned_pointer - (long)page.handle.AddrOfPinnedObject());

--- a/cs/src/core/Utilities/PageAsyncResultTypes.cs
+++ b/cs/src/core/Utilities/PageAsyncResultTypes.cs
@@ -14,27 +14,19 @@ namespace FASTER.core
     /// <typeparam name="TContext"></typeparam>
     public class PageAsyncReadResult<TContext> : IAsyncResult
     {
-        /// <summary>
-        /// Page
-        /// </summary>
-        public long page;
-        /// <summary>
-        /// Context
-        /// </summary>
-        public TContext context;
-        /// <summary>
-        /// Count
-        /// </summary>
-        public int count;
-
+        internal long page;
+        internal TContext context;
         internal CountdownEvent handle;
         internal SectorAlignedMemory freeBuffer1;
         internal SectorAlignedMemory freeBuffer2;
         internal IOCompletionCallback callback;
         internal IDevice objlogDevice;
-        internal long resumeptr;
-        internal long untilptr;
         internal object frame;
+
+        /* Used for iteration */
+        internal long resumePtr;
+        internal long untilPtr;
+        internal long maxPtr;
 
         /// <summary>
         /// 

--- a/cs/test/ComponentRecoveryTests.cs
+++ b/cs/test/ComponentRecoveryTests.cs
@@ -22,6 +22,7 @@ namespace FASTER.test.recovery
             var rand1 = new Random(seed);
             var device = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\MallocFixedPageSizeRecoveryTest.dat", deleteOnClose: true);
             var allocator = new MallocFixedPageSize<HashBucket>();
+            allocator.Acquire();
 
             //do something
             int numBucketsToAdd = 16 * allocator.GetPageSize();
@@ -42,8 +43,12 @@ namespace FASTER.test.recovery
             //wait until complete
             allocator.IsCheckpointCompleted(true);
 
+            allocator.Release();
+            allocator.Dispose();
 
             var recoveredAllocator = new MallocFixedPageSize<HashBucket>();
+            recoveredAllocator.Acquire();
+
             //issue call to recover
             recoveredAllocator.BeginRecovery(device, 0, numBucketsToAdd, numBytesWritten, out ulong numBytesRead);
             //wait until complete
@@ -61,6 +66,9 @@ namespace FASTER.test.recovery
                     Assert.IsTrue(bucket->bucket_entries[j] == rand2.Next());
                 }
             }
+
+            recoveredAllocator.Release();
+            recoveredAllocator.Dispose();
         }
 
         [Test]
@@ -135,6 +143,9 @@ namespace FASTER.test.recovery
                     Assert.IsTrue(entry1.word == entry2.word);
                 }
             }
+
+            hash_table1.Free();
+            hash_table2.Free();
         }
     }
 }

--- a/cs/test/FullRecoveryTests.cs
+++ b/cs/test/FullRecoveryTests.cs
@@ -78,6 +78,8 @@ namespace FASTER.test.recovery.sumstore
         public void RecoveryTest1()
         {
             Populate();
+            fht.Dispose();
+            fht = null;
             log.Close();
             Setup();
             RecoverAndTest(token, token);

--- a/cs/test/ObjectRecoveryTest.cs
+++ b/cs/test/ObjectRecoveryTest.cs
@@ -87,6 +87,8 @@ namespace FASTER.test.recovery.objectstore
         public void ObjectRecoveryTest1()
         {
             Populate();
+            fht.Dispose();
+            fht = null;
             log.Close();
             objlog.Close();
             Setup();


### PR DESCRIPTION
We have used ThreadStatic until now, for storing thread-local variables. This does not work when you have multiple instances of FASTER operating at the same time. This PR fixes the problem by using instance-specific thread-local variables instead. We have implemented our own version of thread-local for this purpose, called FastThreadLocal<T>. Incidentally, FastThreadLocal<T> is optimized to be around 10x faster than ThreadLocal<T> in our micro-benchmarks. There is a configurable (in code) limit of 128 instances of a particular thread-local variable type. This may be relaxed in future if the requirement comes up. With this PR, there are no shared objects between instances, except for the buffer pool which is shared static for the entire process.