### PR TITLE
Add yield to complete pending

### DIFF
--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -183,6 +183,7 @@ namespace FASTER.core
 
                 if (wait)
                 {
+                    // Yield before checking again
                     Thread.Yield();
                 }
             } while (wait);

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -180,6 +180,11 @@ namespace FASTER.core
                 {
                     return true;
                 }
+
+                if (wait)
+                {
+                    Thread.Yield();
+                }
             } while (wait);
 
             return false;


### PR DESCRIPTION
Changing the spin-wait technique to Yield in AsyncGetFromDisk greatly improved performance. Adding analogous change to InternalCompletePending.