### PR TITLE
Cross target .NETSTANDARD2.1 and update playground examples to .NETCOREAPP3.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,8 +155,7 @@ jobs:
     inputs:
       restoreSolution: '$(solution)'
 
-  - task: DotNetCoreInstaller@0
-    displayName: 'Install'
+  - task: UseDotNet@2
     inputs:
       packageType: 'sdk'
       version: '3.1.201'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,9 +25,9 @@ jobs:
         buildConfiguration: 'Release'
 
   steps:
-  - task: NuGetToolInstaller@0
+  - task: NuGetToolInstaller@1
     inputs:
-      versionSpec: '4.8.2'
+      versionSpec: '5.5.0'
 
   - task: NuGetCommand@2
     inputs:
@@ -54,8 +54,8 @@ jobs:
   - task: VSTest@2
     inputs:
       testAssemblyVer2: |
-       **\$(BuildConfiguration)\net46*\*test*.dll
-       **\$(BuildConfiguration)\**\net46*\*test*.dll
+       **\$(BuildConfiguration)\net46*\*test.dll
+       **\$(BuildConfiguration)\**\net46*\*test.dll
        !**\*Microsoft.VisualStudio.TestPlatform*
        !**\obj\**
        !**\*TestAdapter.dll
@@ -66,8 +66,8 @@ jobs:
   - task: VSTest@2
     inputs:
       testAssemblyVer2: |
-       **\$(BuildConfiguration)\netcoreapp*\*test*.dll
-       **\$(BuildConfiguration)\**\netcoreapp*\*test*.dll
+       **\$(BuildConfiguration)\netcoreapp*\*test.dll
+       **\$(BuildConfiguration)\**\netcoreapp*\*test.dll
        !**\*Microsoft.VisualStudio.TestPlatform*
        !**\obj\**
        !**\*TestAdapter.dll
@@ -147,9 +147,9 @@ jobs:
   displayName: 'C# (Linux)'
 
   steps:
-  - task: NuGetToolInstaller@0
+  - task: NuGetToolInstaller@1
     inputs:
-      versionSpec: '4.8.2'
+      versionSpec: '5.5.0'
 
   - task: NuGetCommand@2
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ jobs:
        !**\*TestAdapter.dll
       platform: '$(buildPlatform)'
       configuration: '$(buildConfiguration)'
-      otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.0'
+      otherConsoleOptions: '/Framework:.NETCoreApp,Version=v3.1'
 
   - task: PublishTestResults@2
     inputs:
@@ -159,7 +159,7 @@ jobs:
     displayName: 'Install'
     inputs:
       packageType: 'sdk'
-      version: '2.2.401'
+      version: '3.1.201'
 
   - script: |
       mono --version

--- a/cs/benchmark/FASTER.benchmark.csproj
+++ b/cs/benchmark/FASTER.benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>

--- a/cs/playground/ClassCache/ClassCache.csproj
+++ b/cs/playground/ClassCache/ClassCache.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>

--- a/cs/playground/ClassCacheMT/ClassCacheMT.csproj
+++ b/cs/playground/ClassCacheMT/ClassCacheMT.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>

--- a/cs/playground/ClassRecoveryDurablity/ClassRecoveryDurablity.csproj
+++ b/cs/playground/ClassRecoveryDurablity/ClassRecoveryDurablity.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>preview</LangVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/cs/playground/ClassSample/ClassSample.csproj
+++ b/cs/playground/ClassSample/ClassSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>

--- a/cs/playground/FasterKVAsyncSample/FasterKVAsyncSample.csproj
+++ b/cs/playground/FasterKVAsyncSample/FasterKVAsyncSample.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
-    <LangVersion>preview</LangVersion>
     <RuntimeIdentifiers>win7-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/cs/playground/FasterKVDiskReadBenchmark/FasterKVDiskReadBenchmark.csproj
+++ b/cs/playground/FasterKVDiskReadBenchmark/FasterKVDiskReadBenchmark.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
-    <LangVersion>preview</LangVersion>
     <RuntimeIdentifiers>win7-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/cs/playground/FasterLogSample/FasterLogSample.csproj
+++ b/cs/playground/FasterLogSample/FasterLogSample.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
-    <LangVersion>preview</LangVersion>
     <RuntimeIdentifiers>win7-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/cs/playground/FixedLenStructSample/FixedLenStructSample.csproj
+++ b/cs/playground/FixedLenStructSample/FixedLenStructSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>

--- a/cs/playground/PeriodicCompaction/PeriodicCompaction.csproj
+++ b/cs/playground/PeriodicCompaction/PeriodicCompaction.csproj
@@ -3,10 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/playground/StructSample/StructSample.csproj
+++ b/cs/playground/StructSample/StructSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>

--- a/cs/playground/StructSampleCore/StructSampleCore.csproj
+++ b/cs/playground/StructSampleCore/StructSampleCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <RuntimeIdentifiers>win7-x64;linux-x64</RuntimeIdentifiers>
     <HighEntropyVA>true</HighEntropyVA>

--- a/cs/playground/SumStore/SumStore.csproj
+++ b/cs/playground/SumStore/SumStore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>

--- a/cs/playground/VarLenStructSample/VarLenStructSample.csproj
+++ b/cs/playground/VarLenStructSample/VarLenStructSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>

--- a/cs/src/core/FASTER.core.csproj
+++ b/cs/src/core/FASTER.core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
@@ -33,7 +33,7 @@
     <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(TargetFramework)'!='net461'">
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net461'">
     <DefineConstants>$(DefineConstants);DOTNETCORE</DefineConstants>
   </PropertyGroup>
 

--- a/cs/src/core/FASTER.core.csproj
+++ b/cs/src/core/FASTER.core.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -25,25 +25,33 @@
     <DebugType>full</DebugType>
     <OutputPath>bin\$(Platform)\Debug\</OutputPath>
   </PropertyGroup>
+  
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'!='net46'">
+  
+  <PropertyGroup Condition="'$(TargetFramework)'!='net461'">
     <DefineConstants>$(DefineConstants);DOTNETCORE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.3" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="System.Interactive.Async" Version="4.0.0" />
+    <PackageReference Include="System.Interactive.Async" Version="4.1.1" />
   </ItemGroup>
 </Project>

--- a/cs/src/core/FASTER.core.debug.nuspec
+++ b/cs/src/core/FASTER.core.debug.nuspec
@@ -15,28 +15,35 @@
     <language>en-US</language>
     <tags>key-value store dictionary hashtable concurrent log persistent commit write-ahead</tags>
     <dependencies>
-      <group targetFramework="net46">
-        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.7.0" />
-        <dependency id="System.Memory" version="4.5.3" />
-        <dependency id="System.Threading.Tasks.Extensions" version="4.5.3" />
+      <group targetFramework="net461">
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" />
+        <dependency id="System.Memory" version="4.5.4" />
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" />
         <dependency id="System.ValueTuple" version="4.5.0" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.7.0" />
-        <dependency id="System.Memory" version="4.5.3" />
-        <dependency id="System.Threading.Tasks.Extensions" version="4.5.3" />
-        <dependency id="System.ValueTuple" version="4.5.0" />
-        <dependency id="System.Interactive.Async" version="4.0.0" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" />
+        <dependency id="System.Memory" version="4.5.4" />
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" />
+        <dependency id="System.Interactive.Async" version="4.1.1" />
+        <dependency id="Mono.Posix.NETStandard" version="1.0.0" />
+      </group>
+      <group targetFramework="netstandard2.1">
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" />
+        <dependency id="System.Interactive.Async" version="4.1.1" />
         <dependency id="Mono.Posix.NETStandard" version="1.0.0" />
       </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\AnyCPU\Debug\net46\FASTER.core.dll" target="lib\net46" />
-    <file src="bin\AnyCPU\Debug\net46\FASTER.core.pdb" target="lib\net46" />
-    <file src="bin\AnyCPU\Debug\net46\FASTER.core.xml" target="lib\net46" />
+    <file src="bin\AnyCPU\Debug\net461\FASTER.core.dll" target="lib\net46" />
+    <file src="bin\AnyCPU\Debug\net461\FASTER.core.pdb" target="lib\net46" />
+    <file src="bin\AnyCPU\Debug\net461\FASTER.core.xml" target="lib\net46" />
     <file src="bin\AnyCPU\Debug\netstandard2.0\FASTER.core.dll" target="lib\netstandard2.0" />
     <file src="bin\AnyCPU\Debug\netstandard2.0\FASTER.core.pdb" target="lib\netstandard2.0" />
     <file src="bin\AnyCPU\Debug\netstandard2.0\FASTER.core.xml" target="lib\netstandard2.0" />
+    <file src="bin\AnyCPU\Debug\netstandard2.1\FASTER.core.dll" target="lib\netstandard2.1" />
+    <file src="bin\AnyCPU\Debug\netstandard2.1\FASTER.core.pdb" target="lib\netstandard2.1" />
+    <file src="bin\AnyCPU\Debugs\netstandard2.1\FASTER.core.xml" target="lib\netstandard2.1" />
   </files>
 </package>

--- a/cs/src/core/FASTER.core.debug.nuspec
+++ b/cs/src/core/FASTER.core.debug.nuspec
@@ -36,9 +36,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\AnyCPU\Debug\net461\FASTER.core.dll" target="lib\net46" />
-    <file src="bin\AnyCPU\Debug\net461\FASTER.core.pdb" target="lib\net46" />
-    <file src="bin\AnyCPU\Debug\net461\FASTER.core.xml" target="lib\net46" />
+    <file src="bin\AnyCPU\Debug\net461\FASTER.core.dll" target="lib\net461" />
+    <file src="bin\AnyCPU\Debug\net461\FASTER.core.pdb" target="lib\net461" />
+    <file src="bin\AnyCPU\Debug\net461\FASTER.core.xml" target="lib\net461" />
     <file src="bin\AnyCPU\Debug\netstandard2.0\FASTER.core.dll" target="lib\netstandard2.0" />
     <file src="bin\AnyCPU\Debug\netstandard2.0\FASTER.core.pdb" target="lib\netstandard2.0" />
     <file src="bin\AnyCPU\Debug\netstandard2.0\FASTER.core.xml" target="lib\netstandard2.0" />

--- a/cs/src/core/FASTER.core.nuspec
+++ b/cs/src/core/FASTER.core.nuspec
@@ -15,28 +15,35 @@
     <language>en-US</language>
     <tags>key-value store dictionary hashtable concurrent log persistent commit write-ahead</tags>
     <dependencies>
-      <group targetFramework="net46">
-        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.7.0" />
-        <dependency id="System.Memory" version="4.5.3" />
-        <dependency id="System.Threading.Tasks.Extensions" version="4.5.3" />
+      <group targetFramework="net461">
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" />
+        <dependency id="System.Memory" version="4.5.4" />
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" />
         <dependency id="System.ValueTuple" version="4.5.0" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.7.0" />
-        <dependency id="System.Memory" version="4.5.3" />
-        <dependency id="System.Threading.Tasks.Extensions" version="4.5.3" />
-        <dependency id="System.ValueTuple" version="4.5.0" />
-        <dependency id="System.Interactive.Async" version="4.0.0" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" />
+        <dependency id="System.Memory" version="4.5.4" />
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" />
+        <dependency id="System.Interactive.Async" version="4.1.1" />
+        <dependency id="Mono.Posix.NETStandard" version="1.0.0" />
+      </group>
+      <group targetFramework="netstandard2.1">
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" />
+        <dependency id="System.Interactive.Async" version="4.1.1" />
         <dependency id="Mono.Posix.NETStandard" version="1.0.0" />
       </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\AnyCPU\Release\net46\FASTER.core.dll" target="lib\net46" />
-    <file src="bin\AnyCPU\Release\net46\FASTER.core.pdb" target="lib\net46" />
-    <file src="bin\AnyCPU\Release\net46\FASTER.core.xml" target="lib\net46" />
+    <file src="bin\AnyCPU\Release\net461\FASTER.core.dll" target="lib\net46" />
+    <file src="bin\AnyCPU\Release\net461\FASTER.core.pdb" target="lib\net46" />
+    <file src="bin\AnyCPU\Release\net461\FASTER.core.xml" target="lib\net46" />
     <file src="bin\AnyCPU\Release\netstandard2.0\FASTER.core.dll" target="lib\netstandard2.0" />
     <file src="bin\AnyCPU\Release\netstandard2.0\FASTER.core.pdb" target="lib\netstandard2.0" />
     <file src="bin\AnyCPU\Release\netstandard2.0\FASTER.core.xml" target="lib\netstandard2.0" />
+    <file src="bin\AnyCPU\Release\netstandard2.1\FASTER.core.dll" target="lib\netstandard2.1" />
+    <file src="bin\AnyCPU\Release\netstandard2.1\FASTER.core.pdb" target="lib\netstandard2.1" />
+    <file src="bin\AnyCPU\Release\netstandard2.1\FASTER.core.xml" target="lib\netstandard2.1" />
   </files>
 </package>

--- a/cs/src/core/FASTER.core.nuspec
+++ b/cs/src/core/FASTER.core.nuspec
@@ -36,9 +36,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\AnyCPU\Release\net461\FASTER.core.dll" target="lib\net46" />
-    <file src="bin\AnyCPU\Release\net461\FASTER.core.pdb" target="lib\net46" />
-    <file src="bin\AnyCPU\Release\net461\FASTER.core.xml" target="lib\net46" />
+    <file src="bin\AnyCPU\Release\net461\FASTER.core.dll" target="lib\net461" />
+    <file src="bin\AnyCPU\Release\net461\FASTER.core.pdb" target="lib\net461" />
+    <file src="bin\AnyCPU\Release\net461\FASTER.core.xml" target="lib\net461" />
     <file src="bin\AnyCPU\Release\netstandard2.0\FASTER.core.dll" target="lib\netstandard2.0" />
     <file src="bin\AnyCPU\Release\netstandard2.0\FASTER.core.pdb" target="lib\netstandard2.0" />
     <file src="bin\AnyCPU\Release\netstandard2.0\FASTER.core.xml" target="lib\netstandard2.0" />

--- a/cs/src/devices/AzureStorageDevice/FASTER.devices.AzureStorageDevice.csproj
+++ b/cs/src/devices/AzureStorageDevice/FASTER.devices.AzureStorageDevice.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
@@ -32,7 +32,7 @@
     <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(TargetFramework)'!='net46'">
+  <PropertyGroup Condition="'$(TargetFramework)'!='net461'">
     <DefineConstants>$(DefineConstants);DOTNETCORE</DefineConstants>
   </PropertyGroup>
 

--- a/cs/src/devices/AzureStorageDevice/FASTER.devices.AzureStorageDevice.csproj
+++ b/cs/src/devices/AzureStorageDevice/FASTER.devices.AzureStorageDevice.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
@@ -24,18 +24,20 @@
     <DebugType>full</DebugType>
     <OutputPath>bin\$(Platform)\Debug\</OutputPath>
   </PropertyGroup>
+  
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
+  
   <PropertyGroup Condition="'$(TargetFramework)'!='net46'">
     <DefineConstants>$(DefineConstants);DOTNETCORE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\FASTER.core.csproj" />

--- a/cs/src/devices/AzureStorageDevice/FASTER.devices.AzureStorageDevice.nuspec
+++ b/cs/src/devices/AzureStorageDevice/FASTER.devices.AzureStorageDevice.nuspec
@@ -15,22 +15,29 @@
     <language>en-US</language>
     <tags>key-value store dictionary hashtable concurrent log persistent azure storage FASTER</tags>
     <dependencies>
-      <group targetFramework="net46">
-        <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.0" />
+      <group targetFramework="net461">
+        <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.3" />
         <dependency id="Microsoft.FASTER" version="$version$" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.0" />
+        <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.3" />
+        <dependency id="Microsoft.FASTER" version="$version$" />
+      </group>
+      <group targetFramework="netstandard2.1">
+        <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.3" />
         <dependency id="Microsoft.FASTER" version="$version$" />
       </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\AnyCPU\Release\net46\FASTER.devices.AzureStorageDevice.dll" target="lib\net46" />
-    <file src="bin\AnyCPU\Release\net46\FASTER.devices.AzureStorageDevice.pdb" target="lib\net46" />
-    <file src="bin\AnyCPU\Release\net46\FASTER.devices.AzureStorageDevice.xml" target="lib\net46" />
+    <file src="bin\AnyCPU\Release\net461\FASTER.devices.AzureStorageDevice.dll" target="lib\net461" />
+    <file src="bin\AnyCPU\Release\net461\FASTER.devices.AzureStorageDevice.pdb" target="lib\net461" />
+    <file src="bin\AnyCPU\Release\net461\FASTER.devices.AzureStorageDevice.xml" target="lib\net461" />
     <file src="bin\AnyCPU\Release\netstandard2.0\FASTER.devices.AzureStorageDevice.dll" target="lib\netstandard2.0" />
     <file src="bin\AnyCPU\Release\netstandard2.0\FASTER.devices.AzureStorageDevice.pdb" target="lib\netstandard2.0" />
     <file src="bin\AnyCPU\Release\netstandard2.0\FASTER.devices.AzureStorageDevice.xml" target="lib\netstandard2.0" />
+    <file src="bin\AnyCPU\Release\netstandard2.1\FASTER.devices.AzureStorageDevice.dll" target="lib\netstandard2.1" />
+    <file src="bin\AnyCPU\Release\netstandard2.1\FASTER.devices.AzureStorageDevice.pdb" target="lib\netstandard2.1" />
+    <file src="bin\AnyCPU\Release\netstandard2.1\FASTER.devices.AzureStorageDevice.xml" target="lib\netstandard2.1" />
   </files>
 </package>

--- a/cs/test/FASTER.test.csproj
+++ b/cs/test/FASTER.test.csproj
@@ -34,7 +34,7 @@
     <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(TargetFramework)'!='net46'">
+  <PropertyGroup Condition="'$(TargetFramework)'!='net461'">
     <DefineConstants>$(DefineConstants);DOTNETCORE</DefineConstants>
   </PropertyGroup>
     

--- a/cs/test/FASTER.test.csproj
+++ b/cs/test/FASTER.test.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <HighEntropyVA>true</HighEntropyVA>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -26,23 +26,28 @@
     <DebugType>full</DebugType>
     <OutputPath>bin\$(Platform)\Debug\</OutputPath>
   </PropertyGroup>
+  
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
+  
   <PropertyGroup Condition="'$(TargetFramework)'!='net46'">
     <DefineConstants>$(DefineConstants);DOTNETCORE</DefineConstants>
   </PropertyGroup>
+    
   <PropertyGroup>
     <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\src\core\FASTER.core.csproj" />
     <ProjectReference Include="..\src\devices\AzureStorageDevice\FASTER.devices.AzureStorageDevice.csproj" />

--- a/cs/test/FASTER.test.csproj
+++ b/cs/test/FASTER.test.csproj
@@ -43,9 +43,12 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
This PR:

- Adds build target for .NETSTANDARD 2.1 and simplifies dependencies for .NETCOREAPP3.1 & NET5.0
- Increases the minimum .NETFramework version to 4.6.1. Several dependent libraries dropped net46.
- Updates the nuget packages to their latest versions
- Updates playground samples to .NETCOREAPP3.1