### PR TITLE
[c++] in_memory_test: fix inverted rmw replace condition

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
   steps:
   - task: NuGetToolInstaller@0
     inputs:
-      versionSpec: '4.4.1' 
+      versionSpec: '4.8.2' 
     
   - task: NuGetCommand@2
     inputs:
@@ -142,6 +142,20 @@ jobs:
   displayName: 'C# (Linux)'
 
   steps:
+  - task: NuGetToolInstaller@0
+    inputs:
+      versionSpec: '4.8.2' 
+    
+  - task: NuGetCommand@2
+    inputs:
+      restoreSolution: '$(solution)'
+
+  - task: DotNetCoreInstaller@0
+    displayName: 'Install'
+    inputs:
+      packageType: 'sdk'
+      version: '2.2.401'
+
   - script: |
       mono --version
       msbuild /version

--- a/cc/test/in_memory_test.cc
+++ b/cc/test/in_memory_test.cc
@@ -680,7 +680,7 @@ TEST(InMemFaster, UpsertRead_ResizeValue_Concurrent) {
       return false;
     }
     inline void unlock(bool replaced) {
-      if(replaced) {
+      if(!replaced) {
         // Just turn off "locked" bit and increase gen number.
         uint64_t sub_delta = ((uint64_t)1 << 62) - 1;
         control_.fetch_sub(sub_delta);
@@ -1409,7 +1409,7 @@ TEST(InMemFaster, Rmw_ResizeValue_Concurrent) {
       return false;
     }
     inline void unlock(bool replaced) {
-      if(replaced) {
+      if(!replaced) {
         // Just turn off "locked" bit and increase gen number.
         uint64_t sub_delta = ((uint64_t)1 << 62) - 1;
         control_.fetch_sub(sub_delta);


### PR DESCRIPTION
Currently, the example code has branches that do the opposite to what
the condition implies should happen. As a result, non-replaced records
are being marked as replaced and causing unnecessary read-copy-updates.

I discovered a bug in `faster-rs` where we were using the original logic and were performing subsequent RCU operations even though the values were being updated in-place.