### PR TITLE
Bug fixes

### DIFF
--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Runtime.InteropServices;
 using System.Diagnostics;
-using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace FASTER.core
 {
@@ -1258,7 +1257,7 @@ namespace FASTER.core
                     asyncResult.maxPtr = readLength;
                     readLength = (uint)((readLength + (sectorSize - 1)) & ~(sectorSize - 1));
                 }
-                
+
                 if (device != null)
                     offsetInFile = (ulong)(AlignedPageSizeBytes * (readPage - devicePageOffset));
 
@@ -1279,7 +1278,7 @@ namespace FASTER.core
             int numPages = (int)(endPage - startPage);
 
             long offsetInStartPage = GetOffsetInPage(fromAddress);
-            long offsetInEndPage = GetOffsetInPage(untilAddress);                
+            long offsetInEndPage = GetOffsetInPage(untilAddress);
 
             // Extra (partial) page being flushed
             if (offsetInEndPage > 0)
@@ -1513,11 +1512,7 @@ namespace FASTER.core
                     WriteAsync(request.fromAddress >> LogPageSizeBits, AsyncFlushPageCallback, request);
                 }
             }
-            catch
-            {
-                if (!disposed)
-                    throw;
-            }
+            catch when (disposed) { }
             finally
             {
                 Overlapped.Free(overlap);
@@ -1546,11 +1541,7 @@ namespace FASTER.core
                     result.Free();
                 }
             }
-            catch
-            {
-                if (!disposed)
-                    throw;
-            }
+            catch when (disposed) { }
             finally
             {
                 Overlapped.Free(overlap);

--- a/cs/src/core/Index/FasterLog/FasterLog.cs
+++ b/cs/src/core/Index/FasterLog/FasterLog.cs
@@ -344,6 +344,9 @@ namespace FASTER.core
             var tailAddress = untilAddress;
             if (tailAddress == 0) tailAddress = allocator.GetTailAddress();
 
+            if (CommittedUntilAddress >= tailAddress)
+                return;
+
             while (true)
             {
                 var linkedCommitInfo = await task.WithCancellationAsync(token);
@@ -490,6 +493,7 @@ namespace FASTER.core
                 }
             }
 
+            // since the task object was read before enqueueing, there is no need for the CommittedUntilAddress >= logicalAddress check like in WaitForCommit
             // Phase 2: wait for commit/flush to storage
             while (true)
             {
@@ -542,6 +546,7 @@ namespace FASTER.core
                 }
             }
 
+            // since the task object was read before enqueueing, there is no need for the CommittedUntilAddress >= logicalAddress check like in WaitForCommit
             // Phase 2: wait for commit/flush to storage
             while (true)
             {
@@ -594,6 +599,7 @@ namespace FASTER.core
                 }
             }
 
+            // since the task object was read before enqueueing, there is no need for the CommittedUntilAddress >= logicalAddress check like in WaitForCommit
             // Phase 2: wait for commit/flush to storage
             while (true)
             {


### PR DESCRIPTION
1. Fix a bug in FasterLog.WaitForCommitAsync(untilAddress) where the incoming address has already been Committed.

2. Exit from Iterator.WaitAsync when the iterator is disposed. Return a true/false from WaitAsync to signal if the caller should expect more events to be visible, or should stop trying

3. Free up async iterators in FasterLogIterator when the iterator is disposed.

4. (not fixed, added commented code for this:) if an endAddress was specified and iterator is at the end, WaitAsync should return false to make the caller stop trying