### PR TITLE
inline gtest print support function defns

### DIFF
--- a/cc/src/core/faster.h
+++ b/cc/src/core/faster.h
@@ -2869,15 +2869,15 @@ bool FasterKv<K, V, D>::GrowIndex(GrowState::callback_t caller_callback) {
 }
 
 // Some printing support for gtest
-std::ostream& operator << (std::ostream& out, const Status s) {
+inline std::ostream& operator << (std::ostream& out, const Status s) {
   return out << (uint8_t)s;
 }
 
-std::ostream& operator << (std::ostream& out, const Guid guid) {
+inline std::ostream& operator << (std::ostream& out, const Guid guid) {
   return out << guid.ToString();
 }
 
-std::ostream& operator << (std::ostream& out, const FixedPageAddress address) {
+inline std::ostream& operator << (std::ostream& out, const FixedPageAddress address) {
   return out << address.control();
 }
 


### PR DESCRIPTION
We have some application code including faster.h, and found that inline definitions for the new gtest print support functions reduce our build situations of linker error for multiple defns. There is a decent chance for collisions on the "<<" operator defn depending on what other c++ libraries are included in the application code.

Linux, C++, g++ 7.4