### PR TITLE
cc: GetAtomic: change return type to bool

### DIFF
--- a/cc/benchmark-dir/benchmark.cc
+++ b/cc/benchmark-dir/benchmark.cc
@@ -141,7 +141,7 @@ class ReadContext : public IAsyncContext {
 
   // For this benchmark, we don't copy out, so these are no-ops.
   inline void Get(const value_t& value) { }
-  inline void GetAtomic(const value_t& value) { }
+  inline bool GetAtomic(const value_t& value) { return true; }
 
  protected:
   /// The explicit interface requires a DeepCopy_Internal() implementation.

--- a/cc/playground/sum_store-dir/sum_store.h
+++ b/cc/playground/sum_store-dir/sum_store.h
@@ -142,8 +142,9 @@ class ReadContext : public IAsyncContext {
   inline void Get(const value_t& value) {
     *result_ = value.num_clicks;
   }
-  inline void GetAtomic(const value_t& value) {
+  inline bool GetAtomic(const value_t& value) {
     *result_ = value.atomic_num_clicks;
+    return true;
   }
 
  protected:

--- a/cc/src/core/faster.h
+++ b/cc/src/core/faster.h
@@ -764,8 +764,10 @@ inline OperationStatus FasterKv<K, V, D>::InternalRead(C& pending_context) const
   if(address >= safe_read_only_address) {
     // Mutable or fuzzy region
     // concurrent read
-    pending_context.GetAtomic(hlog.Get(address));
-    return OperationStatus::SUCCESS;
+    if (pending_context.GetAtomic(hlog.Get(address))) {
+      return OperationStatus::SUCCESS;
+    }
+    return OperationStatus::RETRY_NOW;
   } else if(address >= head_address) {
     // Immutable region
     // single-thread read

--- a/cc/src/core/internal_contexts.h
+++ b/cc/src/core/internal_contexts.h
@@ -126,7 +126,7 @@ class AsyncPendingReadContext : public PendingContext<K> {
   }
  public:
   virtual void Get(const void* rec) = 0;
-  virtual void GetAtomic(const void* rec) = 0;
+  virtual bool GetAtomic(const void* rec) = 0;
 };
 
 /// A synchronous Read() context preserves its type information.
@@ -166,9 +166,9 @@ class PendingReadContext : public AsyncPendingReadContext<typename RC::key_t> {
     const record_t* record = reinterpret_cast<const record_t*>(rec);
     read_context().Get(record->value());
   }
-  inline void GetAtomic(const void* rec) final {
+  inline bool GetAtomic(const void* rec) final {
     const record_t* record = reinterpret_cast<const record_t*>(rec);
-    read_context().GetAtomic(record->value());
+    return read_context().GetAtomic(record->value());
   }
 };
 

--- a/cc/test/in_memory_test.cc
+++ b/cc/test/in_memory_test.cc
@@ -131,8 +131,9 @@ TEST(InMemFaster, UpsertRead) {
       // All reads should be atomic (from the mutable tail).
       ASSERT_TRUE(false);
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       output = value.atomic_value_.load();
+      return true;
     }
 
    protected:
@@ -321,8 +322,9 @@ TEST(InMemFaster, UpsertRead_DummyHash) {
       // All reads should be atomic (from the mutable tail).
       ASSERT_TRUE(false);
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       output = value.atomic_value_.load();
+      return true;
     }
 
    protected:
@@ -493,13 +495,14 @@ TEST(InMemFaster, UpsertRead_Concurrent) {
       // All reads should be atomic (from the mutable tail).
       ASSERT_TRUE(false);
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       do {
         output_length = value.length_.load();
-        ASSERT_EQ(0, reinterpret_cast<size_t>(value.value_) % 16);
+        EXPECT_EQ(0, reinterpret_cast<size_t>(value.value_) % 16);
         output_pt1 = *reinterpret_cast<const uint64_t*>(value.value_);
         output_pt2 = *reinterpret_cast<const uint64_t*>(value.value_ + 8);
       } while(output_length != value.length_.load());
+      return true;
     }
 
    protected:
@@ -811,7 +814,7 @@ TEST(InMemFaster, UpsertRead_ResizeValue_Concurrent) {
       // All reads should be atomic (from the mutable tail).
       ASSERT_TRUE(false);
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       GenLock before, after;
       do {
         before = value.gen_lock_.load();
@@ -820,6 +823,7 @@ TEST(InMemFaster, UpsertRead_ResizeValue_Concurrent) {
         output_bytes[1] = value.buffer()[value.length_ - 1];
         after = value.gen_lock_.load();
       } while(before.gen_number != after.gen_number);
+      return true;
     }
 
    protected:
@@ -1037,8 +1041,9 @@ TEST(InMemFaster, Rmw) {
       // All reads should be atomic (from the mutable tail).
       ASSERT_TRUE(false);
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       output = value.atomic_value_.load();
+      return true;
     }
 
    protected:
@@ -1230,8 +1235,9 @@ TEST(InMemFaster, Rmw_Concurrent) {
       // All reads should be atomic (from the mutable tail).
       ASSERT_TRUE(false);
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       output = value.atomic_value_.load();
+      return true;
     }
 
    protected:
@@ -1557,7 +1563,7 @@ TEST(InMemFaster, Rmw_ResizeValue_Concurrent) {
       // All reads should be atomic (from the mutable tail).
       ASSERT_TRUE(false);
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       GenLock before, after;
       do {
         before = value.gen_lock_.load();
@@ -1566,6 +1572,7 @@ TEST(InMemFaster, Rmw_ResizeValue_Concurrent) {
         output_bytes[1] = value.buffer()[value.length_ - 1];
         after = value.gen_lock_.load();
       } while(before.gen_number != after.gen_number);
+      return true;
     }
 
    protected:
@@ -1793,11 +1800,12 @@ public:
       // All reads should be atomic (from the mutable tail).
       ASSERT_TRUE(false);
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       // There are no concurrent updates
       output_length = value.length_;
       output_letters[0] = value.buffer()[0];
       output_letters[1] = value.buffer()[value.length_ - 1];
+      return true;
     }
 
 protected:
@@ -2017,8 +2025,9 @@ TEST(InMemFaster, GrowHashTable) {
       // All reads should be atomic (from the mutable tail).
       ASSERT_TRUE(false);
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       output = value.atomic_value_.load();
+      return true;
     }
 
    protected:
@@ -2306,8 +2315,9 @@ TEST(InMemFaster, UpsertRead_VariableLengthKey) {
         // All reads should be atomic (from the mutable tail).
         ASSERT_TRUE(false);
       }
-      inline void GetAtomic(const Value& value) {
+      inline bool GetAtomic(const Value& value) {
         output = value.atomic_value_.load();
+        return true;
       }
 
   protected:

--- a/cc/test/paging_test.h
+++ b/cc/test/paging_test.h
@@ -156,7 +156,7 @@ TEST(CLASS, UpsertRead_Serial) {
       ASSERT_EQ(expected_, value.length_);
       ASSERT_EQ(expected_, value.value_[expected_ - 5]);
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       uint64_t post_gen = value.gen_.load();
       uint64_t pre_gen;
       uint16_t len;
@@ -168,8 +168,9 @@ TEST(CLASS, UpsertRead_Serial) {
         val = value.value_[len - 5];
         post_gen = value.gen_.load();
       } while(pre_gen != post_gen);
-      ASSERT_EQ(expected_, static_cast<uint8_t>(len));
-      ASSERT_EQ(expected_, val);
+      EXPECT_EQ(expected_, static_cast<uint8_t>(len));
+      EXPECT_EQ(expected_, val);
+      return true;
     }
 
    protected:
@@ -438,7 +439,7 @@ TEST(CLASS, UpsertRead_Concurrent) {
       ASSERT_EQ(expected_, value.length_);
       ASSERT_EQ(expected_, value.value_[expected_ - 5]);
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       uint64_t post_gen = value.gen_.load();
       uint64_t pre_gen;
       uint16_t len;
@@ -450,7 +451,8 @@ TEST(CLASS, UpsertRead_Concurrent) {
         val = value.value_[len - 5];
         post_gen = value.gen_.load();
       } while(pre_gen != post_gen);
-      ASSERT_EQ(expected_, val);
+      EXPECT_EQ(expected_, val);
+      return true;
     }
 
    protected:
@@ -892,8 +894,9 @@ TEST(CLASS, Rmw_Concurrent) {
     inline void Get(const Value& value) {
       counter = value.counter_.load(std::memory_order_acquire);
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       counter = value.counter_.load();
+      return true;
     }
 
    protected:

--- a/cc/test/recovery_test.h
+++ b/cc/test/recovery_test.h
@@ -349,8 +349,9 @@ TEST(CLASS, Serial) {
     inline void Get(const Value1& value) {
       val_ = value.val1_;
     }
-    inline void GetAtomic(const Value1& value) {
+    inline bool GetAtomic(const Value1& value) {
       val_ = value.atomic_val1_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -396,8 +397,9 @@ TEST(CLASS, Serial) {
     inline void Get(const Value2& value) {
       val_ = value.val2_;
     }
-    inline void GetAtomic(const Value2& value) {
+    inline bool GetAtomic(const Value2& value) {
       val_ = value.atomic_val2_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -855,8 +857,9 @@ TEST(CLASS, Serial_VariableLengthKey) {
     inline void Get(const Value1& value) {
       val_ = value.val1_;
     }
-    inline void GetAtomic(const Value1& value) {
+    inline bool GetAtomic(const Value1& value) {
       val_ = value.atomic_val1_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -904,8 +907,9 @@ TEST(CLASS, Serial_VariableLengthKey) {
     inline void Get(const Value2& value) {
       val_ = value.val2_;
     }
-    inline void GetAtomic(const Value2& value) {
+    inline bool GetAtomic(const Value2& value) {
       val_ = value.atomic_val2_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -1311,8 +1315,9 @@ TEST(CLASS, Concurrent_Insert_Small) {
     inline void Get(const Value& value) {
       val_ = value.val_;
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       val_ = value.atomic_val_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -1470,8 +1475,9 @@ TEST(CLASS, Concurrent_Insert_Small) {
     inline void Get(const Value& value) {
       val_ = value.val_;
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       val_ = value.atomic_val_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -1729,8 +1735,9 @@ TEST(CLASS, Concurrent_Insert_Large) {
     inline void Get(const Value& value) {
       val_ = value.val_;
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       val_ = value.atomic_val_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -1886,8 +1893,9 @@ TEST(CLASS, Concurrent_Insert_Large) {
     inline void Get(const Value& value) {
       val_ = value.val_;
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       val_ = value.atomic_val_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -2144,8 +2152,9 @@ TEST(CLASS, Concurrent_Update_Small) {
     inline void Get(const Value& value) {
       val_ = value.val_;
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       val_ = value.atomic_val_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -2313,8 +2322,9 @@ TEST(CLASS, Concurrent_Update_Small) {
     inline void Get(const Value& value) {
       val_ = value.val_;
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       val_ = value.atomic_val_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -2581,8 +2591,9 @@ TEST(CLASS, Concurrent_Update_Large) {
     inline void Get(const Value& value) {
       val_ = value.val_;
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       val_ = value.atomic_val_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -2765,8 +2776,9 @@ TEST(CLASS, Concurrent_Update_Large) {
     inline void Get(const Value& value) {
       val_ = value.val_;
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       val_ = value.atomic_val_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -3028,8 +3040,9 @@ TEST(CLASS, Concurrent_Rmw_Small) {
     inline void Get(const Value& value) {
       val_ = value.val_;
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       val_ = value.atomic_val_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -3208,8 +3221,9 @@ TEST(CLASS, Concurrent_Rmw_Small) {
     inline void Get(const Value& value) {
       val_ = value.val_;
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       val_ = value.atomic_val_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -3472,8 +3486,9 @@ TEST(CLASS, Concurrent_Rmw_Large) {
     inline void Get(const Value& value) {
       val_ = value.val_;
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       val_ = value.atomic_val_.load();
+      return true;
     }
 
     uint64_t val() const {
@@ -3679,8 +3694,9 @@ TEST(CLASS, Concurrent_Rmw_Large) {
     inline void Get(const Value& value) {
       val_ = value.val_;
     }
-    inline void GetAtomic(const Value& value) {
+    inline bool GetAtomic(const Value& value) {
       val_ = value.atomic_val_.load();
+      return true;
     }
 
     uint64_t val() const {


### PR DESCRIPTION
I'm a bit unsure on this but I'm wondering whether it's possible for GetAtomic to read a stale value if another thread has concurrently "replaced" the record? We mark variable-length values as replaced when they are made to be larger than the available buffer in the value. I think the following trace is possible:

* Threads R (reader) and U (upserter) look up the value at address X
* U acquires a user-level lock on value
* U tries to perform upsert but new value is too large for buffer
* U marks record as replaced and releases lock on X 
* U creates a new record at address Y
* R reads the value at X (which is stale)

By changing the return type to `bool`, R can detect (via a flag in Value) that record has been replaced and can retry the operation. R then reads the newer record.

What do you think @badrishc?

