### PR TITLE
Skip WAIT_PENDING check if using relaxed CPR

### DIFF
--- a/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
@@ -88,7 +88,7 @@ namespace FASTER.core
                 case Phase.WAIT_PENDING:
                     if (ctx != null)
                     {
-                        if (!ctx.prevCtx.markers[EpochPhaseIdx.WaitPending])
+                        if (!faster.RelaxedCPR &&!ctx.prevCtx.markers[EpochPhaseIdx.WaitPending])
                         {
                             if (ctx.prevCtx.HasNoPendingRequests)
                                 ctx.prevCtx.markers[EpochPhaseIdx.WaitPending] = true;


### PR DESCRIPTION
After yesterday's discussion, I think we missed this on the previous PR.