### PR TITLE
cc: benchmark: remove misleading comment

### DIFF
--- a/cc/benchmark-dir/benchmark.cc
+++ b/cc/benchmark-dir/benchmark.cc
@@ -589,8 +589,7 @@ void run_benchmark(store_t* store, size_t num_threads) {
 }
 
 void run(Workload workload, size_t num_threads) {
-  // FASTER store has a hash table with approx. kInitCount / 2 entries, a log of size 16 GB,
-  // and a null device (it's in-memory only).
+  // FASTER store has a hash table with approx. kInitCount / 2 entries and a log of size 16 GB
   size_t init_size = next_power_of_two(kInitCount / 2);
   store_t store{ init_size, 17179869184, "storage" };
 


### PR DESCRIPTION
What:
* remove misleading comment

Why:
* the benchmark uses a FileSystemDisk not a NullDisk as implied by this
comment