### PR TITLE
User should be able to provide context class when using async methods

### DIFF
--- a/cs/playground/FasterKVAsyncSample/Program.cs
+++ b/cs/playground/FasterKVAsyncSample/Program.cs
@@ -40,7 +40,7 @@ namespace FasterKVAsyncSample
                 Console.WriteLine($"Unobserved task exception: {e.Exception}");
                 e.SetObserved();
             };
-            
+
             Task[] tasks = new Task[NumParallelTasks];
             for (int i = 0; i < NumParallelTasks; i++)
             {
@@ -67,6 +67,8 @@ namespace FasterKVAsyncSample
 
             await Task.Yield();
 
+            var context = new CacheContext();
+
             if (!batched)
             {
                 // Single commit version - upsert each item and wait for commit
@@ -76,7 +78,7 @@ namespace FasterKVAsyncSample
                 {
                     try
                     {
-                        await session.UpsertAsync(new CacheKey(rand.Next()), new CacheValue(rand.Next()), true);
+                        await session.UpsertAsync(new CacheKey(rand.Next()), new CacheValue(rand.Next()), context, true);
                         Interlocked.Increment(ref numOps);
                     }
                     catch (Exception ex)
@@ -90,9 +92,10 @@ namespace FasterKVAsyncSample
                 // Batched version - we enqueue many entries to memory,
                 // then wait for commit periodically
                 int count = 0;
+
                 while (true)
                 {
-                    await session.UpsertAsync(new CacheKey(rand.Next()), new CacheValue(rand.Next()));
+                    await session.UpsertAsync(new CacheKey(rand.Next()), new CacheValue(rand.Next()), context);
                     if (count++ % 100 == 0)
                     {
                         await session.WaitForCommitAsync();

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -32,7 +32,7 @@ namespace FASTER.core
 
         internal ClientSession(
             FasterKV<Key, Value, Input, Output, Context, Functions> fht,
-            FasterKV<Key, Value, Input, Output, Context, Functions>.FasterExecutionContext ctx, 
+            FasterKV<Key, Value, Input, Output, Context, Functions>.FasterExecutionContext ctx,
             bool supportAsync)
         {
             this.fht = fht;
@@ -84,14 +84,14 @@ namespace FASTER.core
         /// </summary>
         /// <param name="key"></param>
         /// <param name="input"></param>
+        /// <param name="context"></param>
         /// <param name="waitForCommit"></param>
         /// <param name="token"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public async ValueTask<(Status, Output)> ReadAsync(Key key, Input input, bool waitForCommit = false, CancellationToken token = default)
+        public async ValueTask<(Status, Output)> ReadAsync(Key key, Input input, Context context = default, bool waitForCommit = false, CancellationToken token = default)
         {
             Output output = default;
-            Context context = default;
             var status = Read(ref key, ref input, ref output, context, ctx.serialNum + 1);
             if (status == Status.PENDING)
                 return await CompletePendingReadAsync(ctx.serialNum, waitForCommit, token);
@@ -122,13 +122,13 @@ namespace FASTER.core
         /// </summary>
         /// <param name="key"></param>
         /// <param name="desiredValue"></param>
+        /// <param name="context"></param>
         /// <param name="waitForCommit"></param>
         /// <param name="token"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public async ValueTask UpsertAsync(Key key, Value desiredValue, bool waitForCommit = false, CancellationToken token = default)
+        public async ValueTask UpsertAsync(Key key, Value desiredValue, Context context = default, bool waitForCommit = false, CancellationToken token = default)
         {
-            Context context = default;
             var status = Upsert(ref key, ref desiredValue, context, ctx.serialNum + 1);
             if (status == Status.PENDING)
                 await CompletePendingAsync(waitForCommit, token);
@@ -158,13 +158,13 @@ namespace FASTER.core
         /// </summary>
         /// <param name="key"></param>
         /// <param name="input"></param>
+        /// <param name="context"></param>
         /// <param name="waitForCommit"></param>
         /// <param name="token"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public async ValueTask RMWAsync(Key key, Input input, bool waitForCommit = false, CancellationToken token = default)
+        public async ValueTask RMWAsync(Key key, Input input, Context context = default, bool waitForCommit = false, CancellationToken token = default)
         {
-            Context context = default;
             var status = RMW(ref key, ref input, context, ctx.serialNum + 1);
             if (status == Status.PENDING)
                 await CompletePendingAsync(waitForCommit, token);
@@ -196,9 +196,8 @@ namespace FASTER.core
         /// <param name="token"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public async ValueTask DeleteAsync(Key key, bool waitForCommit = false, CancellationToken token = default)
+        public async ValueTask DeleteAsync(Key key, Context context = default, bool waitForCommit = false, CancellationToken token = default)
         {
-            Context context = default;
             var status = Delete(ref key, context, ctx.serialNum + 1);
             if (status == Status.PENDING)
                 await CompletePendingAsync(waitForCommit, token);

--- a/cs/test/ObjectFASTERTests.cs
+++ b/cs/test/ObjectFASTERTests.cs
@@ -19,7 +19,7 @@ namespace FASTER.test
     {
         private FasterKV<MyKey, MyValue, MyInput, MyOutput, Empty, MyFunctions> fht;
         private IDevice log, objlog;
-        
+
         [SetUp]
         public void Setup()
         {
@@ -170,22 +170,22 @@ namespace FASTER.test
             {
                 var key = new MyKey { key = i };
                 var value = new MyValue { value = i };
-                await session.UpsertAsync(key, value);
+                await session.UpsertAsync(key, value, Empty.Default);
             }
 
             var key1 = new MyKey { key = 1989 };
             var input = new MyInput();
-            var result = await session.ReadAsync(key1, input);
+            var result = await session.ReadAsync(key1, input, Empty.Default);
             Assert.IsTrue(result.Item1 == Status.OK);
             Assert.IsTrue(result.Item2.value.value == 1989);
 
             var key2 = new MyKey { key = 23 };
-            result = await session.ReadAsync(key2, input);
+            result = await session.ReadAsync(key2, input, Empty.Default);
             Assert.IsTrue(result.Item1 == Status.OK);
             Assert.IsTrue(result.Item2.value.value == 23);
 
             var key3 = new MyKey { key = 9999 };
-            result = await session.ReadAsync(key3, input);
+            result = await session.ReadAsync(key3, input, Empty.Default);
             Assert.IsTrue(result.Item1 == Status.NOTFOUND);
 
             // Update last 100 using RMW in memory
@@ -193,7 +193,7 @@ namespace FASTER.test
             {
                 var key = new MyKey { key = i };
                 input = new MyInput { value = 1 };
-                await session.RMWAsync(key, input);
+                await session.RMWAsync(key, input, Empty.Default);
             }
 
             // Update first 100 using RMW from storage
@@ -201,7 +201,7 @@ namespace FASTER.test
             {
                 var key = new MyKey { key = i };
                 input = new MyInput { value = 1 };
-                await session.RMWAsync(key, input);
+                await session.RMWAsync(key, input, Empty.Default);
             }
 
             for (int i = 0; i < 2000; i++)
@@ -210,7 +210,7 @@ namespace FASTER.test
                 var key = new MyKey { key = i };
                 var value = new MyValue { value = i };
 
-                result = await session.ReadAsync(key, input);
+                result = await session.ReadAsync(key, input, Empty.Default);
                 Assert.IsTrue(result.Item1 == Status.OK);
                 if (i < 100 || i >= 1900)
                     Assert.IsTrue(result.Item2.value.value == value.value + 1);


### PR DESCRIPTION
Attempts to fix #239 .

If the Functions class depends on the Context instance, async methods will make it fail with a Null Reference Exception.

As per #238, full adherence to TLP semantics would see callbacks on the Functions class gone, maybe replaced by injected middleware semantics, ASPNET.CORE style.