### PR TITLE
Fix recovery logic to read back page, include begin address

### DIFF
--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -1138,7 +1138,8 @@ namespace FASTER.core
         /// </summary>
         /// <param name="tailAddress"></param>
         /// <param name="headAddress"></param>
-        public void RecoveryReset(long tailAddress, long headAddress)
+        /// <param name="beginAddress"></param>
+        public void RecoveryReset(long tailAddress, long headAddress, long beginAddress)
         {
             long tailPage = GetPage(tailAddress);
             long offsetInPage = GetOffsetInPage(tailAddress);
@@ -1151,7 +1152,8 @@ namespace FASTER.core
             var nextPageIndex = (pageIndex + 1) % BufferSize;
             if (tailAddress > 0)
                 AllocatePage(nextPageIndex);
-            
+
+            BeginAddress = beginAddress;
             HeadAddress = headAddress;
             SafeHeadAddress = headAddress;
             FlushedUntilAddress = tailAddress;

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -145,6 +145,10 @@ namespace FASTER.core
         /// </summary>
         public long headAddress;
         /// <summary>
+        /// Begin address
+        /// </summary>
+        public long beginAddress;
+        /// <summary>
         /// Guid array
         /// </summary>
         public Guid[] guids;
@@ -216,6 +220,9 @@ namespace FASTER.core
             headAddress = long.Parse(value);
 
             value = reader.ReadLine();
+            beginAddress = long.Parse(value);
+
+            value = reader.ReadLine();
             numThreads = int.Parse(value);
 
             for (int i = 0; i < numThreads; i++)
@@ -280,6 +287,7 @@ namespace FASTER.core
                     writer.WriteLine(startLogicalAddress);
                     writer.WriteLine(finalLogicalAddress);
                     writer.WriteLine(headAddress);
+                    writer.WriteLine(beginAddress);
                     writer.WriteLine(numThreads);
                     for (int i = 0; i < numThreads; i++)
                     {
@@ -313,6 +321,7 @@ namespace FASTER.core
             Debug.WriteLine("Start Logical Address: {0}", startLogicalAddress);
             Debug.WriteLine("Final Logical Address: {0}", finalLogicalAddress);
             Debug.WriteLine("Head Address: {0}", headAddress);
+            Debug.WriteLine("Begin Address: {0}", beginAddress);
             Debug.WriteLine("Num sessions recovered: {0}", numThreads);
             Debug.WriteLine("Recovered sessions: ");
             foreach (var sessionInfo in continueTokens)

--- a/cs/src/core/Index/Recovery/Checkpoint.cs
+++ b/cs/src/core/Index/Recovery/Checkpoint.cs
@@ -250,6 +250,7 @@ namespace FASTER.core
                             }
 
                             _hybridLogCheckpoint.info.headAddress = hlog.HeadAddress;
+                            _hybridLogCheckpoint.info.beginAddress = hlog.BeginAddress;
 
                             if (FoldOverSnapshot)
                             {


### PR DESCRIPTION
Fix recovery logic to correctly read back current page, and include begin address in recovery info.

Fix https://github.com/microsoft/FASTER/issues/165