### PR TITLE
Fix nuget links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![NuGet](https://img.shields.io/nuget/v/FASTER.svg)](https://www.nuget.org/packages/FASTER/)
+[![NuGet](https://img.shields.io/nuget/v/Microsoft.FASTER.svg)](https://www.nuget.org/packages/Microsoft.FASTER/)
 [![Build Status](https://dev.azure.com/ms/FASTER/_apis/build/status/Microsoft.FASTER)](https://dev.azure.com/ms/FASTER/_build/latest?definitionId=8)
 [![Gitter](https://badges.gitter.im/Microsoft/FASTER.svg)](https://gitter.im/Microsoft/FASTER?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
@@ -30,7 +30,7 @@ Visit our [research website](http://aka.ms/FASTER) for technical details and pap
 :new: For FASTER usage and getting started information, head over to our 
 [GitHub Pages](https://microsoft.github.io/FASTER) website. A detailed guide to getting started with FASTER 
 C# is also available in the repository at [this link](https://github.com/Microsoft/FASTER/blob/master/cs/README.md). FASTER 
-C# binaries are available via [NuGet](https://www.nuget.org/packages/FASTER/).
+C# binaries are available via [NuGet](https://www.nuget.org/packages/Microsoft.FASTER/).
 
 :new: You can take a look at the project roadmap [here](https://microsoft.github.io/FASTER/roadmap).
 


### PR DESCRIPTION
the package is now hosted at https://www.nuget.org/packages/Microsoft.FASTER/