### PR TITLE
Implemented iterator for variable length structs.

### DIFF
--- a/cs/src/core/Allocator/IFasterScanIterator.cs
+++ b/cs/src/core/Allocator/IFasterScanIterator.cs
@@ -34,6 +34,25 @@ namespace FASTER.core
     public interface IFasterScanIterator<Key, Value> : IDisposable
     {
         /// <summary>
+        /// Gets reference to current key
+        /// </summary>
+        /// <returns></returns>
+        ref Key GetKey();
+
+        /// <summary>
+        /// Gets reference to current value
+        /// </summary>
+        /// <returns></returns>
+        ref Value GetValue();
+
+        /// <summary>
+        /// Get next record
+        /// </summary>
+        /// <param name="recordInfo"></param>
+        /// <returns>True if record found, false if end of scan</returns>
+        bool GetNext(out RecordInfo recordInfo);
+
+        /// <summary>
         /// Get next record
         /// </summary>
         /// <param name="recordInfo"></param>


### PR DESCRIPTION
Current IFasterScanIterator interface is not suited for variable length structs as GetNext would only return a fragment of key/value (up to sizeof(Key)/sizeof(Value)). To solve this issue two new methods were added ref GetKey()/ref GetValue() that return references to actual key/value references in hlog.

There is disconnect in GenericScanIterator as it returns a reference to a copy of key/value and not direct reference to hlog. In case this is needed we could have flag to indicate whether we need to read from frame or hlog directly and store current page/offset.

This implementation does not support compaction for variable length structs.