### PR TITLE
[FasterLog] Add support for Cancellation tokens on all the async APIs

### DIFF
--- a/cs/src/core/Index/FasterLog/FasterLog.cs
+++ b/cs/src/core/Index/FasterLog/FasterLog.cs
@@ -302,7 +302,7 @@ namespace FASTER.core
                         // Wait for *some* commit - failure can be ignored except if the token was signaled (which the caller should handle correctly)
                         try
                         {
-                            await task;
+                            await task.WithCancellationAsync(token);
                         }
                         catch when (!token.IsCancellationRequested) { }
                     }

--- a/cs/src/core/Index/FasterLog/FasterLog.cs
+++ b/cs/src/core/Index/FasterLog/FasterLog.cs
@@ -25,7 +25,7 @@ namespace FASTER.core
         private readonly int headerSize;
         private readonly LogChecksumType logChecksum;
         private readonly Dictionary<string, long> RecoveredIterators;
-        private TaskCompletionSource<LinkedCommitInfo> commitTcs 
+        private TaskCompletionSource<LinkedCommitInfo> commitTcs
             = new TaskCompletionSource<LinkedCommitInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace FASTER.core
         /// <param name="logSettings"></param>
         public FasterLog(FasterLogSettings logSettings)
         {
-            logCommitManager = logSettings.LogCommitManager ?? 
+            logCommitManager = logSettings.LogCommitManager ??
                 new LocalLogCommitManager(logSettings.LogCommitFile ??
                 logSettings.LogDevice.FileName + ".commit");
 
@@ -77,7 +77,7 @@ namespace FASTER.core
             CommittedBeginAddress = Constants.kFirstValidAddress;
 
             allocator = new BlittableAllocator<Empty, byte>(
-                logSettings.GetLogSettings(), null, 
+                logSettings.GetLogSettings(), null,
                 null, epoch, CommitCallback);
             allocator.Initialize();
             Restore(out RecoveredIterators);
@@ -210,27 +210,34 @@ namespace FASTER.core
         /// </summary>
         /// <param name="entry"></param>
         /// <returns></returns>
-        public async ValueTask<long> EnqueueAsync(byte[] entry)
+        public ValueTask<long> EnqueueAsync(byte[] entry, CancellationToken token = default)
         {
-            long logicalAddress;
+            token.ThrowIfCancellationRequested();
+            if (TryEnqueue(entry, out long logicalAddress))
+                return new ValueTask<long>(logicalAddress);
 
-            while (true)
+            return SlowEnqueueAsync(this, entry, token);
+            static async ValueTask<long> SlowEnqueueAsync(FasterLog @this, byte[] entry, CancellationToken token)
             {
-                var task = CommitTask;
-                if (TryEnqueue(entry, out logicalAddress))
-                    break;
-                if (NeedToWait(CommittedUntilAddress, TailAddress))
+                long logicalAddress;
+                while (true)
                 {
-                    // Wait for *some* commit - failure can be ignored
-                    try
+                    var task = @this.CommitTask;
+                    if (@this.TryEnqueue(entry, out logicalAddress))
+                        break;
+                    if (@this.NeedToWait(@this.CommittedUntilAddress, @this.TailAddress))
                     {
-                        await task;
+                        // Wait for *some* commit - failure can be ignored except if the token was signaled (which the caller should handle correctly)
+                        try
+                        {
+                            await task.WithCancellationAsync(token);
+                        }
+                        catch when (!token.IsCancellationRequested) { }
                     }
-                    catch { }
                 }
-            }
 
-            return logicalAddress;
+                return logicalAddress;
+            }
         }
 
         /// <summary>
@@ -239,27 +246,34 @@ namespace FASTER.core
         /// </summary>
         /// <param name="entry"></param>
         /// <returns></returns>
-        public async ValueTask<long> EnqueueAsync(ReadOnlyMemory<byte> entry)
+        public ValueTask<long> EnqueueAsync(ReadOnlyMemory<byte> entry, CancellationToken token = default)
         {
-            long logicalAddress;
+            token.ThrowIfCancellationRequested();
+            if (TryEnqueue(entry.Span, out long logicalAddress))
+                return new ValueTask<long>(logicalAddress);
 
-            while (true)
+            return SlowEnqueueAsync(this, entry, token);
+            static async ValueTask<long> SlowEnqueueAsync(FasterLog @this, ReadOnlyMemory<byte> entry, CancellationToken token)
             {
-                var task = CommitTask;
-                if (TryEnqueue(entry.Span, out logicalAddress))
-                    break;
-                if (NeedToWait(CommittedUntilAddress, TailAddress))
+                long logicalAddress;
+                while (true)
                 {
-                    // Wait for *some* commit - failure can be ignored
-                    try
+                    var task = @this.CommitTask;
+                    if (@this.TryEnqueue(entry.Span, out logicalAddress))
+                        break;
+                    if (@this.NeedToWait(@this.CommittedUntilAddress, @this.TailAddress))
                     {
-                        await task;
+                        // Wait for *some* commit - failure can be ignored except if the token was signaled (which the caller should handle correctly)
+                        try
+                        {
+                            await task.WithCancellationAsync(token);
+                        }
+                        catch when (!token.IsCancellationRequested) { }
                     }
-                    catch { }
                 }
-            }
 
-            return logicalAddress;
+                return logicalAddress;
+            }
         }
 
         /// <summary>
@@ -268,27 +282,34 @@ namespace FASTER.core
         /// </summary>
         /// <param name="readOnlySpanBatch"></param>
         /// <returns></returns>
-        public async ValueTask<long> EnqueueAsync(IReadOnlySpanBatch readOnlySpanBatch)
+        public ValueTask<long> EnqueueAsync(IReadOnlySpanBatch readOnlySpanBatch, CancellationToken token = default)
         {
-            long logicalAddress;
+            token.ThrowIfCancellationRequested();
+            if (TryEnqueue(readOnlySpanBatch, out long address))
+                return new ValueTask<long>(address);
 
-            while (true)
+            return SlowEnqueueAsync(this, readOnlySpanBatch, token);
+            static async ValueTask<long> SlowEnqueueAsync(FasterLog @this, IReadOnlySpanBatch readOnlySpanBatch, CancellationToken token)
             {
-                var task = CommitTask;
-                if (TryEnqueue(readOnlySpanBatch, out logicalAddress))
-                    break;
-                if (NeedToWait(CommittedUntilAddress, TailAddress))
+                long logicalAddress;
+                while (true)
                 {
-                    // Wait for *some* commit - failure can be ignored
-                    try
+                    var task = @this.CommitTask;
+                    if (@this.TryEnqueue(readOnlySpanBatch, out logicalAddress))
+                        break;
+                    if (@this.NeedToWait(@this.CommittedUntilAddress, @this.TailAddress))
                     {
-                        await task;
+                        // Wait for *some* commit - failure can be ignored except if the token was signaled (which the caller should handle correctly)
+                        try
+                        {
+                            await task;
+                        }
+                        catch when (!token.IsCancellationRequested) { }
                     }
-                    catch { }
                 }
-            }
 
-            return logicalAddress;
+                return logicalAddress;
+            }
         }
         #endregion
 
@@ -316,15 +337,16 @@ namespace FASTER.core
         /// </summary>
         /// <param name="untilAddress">Address until which we should wait for commit, default 0 for tail of log</param>
         /// <returns></returns>
-        public async ValueTask WaitForCommitAsync(long untilAddress = 0)
+        public async ValueTask WaitForCommitAsync(long untilAddress = 0, CancellationToken token = default)
         {
+            token.ThrowIfCancellationRequested();
             var task = CommitTask;
             var tailAddress = untilAddress;
             if (tailAddress == 0) tailAddress = allocator.GetTailAddress();
 
             while (true)
             {
-                var linkedCommitInfo = await task;
+                var linkedCommitInfo = await task.WithCancellationAsync(token);
                 if (linkedCommitInfo.CommitInfo.UntilAddress < tailAddress)
                     task = linkedCommitInfo.NextTask;
                 else
@@ -333,7 +355,7 @@ namespace FASTER.core
         }
         #endregion
 
-        #region Commit
+        #region Commit and CommitAsync
 
         /// <summary>
         /// Issue commit request for log (until tail)
@@ -351,14 +373,15 @@ namespace FASTER.core
         /// ongoing commit fails.
         /// </summary>
         /// <returns></returns>
-        public async ValueTask CommitAsync()
+        public async ValueTask CommitAsync(CancellationToken token = default)
         {
+            token.ThrowIfCancellationRequested();
             var task = CommitTask;
             var tailAddress = CommitInternal();
 
             while (true)
             {
-                var linkedCommitInfo = await task;
+                var linkedCommitInfo = await task.WithCancellationAsync(token);
                 if (linkedCommitInfo.CommitInfo.UntilAddress < tailAddress)
                     task = linkedCommitInfo.NextTask;
                 else
@@ -372,14 +395,15 @@ namespace FASTER.core
         /// from prevCommitTask to current fails.
         /// </summary>
         /// <returns></returns>
-        public async ValueTask<Task<LinkedCommitInfo>> CommitAsync(Task<LinkedCommitInfo> prevCommitTask)
+        public async ValueTask<Task<LinkedCommitInfo>> CommitAsync(Task<LinkedCommitInfo> prevCommitTask, CancellationToken token = default)
         {
-            if (prevCommitTask == null) prevCommitTask = commitTcs.Task;
+            token.ThrowIfCancellationRequested();
+            if (prevCommitTask == null) prevCommitTask = CommitTask;
             var tailAddress = CommitInternal();
 
             while (true)
             {
-                var linkedCommitInfo = await prevCommitTask;
+                var linkedCommitInfo = await prevCommitTask.WithCancellationAsync(token);
                 if (linkedCommitInfo.CommitInfo.UntilAddress < tailAddress)
                     prevCommitTask = linkedCommitInfo.NextTask;
                 else
@@ -443,8 +467,9 @@ namespace FASTER.core
         /// </summary>
         /// <param name="entry"></param>
         /// <returns></returns>
-        public async ValueTask<long> EnqueueAndWaitForCommitAsync(byte[] entry)
+        public async ValueTask<long> EnqueueAndWaitForCommitAsync(byte[] entry, CancellationToken token = default)
         {
+            token.ThrowIfCancellationRequested();
             long logicalAddress;
             Task<LinkedCommitInfo> task;
 
@@ -456,12 +481,12 @@ namespace FASTER.core
                     break;
                 if (NeedToWait(CommittedUntilAddress, TailAddress))
                 {
-                    // Wait for *some* commit - failure can be ignored
+                    // Wait for *some* commit - failure can be ignored except if the token was signaled (which the caller should handle correctly)
                     try
                     {
-                        await task;
+                        await task.WithCancellationAsync(token);
                     }
-                    catch { }
+                    catch when (!token.IsCancellationRequested) { }
                 }
             }
 
@@ -471,13 +496,13 @@ namespace FASTER.core
                 LinkedCommitInfo linkedCommitInfo;
                 try
                 {
-                    linkedCommitInfo = await task;
+                    linkedCommitInfo = await task.WithCancellationAsync(token);
                 }
                 catch (CommitFailureException e)
                 {
                     linkedCommitInfo = e.LinkedCommitInfo;
                     if (logicalAddress >= linkedCommitInfo.CommitInfo.FromAddress && logicalAddress < linkedCommitInfo.CommitInfo.UntilAddress)
-                        throw e;
+                        throw;
                 }
                 if (linkedCommitInfo.CommitInfo.UntilAddress < logicalAddress + 1)
                     task = linkedCommitInfo.NextTask;
@@ -494,8 +519,9 @@ namespace FASTER.core
         /// </summary>
         /// <param name="entry"></param>
         /// <returns></returns>
-        public async ValueTask<long> EnqueueAndWaitForCommitAsync(ReadOnlyMemory<byte> entry)
+        public async ValueTask<long> EnqueueAndWaitForCommitAsync(ReadOnlyMemory<byte> entry, CancellationToken token = default)
         {
+            token.ThrowIfCancellationRequested();
             long logicalAddress;
             Task<LinkedCommitInfo> task;
 
@@ -507,12 +533,12 @@ namespace FASTER.core
                     break;
                 if (NeedToWait(CommittedUntilAddress, TailAddress))
                 {
-                    // Wait for *some* commit - failure can be ignored
+                    // Wait for *some* commit - failure can be ignored except if the token was signaled (which the caller should handle correctly)
                     try
                     {
-                        await task;
+                        await task.WithCancellationAsync(token);
                     }
-                    catch { }
+                    catch when (!token.IsCancellationRequested) { }
                 }
             }
 
@@ -522,13 +548,13 @@ namespace FASTER.core
                 LinkedCommitInfo linkedCommitInfo;
                 try
                 {
-                    linkedCommitInfo = await task;
+                    linkedCommitInfo = await task.WithCancellationAsync(token);
                 }
                 catch (CommitFailureException e)
                 {
                     linkedCommitInfo = e.LinkedCommitInfo;
                     if (logicalAddress >= linkedCommitInfo.CommitInfo.FromAddress && logicalAddress < linkedCommitInfo.CommitInfo.UntilAddress)
-                        throw e;
+                        throw;
                 }
                 if (linkedCommitInfo.CommitInfo.UntilAddress < logicalAddress + 1)
                     task = linkedCommitInfo.NextTask;
@@ -545,8 +571,9 @@ namespace FASTER.core
         /// </summary>
         /// <param name="readOnlySpanBatch"></param>
         /// <returns></returns>
-        public async ValueTask<long> EnqueueAndWaitForCommitAsync(IReadOnlySpanBatch readOnlySpanBatch)
+        public async ValueTask<long> EnqueueAndWaitForCommitAsync(IReadOnlySpanBatch readOnlySpanBatch, CancellationToken token = default)
         {
+            token.ThrowIfCancellationRequested();
             long logicalAddress;
             Task<LinkedCommitInfo> task;
 
@@ -558,12 +585,12 @@ namespace FASTER.core
                     break;
                 if (NeedToWait(CommittedUntilAddress, TailAddress))
                 {
-                    // Wait for *some* commit - failure can be ignored
+                    // Wait for *some* commit - failure can be ignored except if the token was signaled (which the caller should handle correctly)
                     try
                     {
-                        await task;
+                        await task.WithCancellationAsync(token);
                     }
-                    catch { }
+                    catch when (!token.IsCancellationRequested) { }
                 }
             }
 
@@ -573,13 +600,13 @@ namespace FASTER.core
                 LinkedCommitInfo linkedCommitInfo;
                 try
                 {
-                    linkedCommitInfo = await task;
+                    linkedCommitInfo = await task.WithCancellationAsync(token);
                 }
                 catch (CommitFailureException e)
                 {
                     linkedCommitInfo = e.LinkedCommitInfo;
                     if (logicalAddress >= linkedCommitInfo.CommitInfo.FromAddress && logicalAddress < linkedCommitInfo.CommitInfo.UntilAddress)
-                        throw e;
+                        throw;
                 }
                 if (linkedCommitInfo.CommitInfo.UntilAddress < logicalAddress + 1)
                     task = linkedCommitInfo.NextTask;
@@ -635,8 +662,9 @@ namespace FASTER.core
         /// <param name="address">Logical address to read from</param>
         /// <param name="estimatedLength">Estimated length of entry, if known</param>
         /// <returns></returns>
-        public async ValueTask<(byte[], int)> ReadAsync(long address, int estimatedLength = 0)
+        public async ValueTask<(byte[], int)> ReadAsync(long address, int estimatedLength = 0, CancellationToken token = default)
         {
+            token.ThrowIfCancellationRequested();
             epoch.Resume();
             if (address >= CommittedUntilAddress || address < BeginAddress)
             {
@@ -653,7 +681,7 @@ namespace FASTER.core
                 allocator.AsyncReadRecordToMemory(address, headerSize + estimatedLength, AsyncGetFromDiskCallback, ref ctx);
             }
             epoch.Suspend();
-            await ctx.completedRead.WaitAsync();
+            await ctx.completedRead.WaitAsync(token);
             return GetRecordAndFree(ctx.record);
         }
 
@@ -866,10 +894,13 @@ namespace FASTER.core
                 epoch.Suspend();
                 var beginAddress = allocator.BeginAddress;
                 if (beginAddress > CommittedBeginAddress || FasterLogScanIterator.PersistedIterators.Count > 0)
-                    CommitCallback(new CommitInfo { BeginAddress = beginAddress,
+                    CommitCallback(new CommitInfo
+                    {
+                        BeginAddress = beginAddress,
                         FromAddress = CommittedUntilAddress,
                         UntilAddress = CommittedUntilAddress,
-                        ErrorCode = 0 });
+                        ErrorCode = 0
+                    });
             }
 
             return tailAddress;


### PR DESCRIPTION
- Added a WithCancellationAsync method to make all the awaits respect a user provided cancellation token

- In cases where exceptions were getting swallowed from the awaited task, added checks to make sure OperationCanceledExceptions bubble up to the caller