### PR TITLE
Thread.Yield on CompletePending control flow is too CPU Heavy

### DIFF
--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -147,6 +147,7 @@ namespace FASTER.core
 
         internal bool InternalCompletePending(FasterExecutionContext ctx, bool wait = false)
         {
+            var spin = new SpinWait();
             do
             {
                 bool done = true;
@@ -181,7 +182,7 @@ namespace FASTER.core
                 if (wait)
                 {
                     // SpinOnce before checking again
-                    new SpinWait().SpinOnce();
+                    spin.SpinOnce();
                 }
             } while (wait);
 

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -180,8 +180,8 @@ namespace FASTER.core
 
                 if (wait)
                 {
-                    // Yield before checking again
-                    Thread.Yield();
+                    // SpinOnce before checking again
+                    new SpinWait().SpinOnce();
                 }
             } while (wait);
 


### PR DESCRIPTION
As per #238, frequent calls to CompletePending get a lot lighter on the CPU if we don't Yield the Thread.

Also, there's other call sites to Thread.Yield, that should be justified:

https://github.com/microsoft/FASTER/blob/8f9cf2c2ea8ea334b94ee1585f3cf4cc4cf496ca/cs/src/core/Allocator/ErrorList.cs#L39

https://github.com/microsoft/FASTER/blob/8f9cf2c2ea8ea334b94ee1585f3cf4cc4cf496ca/cs/src/core/Index/FASTER/FASTERImpl.cs#L1883-L1901

https://github.com/microsoft/FASTER/blob/8f9cf2c2ea8ea334b94ee1585f3cf4cc4cf496ca/cs/src/core/Allocator/AllocatorBase.cs#L1430

https://github.com/microsoft/FASTER/blob/8f9cf2c2ea8ea334b94ee1585f3cf4cc4cf496ca/cs/src/core/Index/FasterLog/FasterLog.cs#L948

https://github.com/microsoft/FASTER/blob/8f9cf2c2ea8ea334b94ee1585f3cf4cc4cf496ca/cs/src/core/Index/FasterLog/FasterLog.cs#L1028