### PR TITLE
Update other README.md docs with correct NuGet download link.

### DIFF
--- a/cs/README.md
+++ b/cs/README.md
@@ -17,7 +17,7 @@ Table of Contents
 Clone the Git repo, open cs/FASTER.sln in VS 2019, and build.
 
 ### NuGet
-You can install FASTER binaries using Nuget, from Nuget.org. Right-click on your project, manage NuGet packages, browse for FASTER. Here is a [direct link](https://www.nuget.org/packages/FASTER).
+You can install FASTER binaries using Nuget, from Nuget.org. Right-click on your project, manage NuGet packages, browse for FASTER. Here is a [direct link](https://www.nuget.org/packages/Microsoft.FASTER).
 
 ## Basic Concepts
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ C# and C++ versions of FASTER are very similar.
 
 * Visit our [research page](http://aka.ms/FASTER) for technical details and papers.
 * Start reading about FASTER C# [here](cs).
-* FASTER C# binaries are available via [NuGet](https://www.nuget.org/packages/FASTER/).
+* FASTER C# binaries are available via [NuGet](https://www.nuget.org/packages/Microsoft.FASTER).
 * Start reading about FASTER C++ [here](cc).
 
 


### PR DESCRIPTION
Hello Microsoft,

There were some outdated NuGet links to an old package in your README.md files. This PR changes the outdated NuGet links to the current NuGet link: https://www.nuget.org/packages/Microsoft.FASTER

Thanks,
Brian Chavez