### PR TITLE
Clarified TruncateUntil, added TruncateUntilPageStart

### DIFF
--- a/cs/playground/FasterLogSample/Program.cs
+++ b/cs/playground/FasterLogSample/Program.cs
@@ -167,7 +167,11 @@ namespace FasterLogSample
                     // Example of random read from given address
                     // (result, _) = log.ReadAsync(iter.CurrentAddress).GetAwaiter().GetResult();
 
+                    // Truncate log until after recently processed entry
                     log.TruncateUntil(iter.NextAddress);
+
+                    // Safer truncate variant: truncate until start of page
+                    // log.TruncateUntilPageStart(iter.NextAddress);
                 }
             }
 

--- a/cs/src/core/Index/FasterLog/FasterLog.cs
+++ b/cs/src/core/Index/FasterLog/FasterLog.cs
@@ -619,12 +619,25 @@ namespace FASTER.core
         #endregion
 
         /// <summary>
-        /// Truncate the log until, but not including, untilAddress
+        /// Truncate the log until, but not including, untilAddress. **User should ensure
+        /// that the provided address is a valid starting address for some record.** The
+        /// truncation is not persisted until the next commit.
         /// </summary>
-        /// <param name="untilAddress"></param>
+        /// <param name="untilAddress">Until address</param>
         public void TruncateUntil(long untilAddress)
         {
             allocator.ShiftBeginAddress(untilAddress);
+        }
+
+        /// <summary>
+        /// Truncate the log until the start of the page corresponding to untilAddress. This is 
+        /// safer than TruncateUntil, as page starts are always a valid truncation point. The
+        /// truncation is not persisted until the next commit.
+        /// </summary>
+        /// <param name="untilAddress">Until address</param>
+        public void TruncateUntilPageStart(long untilAddress)
+        {
+            allocator.ShiftBeginAddress(untilAddress & allocator.PageSizeMask);
         }
 
         /// <summary>


### PR DESCRIPTION
Clarified TruncateUntil caveat in comment, for user providing a valid until address. Added a safer variant: TruncateUntilPageStart.

Fix https://github.com/microsoft/FASTER/issues/191