### PR TITLE
Remove using namespace from header file

### DIFF
--- a/cc/src/device/null_disk.h
+++ b/cc/src/device/null_disk.h
@@ -22,30 +22,30 @@ struct NullHandler {
 
 class NullFile {
  public:
-  Status Open(NullHandler* handler) {
-    return Status::Ok;
+  core::Status Open(NullHandler* handler) {
+    return core::Status::Ok;
   }
-  Status Close() {
-    return Status::Ok;
+  core::Status Close() {
+    return core::Status::Ok;
   }
-  Status Delete() {
-    return Status::Ok;
+  core::Status Delete() {
+    return core::Status::Ok;
   }
-  void Truncate(uint64_t new_begin_offset, GcState::truncate_callback_t callback) {
+  void Truncate(uint64_t new_begin_offset, core::GcState::truncate_callback_t callback) {
     if(callback) {
       callback(new_begin_offset);
     }
   }
 
-  Status ReadAsync(uint64_t source, void* dest, uint32_t length,
-                   AsyncIOCallback callback, IAsyncContext& context) const {
-    callback(&context, Status::Ok, length);
-    return Status::Ok;
+  core::Status ReadAsync(uint64_t source, void* dest, uint32_t length,
+                   core::AsyncIOCallback callback, core::IAsyncContext& context) const {
+    callback(&context, core::Status::Ok, length);
+    return core::Status::Ok;
   }
-  Status WriteAsync(const void* source, uint64_t dest, uint32_t length,
-                    AsyncIOCallback callback, IAsyncContext& context) {
-    callback(&context, Status::Ok, length);
-    return Status::Ok;
+  core::Status WriteAsync(const void* source, uint64_t dest, uint32_t length,
+                    core::AsyncIOCallback callback, core::IAsyncContext& context) {
+    callback(&context, core::Status::Ok, length);
+    return core::Status::Ok;
   }
 
   static size_t alignment() {
@@ -63,7 +63,7 @@ class NullDisk {
   typedef NullFile file_t;
   typedef NullFile log_file_t;
 
-  NullDisk(const std::string& filename, LightEpoch& epoch) {
+  NullDisk(const std::string& filename, core::LightEpoch& epoch) {
   }
 
   static uint32_t sector_size() {
@@ -78,28 +78,28 @@ class NullDisk {
     return log_;
   }
 
-  std::string relative_index_checkpoint_path(const Guid& token) const {
+  std::string relative_index_checkpoint_path(const core::Guid& token) const {
     assert(false);
     return "";
   }
-  std::string index_checkpoint_path(const Guid& token) const {
-    assert(false);
-    return "";
-  }
-
-  std::string relative_cpr_checkpoint_path(const Guid& token) const {
-    assert(false);
-    return "";
-  }
-  std::string cpr_checkpoint_path(const Guid& token) const {
+  std::string index_checkpoint_path(const core::Guid& token) const {
     assert(false);
     return "";
   }
 
-  void CreateIndexCheckpointDirectory(const Guid& token) {
+  std::string relative_cpr_checkpoint_path(const core::Guid& token) const {
+    assert(false);
+    return "";
+  }
+  std::string cpr_checkpoint_path(const core::Guid& token) const {
+    assert(false);
+    return "";
+  }
+
+  void CreateIndexCheckpointDirectory(const core::Guid& token) {
     assert(false);
   }
-  void CreateCprCheckpointDirectory(const Guid& token) {
+  void CreateCprCheckpointDirectory(const core::Guid& token) {
     assert(false);
   }
 

--- a/cc/src/environment/file_common.h
+++ b/cc/src/environment/file_common.h
@@ -8,8 +8,6 @@
 #include "../core/async.h"
 #include "../core/lss_allocator.h"
 
-using namespace FASTER::core;
-
 namespace FASTER {
 namespace environment {
 

--- a/cc/src/environment/file_linux.cc
+++ b/cc/src/environment/file_linux.cc
@@ -14,6 +14,10 @@
 namespace FASTER {
 namespace environment {
 
+using FASTER::core::Status;
+using FASTER::core::AsyncIOCallback;
+using FASTER::core::IAsyncContext;
+
 #ifdef _DEBUG
 #define DCHECK_ALIGNMENT(o, l, b) \
 do { \
@@ -105,7 +109,7 @@ int File::GetCreateDisposition(FileCreateDisposition create_disposition) {
 
 void QueueIoHandler::IoCompletionCallback(io_context_t ctx, struct iocb* iocb, long res,
     long res2) {
-  auto callback_context = make_context_unique_ptr<IoCallbackContext>(
+  auto callback_context = core::make_context_unique_ptr<IoCallbackContext>(
                             reinterpret_cast<IoCallbackContext*>(iocb));
   size_t bytes_transferred;
   Status return_status;
@@ -172,7 +176,7 @@ Status QueueFile::Write(size_t offset, uint32_t length, const uint8_t* buffer,
 Status QueueFile::ScheduleOperation(FileOperationType operationType, uint8_t* buffer,
                                     size_t offset, uint32_t length, IAsyncContext& context,
                                     AsyncIOCallback callback) {
-  auto io_context = alloc_context<QueueIoHandler::IoCallbackContext>(sizeof(
+  auto io_context = core::alloc_context<QueueIoHandler::IoCallbackContext>(sizeof(
                       QueueIoHandler::IoCallbackContext));
   if(!io_context.get()) return Status::OutOfMemory;
 

--- a/cc/src/environment/file_linux.cc
+++ b/cc/src/environment/file_linux.cc
@@ -14,9 +14,7 @@
 namespace FASTER {
 namespace environment {
 
-using FASTER::core::Status;
-using FASTER::core::AsyncIOCallback;
-using FASTER::core::IAsyncContext;
+using namespace FASTER::core;
 
 #ifdef _DEBUG
 #define DCHECK_ALIGNMENT(o, l, b) \

--- a/cc/src/environment/file_linux.h
+++ b/cc/src/environment/file_linux.h
@@ -66,7 +66,7 @@ class File {
 
   ~File() {
     if(owner_) {
-      Status s = Close();
+      core::Status s = Close();
     }
   }
 
@@ -86,11 +86,11 @@ class File {
   }
 
  protected:
-  Status Open(int flags, FileCreateDisposition create_disposition, bool* exists = nullptr);
+  core::Status Open(int flags, FileCreateDisposition create_disposition, bool* exists = nullptr);
 
  public:
-  Status Close();
-  Status Delete();
+  core::Status Close();
+  core::Status Delete();
 
   uint64_t size() const {
     struct stat stat_buffer;
@@ -119,7 +119,7 @@ class File {
 #endif
 
  private:
-  Status GetDeviceAlignment();
+  core::Status GetDeviceAlignment();
   static int GetCreateDisposition(FileCreateDisposition create_disposition);
 
  protected:
@@ -175,7 +175,7 @@ class QueueIoHandler {
 
   struct IoCallbackContext {
     IoCallbackContext(FileOperationType operation, int fd, size_t offset, uint32_t length,
-                      uint8_t* buffer, IAsyncContext* context_, AsyncIOCallback callback_)
+                      uint8_t* buffer, core::IAsyncContext* context_, core::AsyncIOCallback callback_)
       : caller_context{ context_ }
       , callback{ callback_ } {
       if(FileOperationType::Read == operation) {
@@ -193,10 +193,10 @@ class QueueIoHandler {
     struct iocb parent_iocb;
 
     /// Caller callback context.
-    IAsyncContext* caller_context;
+    core::IAsyncContext* caller_context;
 
     /// The caller's asynchronous callback function
-    AsyncIOCallback callback;
+    core::AsyncIOCallback callback;
   };
 
   inline io_context_t io_object() const {
@@ -235,17 +235,17 @@ class QueueFile : public File {
     return *this;
   }
 
-  Status Open(FileCreateDisposition create_disposition, const FileOptions& options,
+  core::Status Open(FileCreateDisposition create_disposition, const FileOptions& options,
               QueueIoHandler* handler, bool* exists = nullptr);
 
-  Status Read(size_t offset, uint32_t length, uint8_t* buffer,
-              IAsyncContext& context, AsyncIOCallback callback) const;
-  Status Write(size_t offset, uint32_t length, const uint8_t* buffer,
-               IAsyncContext& context, AsyncIOCallback callback);
+  core::Status Read(size_t offset, uint32_t length, uint8_t* buffer,
+                    core::IAsyncContext& context, core::AsyncIOCallback callback) const;
+  core::Status Write(size_t offset, uint32_t length, const uint8_t* buffer,
+                     core::IAsyncContext& context, core::AsyncIOCallback callback);
 
  private:
-  Status ScheduleOperation(FileOperationType operationType, uint8_t* buffer, size_t offset,
-                           uint32_t length, IAsyncContext& context, AsyncIOCallback callback);
+  core::Status ScheduleOperation(FileOperationType operationType, uint8_t* buffer, size_t offset,
+                           uint32_t length, core::IAsyncContext& context, core::AsyncIOCallback callback);
 
   io_context_t io_object_;
 };

--- a/cc/src/environment/file_windows.h
+++ b/cc/src/environment/file_windows.h
@@ -287,7 +287,7 @@ class QueueIoHandler {
   QueueIoHandler(size_t max_threads)
     : io_completion_port_{ 0 } {
     io_completion_port_ = ::CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0,
-                          (DWORD)Thread::kMaxNumThreads);
+                          (DWORD)core::Thread::kMaxNumThreads);
   }
 
   /// Move constructor

--- a/cc/src/environment/file_windows.h
+++ b/cc/src/environment/file_windows.h
@@ -69,7 +69,7 @@ class File {
 
   ~File() {
     if(owner_) {
-      Status s = Close();
+      core::Status s = Close();
     }
   }
 
@@ -89,11 +89,11 @@ class File {
   }
 
  protected:
-  Status Open(DWORD flags, FileCreateDisposition create_disposition, bool* exists = nullptr);
+  core::Status Open(DWORD flags, FileCreateDisposition create_disposition, bool* exists = nullptr);
 
  public:
-  Status Close();
-  Status Delete();
+  core::Status Close();
+  core::Status Delete();
 
   uint64_t size() const {
     LARGE_INTEGER file_size;
@@ -122,7 +122,7 @@ class File {
 #endif
 
  private:
-  Status GetDeviceAlignment();
+  core::Status GetDeviceAlignment();
   static DWORD GetCreateDisposition(FileCreateDisposition create_disposition);
 
  protected:
@@ -168,7 +168,7 @@ class WindowsPtpThreadPool {
 
   ~WindowsPtpThreadPool();
 
-  Status Schedule(Task task, void* task_argument);
+  core::Status Schedule(Task task, void* task_argument);
 
   PTP_CALLBACK_ENVIRON callback_environment() {
     return callback_environment_;
@@ -247,7 +247,7 @@ class ThreadPoolIoHandler {
   }
 
   struct IoCallbackContext {
-    IoCallbackContext(size_t offset, IAsyncContext* context_, AsyncIOCallback callback_)
+    IoCallbackContext(size_t offset, core::IAsyncContext* context_, core::AsyncIOCallback callback_)
       : caller_context{ context_ }
       , callback{ callback_ } {
       ::memset(&parent_overlapped, 0, sizeof(parent_overlapped));
@@ -261,9 +261,9 @@ class ThreadPoolIoHandler {
     /// The overlapped structure for Windows IO
     OVERLAPPED parent_overlapped;
     /// Caller callback context.
-    IAsyncContext* caller_context;
+    core::IAsyncContext* caller_context;
     /// The caller's asynchronous callback function
-    AsyncIOCallback callback;
+    core::AsyncIOCallback callback;
   };
 
   inline static constexpr bool TryComplete() {
@@ -309,7 +309,7 @@ class QueueIoHandler {
   }
 
   struct IoCallbackContext {
-    IoCallbackContext(size_t offset, IAsyncContext* context_, AsyncIOCallback callback_)
+    IoCallbackContext(size_t offset, core::IAsyncContext* context_, core::AsyncIOCallback callback_)
       : caller_context{ context_ }
       , callback{ callback_ } {
       ::memset(&parent_overlapped, 0, sizeof(parent_overlapped));
@@ -323,9 +323,9 @@ class QueueIoHandler {
     /// The overlapped structure for Windows IO
     OVERLAPPED parent_overlapped;
     /// Caller callback context.
-    IAsyncContext* caller_context;
+    core::IAsyncContext* caller_context;
     /// The caller's asynchronous callback function
-    AsyncIOCallback callback;
+    core::AsyncIOCallback callback;
   };
 
   bool TryComplete();
@@ -362,17 +362,17 @@ class ThreadPoolFile : public File {
     return *this;
   }
 
-  Status Open(FileCreateDisposition create_disposition, const FileOptions& options,
+  core::Status Open(FileCreateDisposition create_disposition, const FileOptions& options,
               ThreadPoolIoHandler* handler, bool* exists = nullptr);
 
-  Status Read(size_t offset, uint32_t length, uint8_t* buffer,
-              IAsyncContext& context, AsyncIOCallback callback) const;
-  Status Write(size_t offset, uint32_t length, const uint8_t* buffer,
-               IAsyncContext& context, AsyncIOCallback callback);
+  core::Status Read(size_t offset, uint32_t length, uint8_t* buffer,
+              core::IAsyncContext& context, core::AsyncIOCallback callback) const;
+  core::Status Write(size_t offset, uint32_t length, const uint8_t* buffer,
+               core::IAsyncContext& context, core::AsyncIOCallback callback);
 
  private:
-  Status ScheduleOperation(FileOperationType operationType, uint8_t* buffer, size_t offset,
-                           uint32_t length, IAsyncContext& context, AsyncIOCallback callback);
+  core::Status ScheduleOperation(FileOperationType operationType, uint8_t* buffer, size_t offset,
+                           uint32_t length, core::IAsyncContext& context, core::AsyncIOCallback callback);
 
   PTP_IO io_object_;
 };
@@ -398,17 +398,17 @@ class QueueFile : public File {
     return *this;
   }
 
-  Status Open(FileCreateDisposition create_disposition, const FileOptions& options,
+  core::Status Open(FileCreateDisposition create_disposition, const FileOptions& options,
               QueueIoHandler* handler, bool* exists = nullptr);
 
-  Status Read(size_t offset, uint32_t length, uint8_t* buffer,
-              IAsyncContext& context, AsyncIOCallback callback) const;
-  Status Write(size_t offset, uint32_t length, const uint8_t* buffer,
-               IAsyncContext& context, AsyncIOCallback callback);
+  core::Status Read(size_t offset, uint32_t length, uint8_t* buffer,
+              core::IAsyncContext& context, core::AsyncIOCallback callback) const;
+  core::Status Write(size_t offset, uint32_t length, const uint8_t* buffer,
+               core::IAsyncContext& context, core::AsyncIOCallback callback);
 
  private:
-  Status ScheduleOperation(FileOperationType operationType, uint8_t* buffer, size_t offset,
-                           uint32_t length, IAsyncContext& context, AsyncIOCallback callback);
+  core::Status ScheduleOperation(FileOperationType operationType, uint8_t* buffer, size_t offset,
+                           uint32_t length, core::IAsyncContext& context, core::AsyncIOCallback callback);
 };
 
 }

--- a/cc/test/test_types.h
+++ b/cc/test/test_types.h
@@ -22,9 +22,9 @@ class FixedSizeKey {
     return static_cast<uint32_t>(sizeof(FixedSizeKey));
   }
 
-  inline KeyHash GetHash() const {
+  inline core::KeyHash GetHash() const {
     HashFn hash_fn;
-    return KeyHash{ hash_fn(key) };
+    return core::KeyHash{ hash_fn(key) };
   }
 
   inline bool operator==(const FixedSizeKey& other) const {


### PR DESCRIPTION
As mentioned in #266, having a `using namespace` statement in a header file can cause ambiguous references down the line. This PR removes the `using namespace FASTER::core` statement from a header file and adapts the depending source files to use `core::` explicitly.