### PR TITLE
Fasterlog lowmem

### DIFF
--- a/cs/playground/FasterLogSample/Program.cs
+++ b/cs/playground/FasterLogSample/Program.cs
@@ -10,7 +10,7 @@ namespace FasterLogSample
 {
     public class Program
     {
-        const int entryLength = 9996;
+        const int entryLength = 96;
         static FasterLog log;
 
         static void ReportThread()
@@ -115,13 +115,14 @@ namespace FasterLogSample
             log = new FasterLog(new FasterLogSettings { LogDevice = device });
 
             new Thread(new ThreadStart(AppendThread)).Start();
+            new Thread(new ThreadStart(AppendThread)).Start();
             
             // Can have multiple append threads if needed
             // new Thread(new ThreadStart(AppendThread)).Start();
             
-            new Thread(new ThreadStart(ScanThread)).Start();
+            // new Thread(new ThreadStart(ScanThread)).Start();
             new Thread(new ThreadStart(ReportThread)).Start();
-            new Thread(new ThreadStart(CommitThread)).Start();
+            // new Thread(new ThreadStart(CommitThread)).Start();
 
             Thread.Sleep(500*1000);
         }

--- a/cs/playground/FasterLogSample/Program.cs
+++ b/cs/playground/FasterLogSample/Program.cs
@@ -10,7 +10,7 @@ namespace FasterLogSample
 {
     public class Program
     {
-        const int entryLength = 96;
+        const int entryLength = 10000;
         static FasterLog log;
 
         static void ReportThread()
@@ -84,11 +84,11 @@ namespace FasterLogSample
                         Thread.Sleep(1000);
                     if (!result.SequenceEqual(entrySpan))
                     {
-                        throw new Exception("Invalid entry found");
+                        throw new Exception("Invalid entry found at offset " + FindDiff(result, entrySpan));
                     }
 
-                    if (r.Next(100) < 0)
-                        log.Append(result);
+                    //if (r.Next(100) < 0)
+                    //    log.Append(result);
 
                     if (iter.CurrentAddress - lastAddress > 500000000)
                     {
@@ -99,15 +99,16 @@ namespace FasterLogSample
             }
         }
 
-        static void FindDiff(Span<byte> b1, Span<byte> b2)
+        static int FindDiff(Span<byte> b1, Span<byte> b2)
         {
             for (int i=0; i<b1.Length; i++)
             {
                 if (b1[i] != b2[i])
                 {
-                    Console.WriteLine("Different at " + i);
+                    return i;
                 }
             }
+            return 0;
         }
         static void Main(string[] args)
         {
@@ -115,14 +116,14 @@ namespace FasterLogSample
             log = new FasterLog(new FasterLogSettings { LogDevice = device });
 
             new Thread(new ThreadStart(AppendThread)).Start();
-            new Thread(new ThreadStart(AppendThread)).Start();
+            // new Thread(new ThreadStart(AppendThread)).Start();
             
             // Can have multiple append threads if needed
             // new Thread(new ThreadStart(AppendThread)).Start();
             
-            // new Thread(new ThreadStart(ScanThread)).Start();
+            new Thread(new ThreadStart(ScanThread)).Start();
             new Thread(new ThreadStart(ReportThread)).Start();
-            // new Thread(new ThreadStart(CommitThread)).Start();
+            new Thread(new ThreadStart(CommitThread)).Start();
 
             Thread.Sleep(500*1000);
         }

--- a/cs/playground/FasterLogSample/Program.cs
+++ b/cs/playground/FasterLogSample/Program.cs
@@ -10,7 +10,7 @@ namespace FasterLogSample
 {
     public class Program
     {
-        const int entryLength = 96;
+        const int entryLength = 9996;
         static FasterLog log;
 
         static void ReportThread()
@@ -51,7 +51,7 @@ namespace FasterLogSample
             while (true)
             {
                 log.Append(entry);
-                
+
                 // We also support a Span-based version of Append
 
                 // We also support TryAppend to allow throttling/back-off:
@@ -87,7 +87,7 @@ namespace FasterLogSample
                         throw new Exception("Invalid entry found");
                     }
 
-                    if (r.Next(100) < 10)
+                    if (r.Next(100) < 0)
                         log.Append(result);
 
                     if (iter.CurrentAddress - lastAddress > 500000000)
@@ -99,6 +99,16 @@ namespace FasterLogSample
             }
         }
 
+        static void FindDiff(Span<byte> b1, Span<byte> b2)
+        {
+            for (int i=0; i<b1.Length; i++)
+            {
+                if (b1[i] != b2[i])
+                {
+                    Console.WriteLine("Different at " + i);
+                }
+            }
+        }
         static void Main(string[] args)
         {
             var device = Devices.CreateLogDevice("D:\\logs\\hlog.log");

--- a/cs/playground/FasterLogSample/Program.cs
+++ b/cs/playground/FasterLogSample/Program.cs
@@ -10,7 +10,7 @@ namespace FasterLogSample
 {
     public class Program
     {
-        const int entryLength = 10000;
+        const int entryLength = 96;
         static FasterLog log;
 
         static void ReportThread()
@@ -87,8 +87,8 @@ namespace FasterLogSample
                         throw new Exception("Invalid entry found at offset " + FindDiff(result, entrySpan));
                     }
 
-                    //if (r.Next(100) < 0)
-                    //    log.Append(result);
+                    if (r.Next(100) < 0)
+                        log.Append(result);
 
                     if (iter.CurrentAddress - lastAddress > 500000000)
                     {
@@ -110,6 +110,7 @@ namespace FasterLogSample
             }
             return 0;
         }
+
         static void Main(string[] args)
         {
             var device = Devices.CreateLogDevice("D:\\logs\\hlog.log");

--- a/cs/playground/FasterLogSample/Program.cs
+++ b/cs/playground/FasterLogSample/Program.cs
@@ -10,7 +10,7 @@ namespace FasterLogSample
 {
     public class Program
     {
-        const int entryLength = 96;
+        const int entryLength = 996;
         static FasterLog log;
 
         static void ReportThread()
@@ -87,7 +87,7 @@ namespace FasterLogSample
                         throw new Exception("Invalid entry found at offset " + FindDiff(result, entrySpan));
                     }
 
-                    if (r.Next(100) < 0)
+                    if (r.Next(100) < 10)
                         log.Append(result);
 
                     if (iter.CurrentAddress - lastAddress > 500000000)
@@ -117,7 +117,6 @@ namespace FasterLogSample
             log = new FasterLog(new FasterLogSettings { LogDevice = device });
 
             new Thread(new ThreadStart(AppendThread)).Start();
-            // new Thread(new ThreadStart(AppendThread)).Start();
             
             // Can have multiple append threads if needed
             // new Thread(new ThreadStart(AppendThread)).Start();

--- a/cs/playground/FasterLogSample/Program.cs
+++ b/cs/playground/FasterLogSample/Program.cs
@@ -10,7 +10,7 @@ namespace FasterLogSample
 {
     public class Program
     {
-        const int entryLength = 996;
+        const int entryLength = 96;
         static FasterLog log;
 
         static void ReportThread()

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -784,13 +784,8 @@ namespace FASTER.core
                 return (address);
             }
 
-            int pageIndex = page % BufferSize;
-
-            //Invert the address if either the previous page is not flushed or if it is null
-            if (
-                (page >= -1 + BufferSize + (ClosedUntilAddress >> LogPageSizeBits)) ||
-                (!IsAllocated(pageIndex))
-               )
+            // Negate the address if page not ready to be used
+            if (CannotAllocate(page))
             {
                 address = -address;
             }
@@ -848,15 +843,10 @@ namespace FASTER.core
                 return;
             }
 
-            int pageIndex = p.Page % BufferSize;
-
             PageAlignedShiftHeadAddress(GetTailAddress());
 
-            // Check if we can allocate pageIndex at all
-            if (
-                (p.Page >= -1 + BufferSize + (ClosedUntilAddress >> LogPageSizeBits)) ||
-                (!IsAllocated(pageIndex))
-               )
+            // Check if we can allocate pageIndex
+            if (CannotAllocate(p.Page))
             {
                 return;
             }
@@ -868,6 +858,14 @@ namespace FASTER.core
                 TailPageCache = p.Page;
             }
             return;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool CannotAllocate(int page)
+        {
+            return
+                (page >= BufferSize + (ClosedUntilAddress >> LogPageSizeBits) - 1) ||
+                !IsAllocated(page % BufferSize);
         }
 
         /// <summary>

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -131,10 +131,6 @@ namespace FASTER.core
             long p = (long)handles[index].AddrOfPinnedObject();
             pointers[index] = (p + (sectorSize - 1)) & ~(sectorSize - 1);
             values[index] = tmp;
-
-            PageStatusIndicator[index].PageFlushCloseStatus.PageFlushStatus = PMMFlushStatus.Flushed;
-            PageStatusIndicator[index].PageFlushCloseStatus.PageCloseStatus = PMMCloseStatus.Closed;
-            Interlocked.MemoryBarrier();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -41,8 +41,8 @@ namespace FASTER.core
         private readonly bool keyBlittable = Utility.IsBlittable<Key>();
         private readonly bool valueBlittable = Utility.IsBlittable<Value>();
 
-        public GenericAllocator(LogSettings settings, SerializerSettings<Key, Value> serializerSettings, IFasterEqualityComparer<Key> comparer, Action<long, long> evictCallback = null, LightEpoch epoch = null)
-            : base(settings, comparer, evictCallback, epoch, null)
+        public GenericAllocator(LogSettings settings, SerializerSettings<Key, Value> serializerSettings, IFasterEqualityComparer<Key> comparer, Action<long, long> evictCallback = null, LightEpoch epoch = null, Action<long> flushCallback = null)
+            : base(settings, comparer, evictCallback, epoch, flushCallback)
         {
             SerializerSettings = serializerSettings;
 

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -200,9 +200,6 @@ namespace FASTER.core
         internal override void AllocatePage(int index)
         {
             values[index] = AllocatePage();
-            PageStatusIndicator[index].PageFlushCloseStatus.PageFlushStatus = PMMFlushStatus.Flushed;
-            PageStatusIndicator[index].PageFlushCloseStatus.PageCloseStatus = PMMCloseStatus.Closed;
-            Interlocked.MemoryBarrier();
         }
 
         internal Record<Key, Value>[] AllocatePage()

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -215,10 +215,6 @@ namespace FASTER.core
             long p = (long)handles[index].AddrOfPinnedObject();
             pointers[index] = (p + (sectorSize - 1)) & ~(sectorSize - 1);
             values[index] = tmp;
-
-            PageStatusIndicator[index].PageFlushCloseStatus.PageFlushStatus = PMMFlushStatus.Flushed;
-            PageStatusIndicator[index].PageFlushCloseStatus.PageCloseStatus = PMMCloseStatus.Closed;
-            Interlocked.MemoryBarrier();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -33,8 +33,8 @@ namespace FASTER.core
         internal readonly IVariableLengthStruct<Key> KeyLength;
         internal readonly IVariableLengthStruct<Value> ValueLength;
 
-        public VariableLengthBlittableAllocator(LogSettings settings, VariableLengthStructSettings<Key, Value> vlSettings, IFasterEqualityComparer<Key> comparer, Action<long, long> evictCallback = null, LightEpoch epoch = null)
-            : base(settings, comparer, evictCallback, epoch, null)
+        public VariableLengthBlittableAllocator(LogSettings settings, VariableLengthStructSettings<Key, Value> vlSettings, IFasterEqualityComparer<Key> comparer, Action<long, long> evictCallback = null, LightEpoch epoch = null, Action<long> flushCallback = null)
+            : base(settings, comparer, evictCallback, epoch, flushCallback)
         {
             values = new byte[BufferSize][];
             handles = new GCHandle[BufferSize];

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -1896,7 +1896,7 @@ namespace FASTER.core
                 hlog.CheckForAllocateComplete(ref logicalAddress);
                 if (logicalAddress < 0)
                 {
-                    Thread.Sleep(10);
+                    Thread.Yield();
                 }
             }
 
@@ -1923,7 +1923,7 @@ namespace FASTER.core
                 readcache.CheckForAllocateComplete(ref logicalAddress);
                 if (logicalAddress < 0)
                 {
-                    Thread.Sleep(10);
+                    Thread.Yield();
                 }
             }
 
@@ -2323,29 +2323,32 @@ namespace FASTER.core
             {
                 physicalAddress = readcache.GetPhysicalAddress(logicalAddress);
                 var recordSize = readcache.GetRecordSize(physicalAddress);
-                ref Key key = ref readcache.GetKey(physicalAddress);
                 ref RecordInfo info = ref readcache.GetInfo(physicalAddress);
-                entry.word = info.PreviousAddress;
-                if (!entry.ReadCache)
+                if (!info.Invalid)
                 {
-                    var hash = comparer.GetHashCode64(ref key);
-                    var tag = (ushort)((ulong)hash >> Constants.kHashTagShift);
-
-                    entry = default(HashBucketEntry);
-                    var tagExists = FindTag(hash, tag, ref bucket, ref slot, ref entry);
-                    while (tagExists && entry.ReadCache)
+                    ref Key key = ref readcache.GetKey(physicalAddress);
+                    entry.word = info.PreviousAddress;
+                    if (!entry.ReadCache)
                     {
-                        var updatedEntry = default(HashBucketEntry);
-                        updatedEntry.Tag = tag;
-                        updatedEntry.Address = info.PreviousAddress;
-                        updatedEntry.Pending = entry.Pending;
-                        updatedEntry.Tentative = false;
+                        var hash = comparer.GetHashCode64(ref key);
+                        var tag = (ushort)((ulong)hash >> Constants.kHashTagShift);
 
-                        if (entry.word == Interlocked.CompareExchange
-                            (ref bucket->bucket_entries[slot], updatedEntry.word, entry.word))
-                            break;
+                        entry = default(HashBucketEntry);
+                        var tagExists = FindTag(hash, tag, ref bucket, ref slot, ref entry);
+                        while (tagExists && entry.ReadCache)
+                        {
+                            var updatedEntry = default(HashBucketEntry);
+                            updatedEntry.Tag = tag;
+                            updatedEntry.Address = info.PreviousAddress;
+                            updatedEntry.Pending = entry.Pending;
+                            updatedEntry.Tentative = false;
 
-                        tagExists = FindTag(hash, tag, ref bucket, ref slot, ref entry);
+                            if (entry.word == Interlocked.CompareExchange
+                                (ref bucket->bucket_entries[slot], updatedEntry.word, entry.word))
+                                break;
+
+                            tagExists = FindTag(hash, tag, ref bucket, ref slot, ref entry);
+                        }
                     }
                 }
                 logicalAddress += recordSize;

--- a/cs/src/core/Index/FasterLog/FasterLog.cs
+++ b/cs/src/core/Index/FasterLog/FasterLog.cs
@@ -280,11 +280,9 @@ namespace FASTER.core
         /// </summary>
         private void Commit(long flushAddress)
         {
-            epoch.Resume();
             FasterLogRecoveryInfo info = new FasterLogRecoveryInfo();
-            info.FlushedUntilAddress = allocator.FlushedUntilAddress;
+            info.FlushedUntilAddress = flushAddress;
             info.BeginAddress = allocator.BeginAddress;
-            epoch.Suspend();
 
             // We can only allow serial monotonic synchronous commit
             lock (this)

--- a/cs/src/core/Index/FasterLog/FasterLog.cs
+++ b/cs/src/core/Index/FasterLog/FasterLog.cs
@@ -79,7 +79,8 @@ namespace FASTER.core
         {
             epoch.Resume();
             var length = entry.Length;
-            BlockAllocate(4 + length, out long logicalAddress);
+            var alignedLength = (length + 3) & ~3; // round up to multiple of 4
+            BlockAllocate(4 + alignedLength, out long logicalAddress);
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             *(int*)physicalAddress = length;
             fixed (byte* bp = &entry.GetPinnableReference())
@@ -97,7 +98,8 @@ namespace FASTER.core
         {
             epoch.Resume();
             var length = entry.Length;
-            BlockAllocate(4 + length, out long logicalAddress);
+            var alignedLength = (length + 3) & ~3; // round up to multiple of 4
+            BlockAllocate(4 + alignedLength, out long logicalAddress);
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             *(int*)physicalAddress = length;
             fixed (byte* bp = entry)
@@ -124,7 +126,8 @@ namespace FASTER.core
                 return false;
             }
             var length = entry.Length;
-            BlockAllocate(4 + length, out logicalAddress);
+            var alignedLength = (length + 3) & ~3; // round up to multiple of 4
+            BlockAllocate(4 + alignedLength, out logicalAddress);
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             *(int*)physicalAddress = length;
             fixed (byte* bp = entry)
@@ -151,7 +154,8 @@ namespace FASTER.core
                 return false;
             }
             var length = entry.Length;
-            BlockAllocate(4 + length, out logicalAddress);
+            var alignedLength = (length + 3) & ~3; // round up to multiple of 4
+            BlockAllocate(4 + alignedLength, out logicalAddress);
             var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
             *(int*)physicalAddress = length;
             fixed (byte* bp = &entry.GetPinnableReference())
@@ -172,7 +176,8 @@ namespace FASTER.core
             foreach (var entry in entries)
             {
                 var length = entry.Length;
-                BlockAllocate(4 + length, out logicalAddress);
+                var alignedLength = (length + 3) & ~3; // round up to multiple of 4
+                BlockAllocate(4 + alignedLength, out logicalAddress);
                 var physicalAddress = allocator.GetPhysicalAddress(logicalAddress);
                 *(int*)physicalAddress = length;
                 fixed (byte* bp = entry)

--- a/cs/src/core/Index/FasterLog/FasterLog.cs
+++ b/cs/src/core/Index/FasterLog/FasterLog.cs
@@ -262,7 +262,7 @@ namespace FASTER.core
                 allocator.CheckForAllocateComplete(ref logicalAddress);
                 if (logicalAddress < 0)
                 {
-                    Thread.Sleep(10);
+                    Thread.Yield();
                 }
             }
 

--- a/cs/src/core/Index/FasterLog/FasterLog.cs
+++ b/cs/src/core/Index/FasterLog/FasterLog.cs
@@ -293,7 +293,7 @@ namespace FASTER.core
                 {
                     logCommitManager.Commit(flushAddress, info.ToByteArray());
                     CommittedUntilAddress = flushAddress;
-                    info.DebugPrint();
+                    // info.DebugPrint();
                 }
             }
         }

--- a/cs/src/core/Index/FasterLog/FasterLogIterator.cs
+++ b/cs/src/core/Index/FasterLog/FasterLogIterator.cs
@@ -121,9 +121,9 @@ namespace FASTER.core
 
                 // Check if record fits on page, if not skip to next page
                 int length = *(int*)physicalAddress;
-                int recordSize = 4;
-                if (length > 0)
-                    recordSize += length;
+                int alignedLength = (length + 3) & ~3; // round up to multiple of 4
+
+                int recordSize = 4 + alignedLength;
                 if ((currentAddress & allocator.PageSizeMask) + recordSize > allocator.PageSize)
                 {
                     if (currentAddress >= headAddress)

--- a/cs/src/core/Index/FasterLog/FasterLogSettings.cs
+++ b/cs/src/core/Index/FasterLog/FasterLogSettings.cs
@@ -32,7 +32,7 @@ namespace FASTER.core
         /// <summary>
         /// Total size of in-memory part of log, in bits
         /// </summary>
-        public int MemorySizeBits = 26;
+        public int MemorySizeBits = 24;
 
         /// <summary>
         /// Log commit manager

--- a/cs/src/core/Index/FasterLog/FasterLogSettings.cs
+++ b/cs/src/core/Index/FasterLog/FasterLogSettings.cs
@@ -25,14 +25,15 @@ namespace FASTER.core
         public int PageSizeBits = 22;
 
         /// <summary>
+        /// Total size of in-memory part of log, in bits
+        /// Num pages = 2^(MemorySizeBits-PageSizeBits)
+        /// </summary>
+        public int MemorySizeBits = 24;
+
+        /// <summary>
         /// Size of a segment (group of pages), in bits
         /// </summary>
         public int SegmentSizeBits = 30;
-
-        /// <summary>
-        /// Total size of in-memory part of log, in bits
-        /// </summary>
-        public int MemorySizeBits = 24;
 
         /// <summary>
         /// Log commit manager

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -433,7 +433,8 @@ namespace FASTER.core
                 ((headAddress == untilAddress) && (GetOffsetInPage(headAddress) == 0)) // Empty in-memory page
                 )
             {
-                AllocatePage(GetPageIndexForAddress(headAddress));
+                if (!IsAllocated(GetPageIndexForAddress(headAddress)))
+                    AllocatePage(GetPageIndexForAddress(headAddress));
             }
             else
             {


### PR DESCRIPTION
* Adding support for low memory footprint (4 pages)
* Added support for odd-sized payloads in presence of holes in log
* Fixed concurrency issue that occurs with low num of pages
* Improved max throughput by eliminating a 10ms sleep in BlockAllocate
* Misc cleanup of logic to track flush and close addresses in log