### PR TITLE
Object log recovery fixes

### DIFF
--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -329,7 +329,7 @@ namespace FASTER.core
         /// Allocate page
         /// </summary>
         /// <param name="index"></param>
-        protected abstract void AllocatePage(int index);
+        internal abstract void AllocatePage(int index);
         /// <summary>
         /// Whether page is allocated
         /// </summary>

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -121,7 +121,7 @@ namespace FASTER.core
         /// Allocate memory page, pinned in memory, and in sector aligned form, if possible
         /// </summary>
         /// <param name="index"></param>
-        protected override void AllocatePage(int index)
+        internal override void AllocatePage(int index)
         {
             var adjustedSize = PageSize + 2 * sectorSize;
             byte[] tmp = new byte[adjustedSize];

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -197,7 +197,7 @@ namespace FASTER.core
         /// Allocate memory page, pinned in memory, and in sector aligned form, if possible
         /// </summary>
         /// <param name="index"></param>
-        protected override void AllocatePage(int index)
+        internal override void AllocatePage(int index)
         {
             values[index] = AllocatePage();
             PageStatusIndicator[index].PageFlushCloseStatus.PageFlushStatus = PMMFlushStatus.Flushed;
@@ -312,6 +312,8 @@ namespace FASTER.core
                 }
                 fixed (RecordInfo* pin = &src[0].info)
                 {
+                    Debug.Assert(buffer.aligned_pointer + numBytesToWrite <= (byte*)buffer.handle.AddrOfPinnedObject() + buffer.buffer.Length);
+
                     Buffer.MemoryCopy((void*)((long)Unsafe.AsPointer(ref src[0]) + start), buffer.aligned_pointer + start, 
                         numBytesToWrite - start, numBytesToWrite - start);
                 }
@@ -320,6 +322,8 @@ namespace FASTER.core
             {
                 fixed (RecordInfo* pin = &src[0].info)
                 {
+                    Debug.Assert(buffer.aligned_pointer + numBytesToWrite <= (byte*)buffer.handle.AddrOfPinnedObject() + buffer.buffer.Length);
+
                     Buffer.MemoryCopy((void*)((long)Unsafe.AsPointer(ref src[0]) + aligned_start), buffer.aligned_pointer + aligned_start, 
                         numBytesToWrite - aligned_start, numBytesToWrite - aligned_start);
                 }
@@ -513,26 +517,17 @@ namespace FASTER.core
 
             PageAsyncReadResult<TContext> result = (PageAsyncReadResult<TContext>)Overlapped.Unpack(overlap).AsyncResult;
 
-            var src = values[result.page % BufferSize];
+            Record<Key, Value>[] src;
 
             // We are reading into a frame
             if (result.frame != null)
             {
                 var frame = (GenericFrame<Key, Value>)result.frame;
                 src = frame.GetPage(result.page % frame.frameSize);
-
-                if (result.freeBuffer2 == null && result.freeBuffer1 != null && result.freeBuffer1.required_bytes > 0)
-                {
-                    PopulatePageFrame(result.freeBuffer1.GetValidPointer(), (int)result.maxPtr, src);
-                }
             }
             else
-            {
-                if (result.freeBuffer2 == null && result.freeBuffer1 != null && result.freeBuffer1.required_bytes > 0)
-                {
-                    PopulatePage(result.freeBuffer1.GetValidPointer(), (int)result.maxPtr, result.page);
-                }
-            }
+                src = values[result.page % BufferSize];
+
 
             // Deserialize all objects until untilptr
             if (result.resumePtr < result.untilPtr)
@@ -560,9 +555,8 @@ namespace FASTER.core
             // We will be re-issuing I/O, so free current overlap
             Overlapped.Free(overlap);
 
-            // Compute new untilPtr
             // We will now be able to process all records until (but not including) untilPtr
-            GetObjectInfo(result.freeBuffer1.GetValidPointer(), ref result.untilPtr, result.maxPtr, ObjectBlockSize, src, out long startptr, out long size);
+            GetObjectInfo(result.freeBuffer1.GetValidPointer(), ref result.untilPtr, result.maxPtr, ObjectBlockSize, out long startptr, out long size);
 
             // Object log fragment should be aligned by construction
             Debug.Assert(startptr % sectorSize == 0);
@@ -570,9 +564,9 @@ namespace FASTER.core
             if (size > int.MaxValue)
                 throw new Exception("Unable to read object page, total size greater than 2GB: " + size);
 
-            var objBuffer = bufferPool.Get((int)size);
-            result.freeBuffer2 = objBuffer;
             var alignedLength = (size + (sectorSize - 1)) & ~(sectorSize - 1);
+            var objBuffer = bufferPool.Get((int)alignedLength);
+            result.freeBuffer2 = objBuffer;
 
             // Request objects from objlog
             result.objlogDevice.ReadAsync(
@@ -718,7 +712,10 @@ namespace FASTER.core
 
             while (ptr < untilptr)
             {
-                if (!src[ptr / recordSize].info.Invalid)
+                ref Record<Key, Value> record = ref Unsafe.AsRef<Record<Key, Value>>(raw + ptr);
+                src[ptr / recordSize].info = record.info;
+
+                if (!record.info.Invalid)
                 {
                     if (KeyHasObjects())
                     {
@@ -729,21 +726,32 @@ namespace FASTER.core
                             stream.Seek(streamStartPos + key_addr->Address - start_addr, SeekOrigin.Begin);
                         }
 
-                        src[ptr/recordSize].key = new Key();
+                        src[ptr / recordSize].key = new Key();
                         keySerializer.Deserialize(ref src[ptr/recordSize].key);
-                    } 
-
-                    if (ValueHasObjects() && !src[ptr / recordSize].info.Tombstone)
+                    }
+                    else
                     {
-                        var value_addr = GetValueAddressInfo((long)raw + ptr);
-                        if (start_addr == -1) start_addr = value_addr->Address;
-                        if (stream.Position != streamStartPos + value_addr->Address - start_addr)
-                        {
-                            stream.Seek(streamStartPos + value_addr->Address - start_addr, SeekOrigin.Begin);
-                        }
+                        src[ptr / recordSize].key = record.key;
+                    }
 
-                        src[ptr / recordSize].value = new Value();
-                        valueSerializer.Deserialize(ref src[ptr/recordSize].value);
+                    if (!record.info.Tombstone)
+                    {
+                        if (ValueHasObjects())
+                        {
+                            var value_addr = GetValueAddressInfo((long)raw + ptr);
+                            if (start_addr == -1) start_addr = value_addr->Address;
+                            if (stream.Position != streamStartPos + value_addr->Address - start_addr)
+                            {
+                                stream.Seek(streamStartPos + value_addr->Address - start_addr, SeekOrigin.Begin);
+                            }
+
+                            src[ptr / recordSize].value = new Value();
+                            valueSerializer.Deserialize(ref src[ptr / recordSize].value);
+                        }
+                        else
+                        {
+                            src[ptr / recordSize].value = record.value;
+                        }
                     }
                 }
                 ptr += GetRecordSize(ptr);
@@ -765,17 +773,18 @@ namespace FASTER.core
         /// <param name="ptr"></param>
         /// <param name="untilptr"></param>
         /// <param name="objectBlockSize"></param>
-        /// <param name="src"></param>
         /// <param name="startptr"></param>
         /// <param name="size"></param>
-        public void GetObjectInfo(byte* raw, ref long ptr, long untilptr, int objectBlockSize, Record<Key, Value>[] src, out long startptr, out long size)
+        public void GetObjectInfo(byte* raw, ref long ptr, long untilptr, int objectBlockSize, out long startptr, out long size)
         {
             long minObjAddress = long.MaxValue;
             long maxObjAddress = long.MinValue;
 
             while (ptr < untilptr)
             {
-                if (!src[ptr/recordSize].info.Invalid)
+                ref Record<Key, Value> record = ref Unsafe.AsRef<Record<Key, Value>>(raw + ptr);
+
+                if (!record.info.Invalid)
                 {
                     if (KeyHasObjects())
                     {
@@ -794,7 +803,7 @@ namespace FASTER.core
                     }
 
 
-                    if (ValueHasObjects() && !src[ptr / recordSize].info.Tombstone)
+                    if (ValueHasObjects() && !record.info.Tombstone)
                     {
                         var value_addr = GetValueAddressInfo((long)raw + ptr);
                         var addr = value_addr->Address;
@@ -941,6 +950,8 @@ namespace FASTER.core
         {
             fixed (RecordInfo* pin = &destinationPage[0].info)
             {
+                Debug.Assert(required_bytes <= recordSize * destinationPage.Length);
+
                 Buffer.MemoryCopy(src, Unsafe.AsPointer(ref destinationPage[0]), required_bytes, required_bytes);
             }
         }

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -193,7 +193,7 @@ namespace FASTER.core
         /// Allocate memory page, pinned in memory, and in sector aligned form, if possible
         /// </summary>
         /// <param name="index"></param>
-        protected override void AllocatePage(int index)
+        internal override void AllocatePage(int index)
         {
             var adjustedSize = PageSize + 2 * sectorSize;
             byte[] tmp = new byte[adjustedSize];

--- a/cs/src/core/Device/LocalStorageDevice.cs
+++ b/cs/src/core/Device/LocalStorageDevice.cs
@@ -76,11 +76,6 @@ namespace FASTER.core
                     throw new Exception("Error reading from log file: " + error);
                 }
             }
-            else
-            {
-                // On synchronous completion, issue callback directly
-                callback(0, bytesRead, ovNative);
-            }
         }
 
         /// <summary>
@@ -121,11 +116,6 @@ namespace FASTER.core
                     Overlapped.Free(ovNative);
                     throw new Exception("Error writing to log file: " + error);
                 }
-            }
-            else
-            {
-                // On synchronous completion, issue callback directly
-                callback(0, bytesWritten, ovNative);
             }
         }
 

--- a/cs/src/core/Device/LocalStorageDevice.cs
+++ b/cs/src/core/Device/LocalStorageDevice.cs
@@ -18,7 +18,8 @@ namespace FASTER.core
     {
         private readonly bool preallocateFile;
         private readonly bool deleteOnClose;
-        private readonly ConcurrentDictionary<int, SafeFileHandle> logHandles;
+        private readonly bool disableFileBuffering;
+        private readonly SafeConcurrentDictionary<int, SafeFileHandle> logHandles;
 
         /// <summary>
         /// Constructor
@@ -26,13 +27,15 @@ namespace FASTER.core
         /// <param name="filename"></param>
         /// <param name="preallocateFile"></param>
         /// <param name="deleteOnClose"></param>
-        public LocalStorageDevice(string filename, bool preallocateFile = false, bool deleteOnClose = false)
+        /// <param name="disableFileBuffering"></param>
+        public LocalStorageDevice(string filename, bool preallocateFile = false, bool deleteOnClose = false, bool disableFileBuffering = true)
             : base(filename, GetSectorSize(filename))
         {
             Native32.EnableProcessPrivileges();
             this.preallocateFile = preallocateFile;
             this.deleteOnClose = deleteOnClose;
-            logHandles = new ConcurrentDictionary<int, SafeFileHandle>();
+            this.disableFileBuffering = disableFileBuffering;
+            logHandles = new SafeConcurrentDictionary<int, SafeFileHandle>();
         }
 
         /// <summary>
@@ -72,6 +75,11 @@ namespace FASTER.core
                     Overlapped.Free(ovNative);
                     throw new Exception("Error reading from log file: " + error);
                 }
+            }
+            else
+            {
+                // On synchronous completion, issue callback directly
+                callback(0, bytesRead, ovNative);
             }
         }
 
@@ -113,6 +121,11 @@ namespace FASTER.core
                     Overlapped.Free(ovNative);
                     throw new Exception("Error writing to log file: " + error);
                 }
+            }
+            else
+            {
+                // On synchronous completion, issue callback directly
+                callback(0, bytesWritten, ovNative);
             }
         }
 
@@ -175,7 +188,11 @@ namespace FASTER.core
             uint fileCreation = unchecked((uint)FileMode.OpenOrCreate);
             uint fileFlags = Native32.FILE_FLAG_OVERLAPPED;
 
-            fileFlags = fileFlags | Native32.FILE_FLAG_NO_BUFFERING;
+            if (this.disableFileBuffering)
+            {
+                fileFlags = fileFlags | Native32.FILE_FLAG_NO_BUFFERING;
+            }
+
             if (deleteOnClose)
             {
                 fileFlags = fileFlags | Native32.FILE_FLAG_DELETE_ON_CLOSE;

--- a/cs/src/core/Index/Common/AddressInfo.cs
+++ b/cs/src/core/Index/Common/AddressInfo.cs
@@ -87,7 +87,7 @@ namespace FASTER.core
                 word = (IntPtr)_word;
                 if (value != Address)
                 {
-                    throw new Exception("Overflow in AddressInfo");
+                    throw new Exception("Overflow in AddressInfo" + ((kAddressBits < 64) ? " - consider running the program in x64 mode for larger address space support" : ""));
                 }
             }
         }

--- a/cs/src/core/Index/Common/AddressInfo.cs
+++ b/cs/src/core/Index/Common/AddressInfo.cs
@@ -87,7 +87,7 @@ namespace FASTER.core
                 word = (IntPtr)_word;
                 if (value != Address)
                 {
-                    throw new Exception("Overflow in AddressInfo" + ((kAddressBits < 64) ? " - consider running the program in x64 mode for larger address space support" : ""));
+                    throw new Exception("Overflow in AddressInfo");
                 }
             }
         }

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -273,6 +273,10 @@ namespace FASTER.core
         /// </summary>
         public long finalLogicalAddress;
         /// <summary>
+        /// Head address
+        /// </summary>
+        public long headAddress;
+        /// <summary>
         /// Guid array
         /// </summary>
         public Guid[] guids;
@@ -299,6 +303,7 @@ namespace FASTER.core
             flushedLogicalAddress = 0;
             startLogicalAddress = 0;
             finalLogicalAddress = 0;
+            headAddress = 0;
             guids = new Guid[LightEpoch.kTableSize + 1];
             continueTokens = new Dictionary<Guid, long>();
             objectLogSegmentOffsets = null;
@@ -330,6 +335,9 @@ namespace FASTER.core
 
             value = reader.ReadLine();
             finalLogicalAddress = long.Parse(value);
+
+            value = reader.ReadLine();
+            headAddress = long.Parse(value);
 
             value = reader.ReadLine();
             numThreads = int.Parse(value);
@@ -421,6 +429,7 @@ namespace FASTER.core
             writer.WriteLine(flushedLogicalAddress);
             writer.WriteLine(startLogicalAddress);
             writer.WriteLine(finalLogicalAddress);
+            writer.WriteLine(headAddress);
             writer.WriteLine(numThreads);
             for (int i = 0; i < numThreads; i++)
             {
@@ -449,6 +458,7 @@ namespace FASTER.core
             Debug.WriteLine("Flushed LogicalAddress: {0}", flushedLogicalAddress);
             Debug.WriteLine("Start Logical Address: {0}", startLogicalAddress);
             Debug.WriteLine("Final Logical Address: {0}", finalLogicalAddress);
+            Debug.WriteLine("Head Address: {0}", headAddress);
             Debug.WriteLine("Num sessions recovered: {0}", numThreads);
             Debug.WriteLine("Recovered sessions: ");
             foreach (var sessionInfo in continueTokens)

--- a/cs/src/core/Index/FASTER/Checkpoint.cs
+++ b/cs/src/core/Index/FASTER/Checkpoint.cs
@@ -251,6 +251,8 @@ namespace FASTER.core
                                 WriteIndexCheckpointCompleteFile();
                             }
 
+                            _hybridLogCheckpoint.info.headAddress = hlog.HeadAddress;
+
                             if (FoldOverSnapshot)
                             {
                                 hlog.ShiftReadOnlyToTail(out long tailAddress);

--- a/cs/src/core/Utilities/BufferPool.cs
+++ b/cs/src/core/Utilities/BufferPool.cs
@@ -133,11 +133,11 @@ namespace FASTER.core
             Array.Clear(page.buffer, 0, page.buffer.Length);
             if (!Disabled)
                 queue[page.level].Enqueue(page);
-            //else
-            //{
-            //    page.handle.Free();
-            //    page.buffer = null;
-            //}
+            else
+            {
+                page.handle.Free();
+                page.buffer = null;
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/cs/src/core/Utilities/BufferPool.cs
+++ b/cs/src/core/Utilities/BufferPool.cs
@@ -133,6 +133,11 @@ namespace FASTER.core
             Array.Clear(page.buffer, 0, page.buffer.Length);
             if (!Disabled)
                 queue[page.level].Enqueue(page);
+            //else
+            //{
+            //    page.handle.Free();
+            //    page.buffer = null;
+            //}
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
The logic for reading records in the presence of an object log was writing directly to a pinned array of managed objects, to avoid fine grained copy of parts of the log that are not managed. However, this solution has problems in the presence of GC. This checkin primarily undoes this optimization for the sake of correctness. There are a few other minor improvements, such as using a SafeConcurrentDictionary to store file handles, to avoid spurious creation when many threads read in parallel.