### PR TITLE
Support for callback when records in hybrid log become read-only

### DIFF
--- a/cs/src/core/Allocator/IFasterScanIterator.cs
+++ b/cs/src/core/Allocator/IFasterScanIterator.cs
@@ -18,7 +18,12 @@ namespace FASTER.core
         /// <summary>
         /// Buffer current and next page in scan sequence
         /// </summary>
-        DoublePageBuffering
+        DoublePageBuffering,
+
+        /// <summary>
+        /// Do not buffer - with this mode, you can only scan records already in main memory
+        /// </summary>
+        NoBuffering
     }
 
     /// <summary>

--- a/cs/src/core/Index/FASTER/Extensions.cs
+++ b/cs/src/core/Index/FASTER/Extensions.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+#pragma warning disable 0162
+
+
+using System;
+
+namespace FASTER.core
+{
+    /// <summary>
+    /// Log subscription extensions
+    /// </summary>
+    public static class Extensions
+    {
+        /// <summary>
+        /// Create observable of log records
+        /// </summary>
+        /// <typeparam name="Key"></typeparam>
+        /// <typeparam name="Value"></typeparam>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        public static IObservable<Record<Key, Value>> ToRecordObservable<Key, Value>(this IObservable<IFasterScanIterator<Key, Value>> source)
+        {
+            return new RecordObservable<Key, Value>(source);
+        }
+
+        internal class RecordObservable<Key, Value> : IObservable<Record<Key, Value>>
+        {
+            IObservable<IFasterScanIterator<Key, Value>> o;
+
+            public RecordObservable(IObservable<IFasterScanIterator<Key, Value>> o)
+            {
+                this.o = o;
+            }
+
+            public IDisposable Subscribe(IObserver<Record<Key, Value>> observer)
+            {
+                return o.Subscribe(new RecordObserver<Key, Value>(observer));
+            }
+        }
+
+        internal class RecordObserver<Key, Value> : IObserver<IFasterScanIterator<Key, Value>>
+        {
+            private IObserver<Record<Key, Value>> observer;
+
+            public RecordObserver(IObserver<Record<Key, Value>> observer)
+            {
+                this.observer = observer;
+            }
+
+            public void OnCompleted()
+            {
+                observer.OnCompleted();
+            }
+
+            public void OnError(Exception error)
+            {
+                observer.OnError(error);
+            }
+
+            public void OnNext(IFasterScanIterator<Key, Value> v)
+            {
+                while (v.GetNext(out RecordInfo info, out Key key, out Value value))
+                {
+                    observer.OnNext(new Record<Key, Value> { info = info, key = key, value = value });
+                }
+            }
+        }
+    }
+}

--- a/cs/src/core/Index/FASTER/Extensions.cs
+++ b/cs/src/core/Index/FASTER/Extensions.cs
@@ -65,6 +65,7 @@ namespace FASTER.core
                 {
                     observer.OnNext(new Record<Key, Value> { info = info, key = key, value = value });
                 }
+                v.Dispose();
             }
         }
     }

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -16,7 +16,7 @@ namespace FASTER.core
     /// <typeparam name="Input"></typeparam>
     /// <typeparam name="Output"></typeparam>
     /// <typeparam name="Context"></typeparam>
-    public class LogAccessor<Key, Value, Input, Output, Context>
+    public class LogAccessor<Key, Value, Input, Output, Context> : IObservable<IFasterScanIterator<Key, Value>>
         where Key : new()
         where Value : new()
     {
@@ -87,12 +87,34 @@ namespace FASTER.core
         }
 
         /// <summary>
-        /// Register callback to notify user when records become read-only in FASTER log
+        /// Subscribe to records (in batches) as they become read-only in the log
+        /// Currently, we support only one subscriber to the log (easy to extend)
+        /// Subscriber only receives new log updates from the time of subscription onwards
+        /// To scan the historical part of the log, use the Scan(...) method
         /// </summary>
         /// <param name="readOnlyObserver">Observer to which scan iterator is pushed</param>
-        public void RegisterReadOnlyCallback(IObserver<IFasterScanIterator<Key, Value>> readOnlyObserver)
+        public IDisposable Subscribe(IObserver<IFasterScanIterator<Key, Value>> readOnlyObserver)
         {
             allocator.OnReadOnlyObserver = readOnlyObserver;
+            return new LogSubscribeDisposable(allocator);
+        }
+
+        /// <summary>
+        /// Wrapper to help dispose the subscription
+        /// </summary>
+        class LogSubscribeDisposable : IDisposable
+        {
+            private AllocatorBase<Key, Value> allocator;
+
+            public LogSubscribeDisposable(AllocatorBase<Key, Value> allocator)
+            {
+                this.allocator = allocator;
+            }
+
+            public void Dispose()
+            {
+                allocator.OnReadOnlyObserver = null;
+            }
         }
 
         /// <summary>

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -87,6 +87,15 @@ namespace FASTER.core
         }
 
         /// <summary>
+        /// Register callback to notify user when records become read-only in FASTER log
+        /// </summary>
+        /// <param name="readOnlyObserver">Observer to which scan iterator is pushed</param>
+        public void RegisterReadOnlyCallback(IObserver<IFasterScanIterator<Key, Value>> readOnlyObserver)
+        {
+            allocator.OnReadOnlyObserver = readOnlyObserver;
+        }
+
+        /// <summary>
         /// Shift log read-only address
         /// </summary>
         /// <param name="newReadOnlyAddress">Address to shift read-only until</param>

--- a/cs/test/BlittableLogScanTests.cs
+++ b/cs/test/BlittableLogScanTests.cs
@@ -42,8 +42,8 @@ namespace FASTER.test
         [Test]
         public void BlittableDiskWriteScan()
         {
-            fht.Log.RegisterReadOnlyCallback(new CacheEvictIterator());
-            
+            var s = fht.Log.Subscribe(new LogObserver());
+
             var start = fht.Log.TailAddress;
             for (int i = 0; i < totalRecords; i++)
             {
@@ -78,9 +78,11 @@ namespace FASTER.test
                 val++;
             }
             Assert.IsTrue(totalRecords == val);
+
+            s.Dispose();
         }
 
-        class CacheEvictIterator : IObserver<IFasterScanIterator<KeyStruct, ValueStruct>>
+        class LogObserver : IObserver<IFasterScanIterator<KeyStruct, ValueStruct>>
         {
             int val = 0;
 

--- a/cs/test/GenericLogScanTests.cs
+++ b/cs/test/GenericLogScanTests.cs
@@ -19,6 +19,7 @@ namespace FASTER.test
     {
         private FasterKV<MyKey, MyValue, MyInput, MyOutput, Empty, MyFunctions> fht;
         private IDevice log, objlog;
+        const int totalRecords = 2000;
 
         [SetUp]
         public void Setup()
@@ -49,7 +50,8 @@ namespace FASTER.test
         [Test]
         public void GenericDiskWriteScan()
         {
-            const int totalRecords = 2000;
+            fht.Log.RegisterReadOnlyCallback(new CacheEvictIterator());
+
             var start = fht.Log.TailAddress;
             for (int i = 0; i < totalRecords; i++)
             {
@@ -82,6 +84,31 @@ namespace FASTER.test
                     val++;
                 }
                 Assert.IsTrue(totalRecords == val);
+            }
+        }
+
+        class CacheEvictIterator : IObserver<IFasterScanIterator<MyKey, MyValue>>
+        {
+            int val = 0;
+
+            public void OnCompleted()
+            {
+                Assert.IsTrue(val == totalRecords);
+            }
+
+            public void OnError(Exception error)
+            {
+            }
+
+            public void OnNext(IFasterScanIterator<MyKey, MyValue> iter)
+            {
+                while (iter.GetNext(out _, out MyKey key, out MyValue value))
+                {
+                    Assert.IsTrue(key.key == val);
+                    Assert.IsTrue(value.value == val);
+                    val++;
+                }
+                iter.Dispose();
             }
         }
     }

--- a/cs/test/GenericLogScanTests.cs
+++ b/cs/test/GenericLogScanTests.cs
@@ -50,7 +50,7 @@ namespace FASTER.test
         [Test]
         public void GenericDiskWriteScan()
         {
-            fht.Log.RegisterReadOnlyCallback(new CacheEvictIterator());
+            var s = fht.Log.Subscribe(new LogObserver());
 
             var start = fht.Log.TailAddress;
             for (int i = 0; i < totalRecords; i++)
@@ -85,9 +85,11 @@ namespace FASTER.test
                 }
                 Assert.IsTrue(totalRecords == val);
             }
+
+            s.Dispose();
         }
 
-        class CacheEvictIterator : IObserver<IFasterScanIterator<MyKey, MyValue>>
+        class LogObserver : IObserver<IFasterScanIterator<MyKey, MyValue>>
         {
             int val = 0;
 


### PR DESCRIPTION
This PR allows users to register a user-defined callback, which is invoked when records in the hybrid log become read-only. It can be used for various reasons:

(1) to perform data write-through to an external store
(2) to perform stream processing on the change log created by the key-value store

How it Works
---------------

The FASTER log accessor now supports the `IObservable<IFasterScanIterator<Key, Value>>` interface. This means you can `Subscribe` to FASTER log, in order to receive (as push calls) updates whenever records enter the read-only region of the hybrid log:

```cs
        var s = fht.Log.Subscribe(new LogObserver());
        ...
        s.Dispose();
```

The parameter `LogObserver` is an instance of type `IObserver<IFasterScanIterator<Key, Value>>`. User gets push-based callbacks via the `OnNext` method of the observer. Each callback provides an iterator for a batch of records that have just become read-only, in bulk. The user can then perform operations such as stream processing or write-through to the remote database.

Here is an example of the callback:

```cs
        class LogObserver : IObserver<IFasterScanIterator<Key, Value>>
        {
            public void OnCompleted()
            {
            }

            public void OnError(Exception error)
            {
            }

            public void OnNext(IFasterScanIterator<Key, Value> iter)
            {
                while (iter.GetNext(out RecordInfo info, out Key key, out Value value))
                {
                    // Process key and value
                }
                iter.Dispose();
            }
        }
```