### PR TITLE
ObjectRecoveryTest failing when more data is used

### DIFF
--- a/cs/test/ObjectRecoveryTest2.cs
+++ b/cs/test/ObjectRecoveryTest2.cs
@@ -85,7 +85,7 @@ namespace FASTER.test.recovery.objects
             logPath = Path.Combine(FasterFolderPath, $"FasterRecoverTests.log");
             objPath = Path.Combine(FasterFolderPath, $"FasterRecoverTests_HEAP.log");
             log = Devices.CreateLogDevice(logPath);
-            objlog = Devices.CreateLogDevice(objPath);
+            objlog = Devices.CreateLogDevice(objPath, false);
             h = new FasterKV
                 <MyKey, MyValue, MyInput, MyOutput, MyContext, MyFunctions>
                 (1L << 20, new MyFunctions(),


### PR DESCRIPTION
**This PR is not intended to commit but to show a durability failed tests scenario**

I have added some more data to `ObjectRecoveryTest1` test and increased iterations (to invoke more checkpoints) I would expect this to pass even with the additional changes I made, it seems the `stream` runs out of data to read and that results in `OverflowException` when decentralizing a key

Not sure (yet) why exactly, to reproduce just run this test `ObjectRecoveryTest1`
I came across this issue when writing a POC to simulate the requirements for a project I am currently working on (I can provide the link to the POC if needed but I get the same issues).

Any ideas?

```
System.OverflowException
  HResult=0x80131516
  Message=Arithmetic operation resulted in an overflow.
  Source=FASTER.test
  StackTrace:
   at FASTER.test.recovery.objects.MyKeySerializer.Deserialize(MyKey& key) in C:\Users\dan\Documents\GitHub\FASTER\cs\test\ObjectRecoveryTest2.cs:line 180
   at FASTER.core.GenericAllocator`2.Deserialize(Byte* raw, Int64 ptr, Int64 untilptr, Record`2[] src, Stream stream) in C:\Users\dan\Documents\GitHub\FASTER\cs\src\core\Allocator\GenericAllocator.cs:line 727
   at FASTER.core.GenericAllocator`2.AsyncReadPageWithObjectsCallback[TContext](UInt32 errorCode, UInt32 numBytes, NativeOverlapped* overlap) in C:\Users\dan\Documents\GitHub\FASTER\cs\src\core\Allocator\GenericAllocator.cs:line 534
   at System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* pOVERLAP)
```