### PR TITLE
Allow checkpoint if read cache is unused

### DIFF
--- a/cs/src/core/Index/FASTER/Checkpoint.cs
+++ b/cs/src/core/Index/FASTER/Checkpoint.cs
@@ -766,7 +766,7 @@ namespace FASTER.core
             directoryConfiguration.CreateHybridLogCheckpointFolder(hybridLogToken);
             _hybridLogCheckpoint.Initialize(hybridLogToken, version);
         }
-        
+
         #endregion
     }
 }

--- a/cs/src/core/Index/FASTER/Checkpoint.cs
+++ b/cs/src/core/Index/FASTER/Checkpoint.cs
@@ -180,7 +180,7 @@ namespace FASTER.core
                         }
                     case Phase.INDEX_CHECKPOINT:
                         {
-                            if (UseReadCache)
+                            if (UseReadCache && this.ReadCache.BeginAddress != this.ReadCache.TailAddress)
                             {
                                 throw new Exception("Index checkpoint with read cache is not supported");
                             }
@@ -203,7 +203,7 @@ namespace FASTER.core
                                     }
                                 case Phase.PREP_INDEX_CHECKPOINT:
                                     {
-                                        if (UseReadCache)
+                                        if (UseReadCache && this.ReadCache.BeginAddress != this.ReadCache.TailAddress)
                                         {
                                             throw new Exception("Index checkpoint with read cache is not supported");
                                         }
@@ -766,7 +766,7 @@ namespace FASTER.core
             directoryConfiguration.CreateHybridLogCheckpointFolder(hybridLogToken);
             _hybridLogCheckpoint.Initialize(hybridLogToken, version);
         }
-
+        
         #endregion
     }
 }


### PR DESCRIPTION
Currently, all index checkpoints are disallowed if ReadCache is enabled. This change allows the checkpoint as long as the ReadCache has not yet been used.