### PR TITLE
Fast-forward client session trivially to the current system state, if…

### DIFF
--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -70,6 +70,9 @@ namespace FASTER.core
             Debug.WriteLine("Index Checkpoint: {0}", indexToken);
             Debug.WriteLine("HybridLog Checkpoint: {0}", hybridLogToken);
 
+            // Ensure active state machine to null
+            currentSyncStateMachine = null;
+
             // Recovery appropriate context information
             var recoveredICInfo = new IndexCheckpointInfo();
             recoveredICInfo.Recover(indexToken, checkpointManager);

--- a/cs/src/core/Index/Synchronization/FasterStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/FasterStateMachine.cs
@@ -136,6 +136,18 @@ namespace FASTER.core
             // Target state is the current (non-intermediate state) system state thread needs to catch up to
             var (currentTask, targetState) = CaptureTaskAndTargetState();
 
+            // No state machine associated with target, we can
+            // directly fast forward session to target state
+            if (currentTask == null)
+            {
+                if (ctx != null)
+                {
+                    ctx.phase = targetState.phase;
+                    ctx.version = targetState.version;
+                }
+                return;
+            }
+
             // the current thread state is what the thread remembers, or simply what the current system
             // is if we are calling from somewhere other than an execution thread (e.g. waiting on
             // a checkpoint to complete on a client app thread)


### PR DESCRIPTION
… the current system state were not associated with any state machine (null currentSyncStateMachine implies a trivial state machine). This can happen after recovery.