### PR TITLE
Fix complete-pending & segment sizes for object log

### DIFF
--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -490,7 +490,7 @@ namespace FASTER.core
                 this.epoch = epoch;
 
             settings.LogDevice.Initialize(1L << settings.SegmentSizeBits, epoch);
-            settings.ObjectLogDevice?.Initialize(1L << settings.SegmentSizeBits, epoch);
+            settings.ObjectLogDevice?.Initialize(-1, epoch);
 
             // Page size
             LogPageSizeBits = settings.PageSizeBits;
@@ -1257,6 +1257,7 @@ namespace FASTER.core
                 var asyncResult = new PageAsyncReadResult<TContext>()
                 {
                     page = readPage,
+                    offset = devicePageOffset,
                     context = context,
                     handle = completed,
                     maxPtr = PageSize

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -407,6 +407,9 @@ namespace FASTER.core
                         if (ValueHasObjects())
                             valueSerializer.BeginSerialize(ms);
 
+                        // Reset address list for next chunk
+                        addr = new List<long>();
+
                         objlogDevice.WriteAsync(
                             (IntPtr)_objBuffer.aligned_pointer,
                             (int)(alignedDestinationAddress >> LogSegmentSizeBits),

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -65,6 +65,8 @@ namespace FASTER.core
             {
                 if (objectLogDevice == null)
                     throw new FasterException("Objects in key/value, but object log not provided during creation of FASTER instance");
+                if (objectLogDevice.SegmentSize != -1)
+                    throw new FasterException("Object log device should not have fixed segment size. Set preallocateFile to false when calling CreateLogDevice for object log");
             }
         }
 
@@ -567,7 +569,7 @@ namespace FASTER.core
 
             // Request objects from objlog
             result.objlogDevice.ReadAsync(
-                (int)(result.page >> (LogSegmentSizeBits - LogPageSizeBits)),
+                (int)((result.page - result.offset) >> (LogSegmentSizeBits - LogPageSizeBits)),
                 (ulong)startptr,
                 (IntPtr)objBuffer.aligned_pointer, (uint)alignedLength, AsyncReadPageWithObjectsCallback<TContext>, result);
         }

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -263,13 +263,17 @@ namespace FASTER.core
             if (spinWaitForCommit)
             {
                 if (spinWait != true)
+                {
+                    if (supportAsync) UnsafeSuspendThread();
                     throw new FasterException("Can spin-wait for checkpoint completion only if spinWait is true");
+                }
                 do
                 {
                     fht.InternalCompletePending(ctx, spinWait);
                     if (fht.InRestPhase())
                     {
                         fht.InternalCompletePending(ctx, spinWait);
+                        if (supportAsync) UnsafeSuspendThread();
                         return true;
                     }
                 } while (spinWait);

--- a/cs/src/core/Device/IDevice.cs
+++ b/cs/src/core/Device/IDevice.cs
@@ -48,7 +48,7 @@ namespace FASTER.core
         /// <summary>
         /// Initialize device. This function is used to pass optional information that may only be known after
         /// FASTER initialization (whose constructor takes in IDevice upfront). Implementation are free to ignore
-        /// information if it does not need the supplied information.
+        /// information if it does not need the supplied information. Segment size of -1 is used for object log.
         /// 
         /// This is a bit of a hack. 
         /// </summary>

--- a/cs/src/core/Device/LocalStorageDevice.cs
+++ b/cs/src/core/Device/LocalStorageDevice.cs
@@ -285,7 +285,7 @@ namespace FASTER.core
                 throw new IOException($"Error creating log file for {GetSegmentName(segmentId)}, error: {error}", Native32.MakeHRFromErrorCode(error));
             }
 
-            if (preallocateFile)
+            if (preallocateFile && segmentSize != -1)
                 SetFileSize(FileName, logHandle, segmentSize);
 
             try

--- a/cs/src/core/Device/ManagedLocalStorageDevice.cs
+++ b/cs/src/core/Device/ManagedLocalStorageDevice.cs
@@ -321,7 +321,7 @@ namespace FASTER.core
 #endif
 
             if (preallocateFile && segmentSize != -1)
-            SetFileSize(logWriteHandle, segmentSize);
+                SetFileSize(logWriteHandle, segmentSize);
 
             return logWriteHandle;
         }

--- a/cs/src/core/Device/StorageDeviceBase.cs
+++ b/cs/src/core/Device/StorageDeviceBase.cs
@@ -94,7 +94,8 @@ namespace FASTER.core
         /// <param name="epoch"></param>
         public virtual void Initialize(long segmentSize, LightEpoch epoch = null)
         {
-            Debug.Assert(Capacity == -1 || Capacity % segmentSize == 0, "capacity must be a multiple of segment sizes");
+            if (segmentSize != -1)
+                Debug.Assert(Capacity == -1 || Capacity % segmentSize == 0, "capacity must be a multiple of segment sizes");
             this.segmentSize = segmentSize;
             this.epoch = epoch;
             if (!Utility.IsPowerOfTwo(segmentSize))

--- a/cs/src/core/Index/Recovery/Checkpoint.cs
+++ b/cs/src/core/Index/Recovery/Checkpoint.cs
@@ -262,7 +262,7 @@ namespace FASTER.core
                                 _hybridLogCheckpoint.snapshotFileDevice = checkpointManager.GetSnapshotLogDevice(_hybridLogCheckpointToken);
                                 _hybridLogCheckpoint.snapshotFileObjectLogDevice = checkpointManager.GetSnapshotObjectLogDevice(_hybridLogCheckpointToken);
                                 _hybridLogCheckpoint.snapshotFileDevice.Initialize(hlog.GetSegmentSize());
-                                _hybridLogCheckpoint.snapshotFileObjectLogDevice.Initialize(hlog.GetSegmentSize());
+                                _hybridLogCheckpoint.snapshotFileObjectLogDevice.Initialize(-1);
 
                                 long startPage = hlog.GetPage(_hybridLogCheckpoint.info.flushedLogicalAddress);
                                 long endPage = hlog.GetPage(_hybridLogCheckpoint.info.finalLogicalAddress);

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -222,7 +222,7 @@ namespace FASTER.core
             var recoveryDevice = checkpointManager.GetSnapshotLogDevice(recoveryInfo.guid);
             var objectLogRecoveryDevice = checkpointManager.GetSnapshotObjectLogDevice(recoveryInfo.guid);
             recoveryDevice.Initialize(hlog.GetSegmentSize());
-            objectLogRecoveryDevice.Initialize(hlog.GetSegmentSize());
+            objectLogRecoveryDevice.Initialize(-1);
             var recoveryStatus = new RecoveryStatus(capacity, startPage, endPage, untilAddress)
             {
                 recoveryDevice = recoveryDevice,

--- a/cs/src/core/Utilities/PageAsyncResultTypes.cs
+++ b/cs/src/core/Utilities/PageAsyncResultTypes.cs
@@ -15,6 +15,7 @@ namespace FASTER.core
     public class PageAsyncReadResult<TContext> : IAsyncResult
     {
         internal long page;
+        internal long offset;
         internal TContext context;
         internal CountdownEvent handle;
         internal SectorAlignedMemory freeBuffer1;


### PR DESCRIPTION
* Fix CompletePending to not hold epoch
* Fix object log initialization to set segment size to -1 so that device does not pre-allocate/truncate object log segments to a fixed size

Ref https://github.com/microsoft/FASTER/pull/215
Fix https://github.com/microsoft/FASTER/issues/227
Fix https://github.com/microsoft/FASTER/issues/225
