### PR TITLE
[C++][tests] Extract common (simple) key and value definitions for reuse

### DIFF
--- a/cc/src/core/key_hash.h
+++ b/cc/src/core/key_hash.h
@@ -23,6 +23,7 @@ struct KeyHash {
 
   KeyHash& operator=(const KeyHash& other) {
     control_ = other.control_;
+    return *this;
   }
 
   /// Truncate the key hash's address to get the page_index into a hash table of specified size.

--- a/cc/test/in_memory_test.cc
+++ b/cc/test/in_memory_test.cc
@@ -4,69 +4,21 @@
 #include <cstdint>
 #include <cstring>
 #include <deque>
-#include <functional>
 #include <thread>
 #include "gtest/gtest.h"
 
 #include "core/faster.h"
 #include "device/null_disk.h"
 
+#include "test_types.h"
+
 using namespace FASTER::core;
+using FASTER::test::FixedSizeKey;
+using FASTER::test::SimpleAtomicValue;
+
 TEST(InMemFaster, UpsertRead) {
-  class alignas(2) Key {
-   public:
-    Key(uint8_t key)
-      : key_{ key } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      std::hash<uint8_t> hash_fn;
-      return KeyHash{ hash_fn(key_) };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-   private:
-    uint8_t key_;
-  };
-
-  class UpsertContext;
-  class ReadContext;
-
-  class Value {
-   public:
-    Value()
-      : value_{ 0 } {
-    }
-    Value(const Value& other)
-      : value_{ other.value_ } {
-    }
-    Value(uint8_t value)
-      : value_{ value } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Value));
-    }
-
-    friend class UpsertContext;
-    friend class ReadContext;
-
-   private:
-    union {
-      uint8_t value_;
-      std::atomic<uint8_t> atomic_value_;
-    };
-  };
+  using Key = FixedSizeKey<uint8_t>;
+  using Value = SimpleAtomicValue<uint8_t>;
 
   class UpsertContext : public IAsyncContext {
    public:
@@ -91,10 +43,10 @@ TEST(InMemFaster, UpsertRead) {
     }
     /// Non-atomic and atomic Put() methods.
     inline void Put(Value& value) {
-      value.value_ = 23;
+      value.value = 23;
     }
     inline bool PutAtomic(Value& value) {
-      value.atomic_value_.store(42);
+      value.atomic_value.store(42);
       return true;
     }
 
@@ -132,7 +84,7 @@ TEST(InMemFaster, UpsertRead) {
       ASSERT_TRUE(false);
     }
     inline void GetAtomic(const Value& value) {
-      output = value.atomic_value_.load();
+      output = value.atomic_value.load();
     }
 
    protected:
@@ -201,62 +153,15 @@ TEST(InMemFaster, UpsertRead) {
 
 /// The hash always returns "0," so the FASTER store devolves into a linked list.
 TEST(InMemFaster, UpsertRead_DummyHash) {
-  class UpsertContext;
-  class ReadContext;
-
-  class Key {
+  class DummyHash {
    public:
-    Key(uint16_t key)
-      : key_{ key } {
+    inline size_t operator()(const uint16_t& key) const {
+      return 42;
     }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      return KeyHash{ 42 };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-    friend class UpsertContext;
-    friend class ReadContext;
-
-   private:
-    uint16_t key_;
   };
 
-  class Value {
-   public:
-    Value()
-      : value_{ 0 } {
-    }
-    Value(const Value& other)
-      : value_{ other.value_ } {
-    }
-    Value(uint16_t value)
-      : value_{ value } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Value));
-    }
-
-    friend class UpsertContext;
-    friend class ReadContext;
-
-   private:
-    union {
-      uint16_t value_;
-      std::atomic<uint16_t> atomic_value_;
-    };
-  };
+  using Key = FixedSizeKey<uint16_t, DummyHash>;
+  using Value = SimpleAtomicValue<uint16_t>;
 
   class UpsertContext : public IAsyncContext {
    public:
@@ -281,10 +186,10 @@ TEST(InMemFaster, UpsertRead_DummyHash) {
     }
     /// Non-atomic and atomic Put() methods.
     inline void Put(Value& value) {
-      value.value_ = key_.key_;
+      value.value = key_.key;
     }
     inline bool PutAtomic(Value& value) {
-      value.atomic_value_.store(key_.key_);
+      value.atomic_value.store(key_.key);
       return true;
     }
 
@@ -322,7 +227,7 @@ TEST(InMemFaster, UpsertRead_DummyHash) {
       ASSERT_TRUE(false);
     }
     inline void GetAtomic(const Value& value) {
-      output = value.atomic_value_.load();
+      output = value.atomic_value.load();
     }
 
    protected:
@@ -368,31 +273,7 @@ TEST(InMemFaster, UpsertRead_DummyHash) {
 }
 
 TEST(InMemFaster, UpsertRead_Concurrent) {
-  class Key {
-   public:
-    Key(uint32_t key)
-      : key_{ key } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      std::hash<uint32_t> hash_fn;
-      return KeyHash{ hash_fn(key_) };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-   private:
-    uint32_t key_;
-  };
+  using Key = FixedSizeKey<uint32_t>;
 
   class UpsertContext;
   class ReadContext;
@@ -594,31 +475,7 @@ TEST(InMemFaster, UpsertRead_Concurrent) {
 }
 
 TEST(InMemFaster, UpsertRead_ResizeValue_Concurrent) {
-  class Key {
-   public:
-    Key(uint32_t key)
-      : key_{ key } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      std::hash<uint32_t> hash_fn;
-      return KeyHash{ hash_fn(key_) };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-   private:
-    uint32_t key_;
-  };
+  using Key = FixedSizeKey<uint32_t>;
 
   class UpsertContext;
   class ReadContext;
@@ -914,57 +771,8 @@ TEST(InMemFaster, UpsertRead_ResizeValue_Concurrent) {
   }
 }
 TEST(InMemFaster, Rmw) {
-  class Key {
-   public:
-    Key(uint64_t key)
-      : key_{ key } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      std::hash<uint64_t> hash_fn;
-      return KeyHash{ hash_fn(key_) };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-   private:
-    uint64_t key_;
-  };
-
-  class RmwContext;
-  class ReadContext;
-
-  class Value {
-   public:
-    Value()
-      : value_{ 0 } {
-    }
-    Value(const Value& other)
-      : value_{ other.value_ } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Value));
-    }
-
-    friend class RmwContext;
-    friend class ReadContext;
-
-   private:
-    union {
-      int32_t value_;
-      std::atomic<int32_t> atomic_value_;
-    };
-  };
+  using Key = FixedSizeKey<uint64_t>;
+  using Value = SimpleAtomicValue<uint32_t>;
 
   class RmwContext : public IAsyncContext {
    public:
@@ -993,13 +801,13 @@ TEST(InMemFaster, Rmw) {
       return sizeof(value_t);
     }
     inline void RmwInitial(Value& value) {
-      value.value_ = incr_;
+      value.value = incr_;
     }
     inline void RmwCopy(const Value& old_value, Value& value) {
-      value.value_ = old_value.value_ + incr_;
+      value.value = old_value.value + incr_;
     }
     inline bool RmwAtomic(Value& value) {
-      value.atomic_value_.fetch_add(incr_);
+      value.atomic_value.fetch_add(incr_);
       return true;
     }
 
@@ -1038,7 +846,7 @@ TEST(InMemFaster, Rmw) {
       ASSERT_TRUE(false);
     }
     inline void GetAtomic(const Value& value) {
-      output = value.atomic_value_.load();
+      output = value.atomic_value.load();
     }
 
    protected:
@@ -1106,57 +914,8 @@ TEST(InMemFaster, Rmw) {
 }
 
 TEST(InMemFaster, Rmw_Concurrent) {
-  class Key {
-   public:
-    Key(uint64_t key)
-      : key_{ key } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      std::hash<uint64_t> hash_fn;
-      return KeyHash{ hash_fn(key_) };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-   private:
-    uint64_t key_;
-  };
-
-  class RmwContext;
-  class ReadContext;
-
-  class Value {
-   public:
-    Value()
-      : value_{ 0 } {
-    }
-    Value(const Value& other)
-      : value_{ other.value_ } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Value));
-    }
-
-    friend class RmwContext;
-    friend class ReadContext;
-
-   private:
-    union {
-      int64_t value_;
-      std::atomic<int64_t> atomic_value_;
-    };
-  };
+  using Key = FixedSizeKey<uint64_t>;
+  using Value = SimpleAtomicValue<int64_t>;
 
   class RmwContext : public IAsyncContext {
    public:
@@ -1186,13 +945,13 @@ TEST(InMemFaster, Rmw_Concurrent) {
     }
 
     inline void RmwInitial(Value& value) {
-      value.value_ = incr_;
+      value.value = incr_;
     }
     inline void RmwCopy(const Value& old_value, Value& value) {
-      value.value_ = old_value.value_ + incr_;
+      value.value = old_value.value + incr_;
     }
     inline bool RmwAtomic(Value& value) {
-      value.atomic_value_.fetch_add(incr_);
+      value.atomic_value.fetch_add(incr_);
       return true;
     }
 
@@ -1231,7 +990,7 @@ TEST(InMemFaster, Rmw_Concurrent) {
       ASSERT_TRUE(false);
     }
     inline void GetAtomic(const Value& value) {
-      output = value.atomic_value_.load();
+      output = value.atomic_value.load();
     }
 
    protected:
@@ -1323,31 +1082,7 @@ TEST(InMemFaster, Rmw_Concurrent) {
 }
 
 TEST(InMemFaster, Rmw_ResizeValue_Concurrent) {
-  class Key {
-   public:
-    Key(uint64_t key)
-      : key_{ key } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      std::hash<uint64_t> hash_fn;
-      return KeyHash{ hash_fn(key_) };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-   private:
-    uint64_t key_;
-  };
+  using Key = FixedSizeKey<uint64_t>;
 
   class RmwContext;
   class ReadContext;
@@ -1663,31 +1398,7 @@ TEST(InMemFaster, Rmw_ResizeValue_Concurrent) {
 }
 
 TEST(InMemFaster, Rmw_GrowString_Concurrent) {
-class Key {
-public:
-    Key(uint64_t key)
-            : key_{ key } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      std::hash<uint64_t> hash_fn;
-      return KeyHash{ hash_fn(key_) };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-private:
-    uint64_t key_;
-};
+  using Key = FixedSizeKey<uint64_t>;
 
 class RmwContext;
 class ReadContext;
@@ -1893,57 +1604,8 @@ store.StopSession();
 }
 
 TEST(InMemFaster, GrowHashTable) {
-  class Key {
-   public:
-    Key(uint64_t key)
-      : key_{ key } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      std::hash<uint64_t> hash_fn;
-      return KeyHash{ hash_fn(key_) };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-   private:
-    uint64_t key_;
-  };
-
-  class RmwContext;
-  class ReadContext;
-
-  class Value {
-   public:
-    Value()
-      : value_{ 0 } {
-    }
-    Value(const Value& other)
-      : value_{ other.value_ } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Value));
-    }
-
-    friend class RmwContext;
-    friend class ReadContext;
-
-   private:
-    union {
-      int64_t value_;
-      std::atomic<int64_t> atomic_value_;
-    };
-  };
+  using Key = FixedSizeKey<uint64_t>;
+  using Value = SimpleAtomicValue<int64_t>;
 
   class RmwContext : public IAsyncContext {
    public:
@@ -1973,13 +1635,13 @@ TEST(InMemFaster, GrowHashTable) {
     }
 
     inline void RmwInitial(Value& value) {
-      value.value_ = incr_;
+      value.value = incr_;
     }
     inline void RmwCopy(const Value& old_value, Value& value) {
-      value.value_ = old_value.value_ + incr_;
+      value.value = old_value.value + incr_;
     }
     inline bool RmwAtomic(Value& value) {
-      value.atomic_value_.fetch_add(incr_);
+      value.atomic_value.fetch_add(incr_);
       return true;
     }
 
@@ -2018,7 +1680,7 @@ TEST(InMemFaster, GrowHashTable) {
       ASSERT_TRUE(false);
     }
     inline void GetAtomic(const Value& value) {
-      output = value.atomic_value_.load();
+      output = value.atomic_value.load();
     }
 
    protected:
@@ -2214,34 +1876,7 @@ TEST(InMemFaster, UpsertRead_VariableLengthKey) {
       }
   };
 
-  class UpsertContext;
-  class ReadContext;
-
-  class Value {
-  public:
-      Value()
-              : value_{ 0 } {
-      }
-      Value(const Value& other)
-              : value_{ other.value_ } {
-      }
-      Value(uint8_t value)
-              : value_{ value } {
-      }
-
-      inline static constexpr uint32_t size() {
-        return static_cast<uint32_t>(sizeof(Value));
-      }
-
-      friend class UpsertContext;
-      friend class ReadContext;
-
-  private:
-      union {
-          uint8_t value_;
-          std::atomic<uint8_t> atomic_value_;
-      };
-  };
+  using Value = SimpleAtomicValue<uint8_t>;
 
   class UpsertContext : public IAsyncContext {
   public:
@@ -2266,10 +1901,10 @@ TEST(InMemFaster, UpsertRead_VariableLengthKey) {
       }
       /// Non-atomic and atomic Put() methods.
       inline void Put(Value& value) {
-        value.value_ = 23;
+        value.value = 23;
       }
       inline bool PutAtomic(Value& value) {
-        value.atomic_value_.store(42);
+        value.atomic_value.store(42);
         return true;
       }
 
@@ -2307,7 +1942,7 @@ TEST(InMemFaster, UpsertRead_VariableLengthKey) {
         ASSERT_TRUE(false);
       }
       inline void GetAtomic(const Value& value) {
-        output = value.atomic_value_.load();
+        output = value.atomic_value.load();
       }
 
   protected:

--- a/cc/test/recovery_test.h
+++ b/cc/test/recovery_test.h
@@ -5,7 +5,11 @@
 
 #include <experimental/filesystem>
 
+#include "test_types.h"
+
 using namespace FASTER;
+using FASTER::test::FixedSizeKey;
+using FASTER::test::SimpleAtomicValue;
 
 /// Disk's log uses 32 MB segments.
 typedef FASTER::device::FileSystemDisk<handler_t, 33554432L> disk_t;
@@ -1153,60 +1157,8 @@ TEST(CLASS, Serial_VariableLengthKey) {
 }
 
 TEST(CLASS, Concurrent_Insert_Small) {
-  class Key {
-   public:
-    Key(uint32_t key)
-      : key_{ key } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      std::hash<uint32_t> hash_fn{};
-      return KeyHash{ hash_fn(key_) };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-   private:
-    uint32_t key_;
-  };
-  static_assert(sizeof(Key) == 4, "sizeof(Key) != 4");
-  static_assert(alignof(Key) == 4, "alignof(Key) != 4");
-
-  class UpsertContext;
-  class ReadContext1;
-  class ReadContext2;
-
-  class Value {
-   public:
-    Value()
-      : val_{ 0 } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Value));
-    }
-
-    friend class UpsertContext;
-    friend class ReadContext1;
-    friend class ReadContext2;
-
-   private:
-    union {
-      std::atomic<uint32_t> atomic_val_;
-      uint32_t val_;
-    };
-  };
-  static_assert(sizeof(Value) == 4, "sizeof(Value) != 4");
-  static_assert(alignof(Value) == 4, "alignof(Value) != 4");
+  using Key = FixedSizeKey<uint32_t>;
+  using Value = SimpleAtomicValue<uint32_t>;
 
   class UpsertContext : public IAsyncContext {
    public:
@@ -1233,10 +1185,10 @@ TEST(CLASS, Concurrent_Insert_Small) {
     }
     /// Non-atomic and atomic Put() methods.
     inline void Put(Value& value) {
-      value.val_ = val_;
+      value.value = val_;
     }
     inline bool PutAtomic(Value& value) {
-      value.atomic_val_.store(val_);
+      value.atomic_value.store(val_);
       return true;
     }
 
@@ -1309,10 +1261,10 @@ TEST(CLASS, Concurrent_Insert_Small) {
     }
 
     inline void Get(const Value& value) {
-      val_ = value.val_;
+      val_ = value.value;
     }
     inline void GetAtomic(const Value& value) {
-      val_ = value.atomic_val_.load();
+      val_ = value.atomic_value.load();
     }
 
     uint64_t val() const {
@@ -1468,10 +1420,10 @@ TEST(CLASS, Concurrent_Insert_Small) {
     }
 
     inline void Get(const Value& value) {
-      val_ = value.val_;
+      val_ = value.value;
     }
     inline void GetAtomic(const Value& value) {
-      val_ = value.atomic_val_.load();
+      val_ = value.atomic_value.load();
     }
 
     uint64_t val() const {
@@ -1571,60 +1523,8 @@ TEST(CLASS, Concurrent_Insert_Small) {
 }
 
 TEST(CLASS, Concurrent_Insert_Large) {
-  class Key {
-   public:
-    Key(uint32_t key)
-      : key_{ key } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      std::hash<uint32_t> hash_fn{};
-      return KeyHash{ hash_fn(key_) };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-   private:
-    uint32_t key_;
-  };
-  static_assert(sizeof(Key) == 4, "sizeof(Key) != 4");
-  static_assert(alignof(Key) == 4, "alignof(Key) != 4");
-
-  class UpsertContext;
-  class ReadContext1;
-  class ReadContext2;
-
-  class Value {
-   public:
-    Value()
-      : val_{ 0 } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Value));
-    }
-
-    friend class UpsertContext;
-    friend class ReadContext1;
-    friend class ReadContext2;
-
-   private:
-    union {
-      std::atomic<uint32_t> atomic_val_;
-      uint32_t val_;
-    };
-  };
-  static_assert(sizeof(Value) == 4, "sizeof(Value) != 4");
-  static_assert(alignof(Value) == 4, "alignof(Value) != 4");
+  using Key = FixedSizeKey<uint32_t>;
+  using Value = SimpleAtomicValue<uint32_t>;
 
   class UpsertContext : public IAsyncContext {
    public:
@@ -1651,10 +1551,10 @@ TEST(CLASS, Concurrent_Insert_Large) {
     }
     /// Non-atomic and atomic Put() methods.
     inline void Put(Value& value) {
-      value.val_ = val_;
+      value.value = val_;
     }
     inline bool PutAtomic(Value& value) {
-      value.atomic_val_.store(val_);
+      value.atomic_value.store(val_);
       return true;
     }
 
@@ -1727,10 +1627,10 @@ TEST(CLASS, Concurrent_Insert_Large) {
     }
 
     inline void Get(const Value& value) {
-      val_ = value.val_;
+      val_ = value.value;
     }
     inline void GetAtomic(const Value& value) {
-      val_ = value.atomic_val_.load();
+      val_ = value.atomic_value.load();
     }
 
     uint64_t val() const {
@@ -1884,10 +1784,10 @@ TEST(CLASS, Concurrent_Insert_Large) {
     }
 
     inline void Get(const Value& value) {
-      val_ = value.val_;
+      val_ = value.value;
     }
     inline void GetAtomic(const Value& value) {
-      val_ = value.atomic_val_.load();
+      val_ = value.atomic_value.load();
     }
 
     uint64_t val() const {
@@ -1987,59 +1887,8 @@ TEST(CLASS, Concurrent_Insert_Large) {
 }
 
 TEST(CLASS, Concurrent_Update_Small) {
-  class Key {
-   public:
-    Key(uint32_t key)
-      : key_{ key } {
-    }
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      std::hash<uint32_t> hash_fn{};
-      return KeyHash{ hash_fn(key_) };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-   private:
-    uint32_t key_;
-  };
-  static_assert(sizeof(Key) == 4, "sizeof(Key) != 4");
-  static_assert(alignof(Key) == 4, "alignof(Key) != 4");
-
-  class UpsertContext;
-  class ReadContext1;
-  class ReadContext2;
-
-  class Value {
-   public:
-    Value()
-      : val_{ 0 } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Value));
-    }
-
-    friend class UpsertContext;
-    friend class ReadContext1;
-    friend class ReadContext2;
-
-   private:
-    union {
-      std::atomic<uint32_t> atomic_val_;
-      uint32_t val_;
-    };
-  };
-  static_assert(sizeof(Value) == 4, "sizeof(Value) != 4");
-  static_assert(alignof(Value) == 4, "alignof(Value) != 4");
+  using Key = FixedSizeKey<uint32_t>;
+  using Value = SimpleAtomicValue<uint32_t>;
 
   class UpsertContext : public IAsyncContext {
    public:
@@ -2066,10 +1915,10 @@ TEST(CLASS, Concurrent_Update_Small) {
     }
     /// Non-atomic and atomic Put() methods.
     inline void Put(Value& value) {
-      value.val_ = val_;
+      value.value = val_;
     }
     inline bool PutAtomic(Value& value) {
-      value.atomic_val_.store(val_);
+      value.atomic_value.store(val_);
       return true;
     }
 
@@ -2142,10 +1991,10 @@ TEST(CLASS, Concurrent_Update_Small) {
     }
 
     inline void Get(const Value& value) {
-      val_ = value.val_;
+      val_ = value.value;
     }
     inline void GetAtomic(const Value& value) {
-      val_ = value.atomic_val_.load();
+      val_ = value.atomic_value.load();
     }
 
     uint64_t val() const {
@@ -2311,10 +2160,10 @@ TEST(CLASS, Concurrent_Update_Small) {
     }
 
     inline void Get(const Value& value) {
-      val_ = value.val_;
+      val_ = value.value;
     }
     inline void GetAtomic(const Value& value) {
-      val_ = value.atomic_val_.load();
+      val_ = value.atomic_value.load();
     }
 
     uint64_t val() const {
@@ -2415,60 +2264,8 @@ TEST(CLASS, Concurrent_Update_Small) {
 }
 
 TEST(CLASS, Concurrent_Update_Large) {
-  class Key {
-   public:
-    Key(uint32_t key)
-      : key_{ key } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      std::hash<uint32_t> hash_fn{};
-      return KeyHash{ hash_fn(key_) };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-   private:
-    uint32_t key_;
-  };
-  static_assert(sizeof(Key) == 4, "sizeof(Key) != 4");
-  static_assert(alignof(Key) == 4, "alignof(Key) != 4");
-
-  class UpsertContext;
-  class ReadContext1;
-  class ReadContext2;
-
-  class Value {
-   public:
-    Value()
-      : val_{ 0 } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Value));
-    }
-
-    friend class UpsertContext;
-    friend class ReadContext1;
-    friend class ReadContext2;
-
-   private:
-    union {
-      std::atomic<uint32_t> atomic_val_;
-      uint32_t val_;
-    };
-  };
-  static_assert(sizeof(Value) == 4, "sizeof(Value) != 4");
-  static_assert(alignof(Value) == 4, "alignof(Value) != 4");
+  using Key = FixedSizeKey<uint32_t>;
+  using Value = SimpleAtomicValue<uint32_t>;
 
   class UpsertContext : public IAsyncContext {
    public:
@@ -2495,10 +2292,10 @@ TEST(CLASS, Concurrent_Update_Large) {
     }
     /// Non-atomic and atomic Put() methods.
     inline void Put(Value& value) {
-      value.val_ = val_;
+      value.value = val_;
     }
     inline bool PutAtomic(Value& value) {
-      value.atomic_val_.store(val_);
+      value.atomic_value.store(val_);
       return true;
     }
 
@@ -2579,10 +2376,10 @@ TEST(CLASS, Concurrent_Update_Large) {
     }
 
     inline void Get(const Value& value) {
-      val_ = value.val_;
+      val_ = value.value;
     }
     inline void GetAtomic(const Value& value) {
-      val_ = value.atomic_val_.load();
+      val_ = value.atomic_value.load();
     }
 
     uint64_t val() const {
@@ -2763,10 +2560,10 @@ TEST(CLASS, Concurrent_Update_Large) {
     }
 
     inline void Get(const Value& value) {
-      val_ = value.val_;
+      val_ = value.value;
     }
     inline void GetAtomic(const Value& value) {
-      val_ = value.atomic_val_.load();
+      val_ = value.atomic_value.load();
     }
 
     uint64_t val() const {
@@ -2867,63 +2664,8 @@ TEST(CLASS, Concurrent_Update_Large) {
 }
 
 TEST(CLASS, Concurrent_Rmw_Small) {
-  class RmwContext;
-
-  class Key {
-   public:
-    Key(uint32_t key)
-      : key_{ key } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      std::hash<uint32_t> hash_fn{};
-      return KeyHash{ hash_fn(key_) };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-    friend class RmwContext;
-
-   private:
-    uint32_t key_;
-  };
-  static_assert(sizeof(Key) == 4, "sizeof(Key) != 4");
-  static_assert(alignof(Key) == 4, "alignof(Key) != 4");
-
-  class ReadContext1;
-  class ReadContext2;
-
-  class Value {
-   public:
-    Value()
-      : val_{ 0 } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Value));
-    }
-
-    friend class RmwContext;
-    friend class ReadContext1;
-    friend class ReadContext2;
-
-   private:
-    union {
-      std::atomic<uint32_t> atomic_val_;
-      uint32_t val_;
-    };
-  };
-  static_assert(sizeof(Value) == 4, "sizeof(Value) != 4");
-  static_assert(alignof(Value) == 4, "alignof(Value) != 4");
+  using Key = FixedSizeKey<uint32_t>;
+  using Value = SimpleAtomicValue<uint32_t>;
 
   class RmwContext : public IAsyncContext {
    public:
@@ -2953,13 +2695,13 @@ TEST(CLASS, Concurrent_Rmw_Small) {
     }
     /// Non-atomic and atomic Put() methods.
     inline void RmwInitial(Value& value) {
-      value.val_ = key_.key_;
+      value.value = key_.key;
     }
     inline void RmwCopy(const value_t& old_value, value_t& value) {
-      value.val_ = old_value.val_ + delta_;
+      value.value = old_value.value + delta_;
     }
     inline bool RmwAtomic(value_t& value) {
-      value.atomic_val_ += delta_;
+      value.atomic_value += delta_;
       return true;
     }
    protected:
@@ -3026,10 +2768,10 @@ TEST(CLASS, Concurrent_Rmw_Small) {
     }
 
     inline void Get(const Value& value) {
-      val_ = value.val_;
+      val_ = value.value;
     }
     inline void GetAtomic(const Value& value) {
-      val_ = value.atomic_val_.load();
+      val_ = value.atomic_value.load();
     }
 
     uint64_t val() const {
@@ -3206,10 +2948,10 @@ TEST(CLASS, Concurrent_Rmw_Small) {
     }
 
     inline void Get(const Value& value) {
-      val_ = value.val_;
+      val_ = value.value;
     }
     inline void GetAtomic(const Value& value) {
-      val_ = value.atomic_val_.load();
+      val_ = value.atomic_value.load();
     }
 
     uint64_t val() const {
@@ -3310,63 +3052,8 @@ TEST(CLASS, Concurrent_Rmw_Small) {
 }
 
 TEST(CLASS, Concurrent_Rmw_Large) {
-  class RmwContext;
-
-  class Key {
-   public:
-    Key(uint32_t key)
-      : key_{ key } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Key));
-    }
-    inline KeyHash GetHash() const {
-      std::hash<uint32_t> hash_fn{};
-      return KeyHash{ hash_fn(key_) };
-    }
-
-    /// Comparison operators.
-    inline bool operator==(const Key& other) const {
-      return key_ == other.key_;
-    }
-    inline bool operator!=(const Key& other) const {
-      return key_ != other.key_;
-    }
-
-    friend class RmwContext;
-
-   private:
-    uint32_t key_;
-  };
-  static_assert(sizeof(Key) == 4, "sizeof(Key) != 4");
-  static_assert(alignof(Key) == 4, "alignof(Key) != 4");
-
-  class ReadContext1;
-  class ReadContext2;
-
-  class Value {
-   public:
-    Value()
-      : val_{ 0 } {
-    }
-
-    inline static constexpr uint32_t size() {
-      return static_cast<uint32_t>(sizeof(Value));
-    }
-
-    friend class RmwContext;
-    friend class ReadContext1;
-    friend class ReadContext2;
-
-   private:
-    union {
-      std::atomic<uint32_t> atomic_val_;
-      uint32_t val_;
-    };
-  };
-  static_assert(sizeof(Value) == 4, "sizeof(Value) != 4");
-  static_assert(alignof(Value) == 4, "alignof(Value) != 4");
+  using Key = FixedSizeKey<uint32_t>;
+  using Value = SimpleAtomicValue<uint32_t>;
 
   class RmwContext : public IAsyncContext {
    public:
@@ -3396,13 +3083,13 @@ TEST(CLASS, Concurrent_Rmw_Large) {
     }
     /// Non-atomic and atomic Put() methods.
     inline void RmwInitial(Value& value) {
-      value.val_ = key_.key_;
+      value.value = key_.key;
     }
     inline void RmwCopy(const value_t& old_value, value_t& value) {
-      value.val_ = old_value.val_ + delta_;
+      value.value = old_value.value + delta_;
     }
     inline bool RmwAtomic(value_t& value) {
-      value.atomic_val_ += delta_;
+      value.atomic_value += delta_;
       return true;
     }
    protected:
@@ -3470,10 +3157,10 @@ TEST(CLASS, Concurrent_Rmw_Large) {
     }
 
     inline void Get(const Value& value) {
-      val_ = value.val_;
+      val_ = value.value;
     }
     inline void GetAtomic(const Value& value) {
-      val_ = value.atomic_val_.load();
+      val_ = value.atomic_value.load();
     }
 
     uint64_t val() const {
@@ -3677,10 +3364,10 @@ TEST(CLASS, Concurrent_Rmw_Large) {
     }
 
     inline void Get(const Value& value) {
-      val_ = value.val_;
+      val_ = value.value;
     }
     inline void GetAtomic(const Value& value) {
-      val_ = value.atomic_val_.load();
+      val_ = value.atomic_value.load();
     }
 
     uint64_t val() const {

--- a/cc/test/test_types.h
+++ b/cc/test/test_types.h
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include <atomic>
+#include <functional>
+
+namespace FASTER {
+namespace test {
+
+template<class T, class HashFn = std::hash<T>>
+class FixedSizeKey {
+ public:
+  FixedSizeKey(T value)
+    : key{ value }
+  {}
+
+  FixedSizeKey(const FixedSizeKey&) = default;
+
+  inline static constexpr uint32_t size() {
+    return static_cast<uint32_t>(sizeof(FixedSizeKey));
+  }
+
+  inline KeyHash GetHash() const {
+    HashFn hash_fn;
+    return KeyHash{ hash_fn(key) };
+  }
+
+  inline bool operator==(const FixedSizeKey& other) const {
+    return key == other.key;
+  }
+  inline bool operator!=(const FixedSizeKey& other) const {
+    return key != other.key;
+  }
+
+  T key;
+};
+
+template<class T>
+class SimpleAtomicValue {
+ public:
+  SimpleAtomicValue()
+    : value{}
+  {}
+
+  SimpleAtomicValue(T value_)
+    : value{ value_ }
+  {}
+
+  SimpleAtomicValue(const SimpleAtomicValue& other)
+    : value{ other.value }
+  {}
+
+  inline static constexpr uint32_t size() {
+    return static_cast<uint32_t>(sizeof(SimpleAtomicValue));
+  }
+
+  union {
+    T value;
+    std::atomic<T> atomic_value;
+  };
+};
+
+}
+} // namespace FASTER::test


### PR DESCRIPTION
This is a small refactoring of tests for C++ version of FASTER.