### PR TITLE
Removing direct call of callback when IO completes synchronously

### DIFF
--- a/cs/src/core/Device/LocalStorageDevice.cs
+++ b/cs/src/core/Device/LocalStorageDevice.cs
@@ -73,11 +73,6 @@ namespace FASTER.core
                     throw new Exception("Error reading from log file: " + error);
                 }
             }
-            else
-            {
-                // On synchronous completion, issue callback directly
-                callback(0, bytesRead, ovNative);
-            }
         }
 
         /// <summary>
@@ -118,11 +113,6 @@ namespace FASTER.core
                     Overlapped.Free(ovNative);
                     throw new Exception("Error writing to log file: " + error);
                 }
-            }
-            else
-            {
-                // On synchronous completion, issue callback directly
-                callback(0, bytesWritten, ovNative);
             }
         }
 


### PR DESCRIPTION
Removing direct call of callback when IO completes synchronously - we expect the OS to call the callback in this case.

Fix #135 