### PR TITLE
Make sure we have at least kHeaderSize immutable pages in log

### DIFF
--- a/cc/src/core/faster.h
+++ b/cc/src/core/faster.h
@@ -101,7 +101,7 @@ class FasterKv {
            double log_mutable_fraction = 0.9, bool pre_allocate_log = false)
     : min_table_size_{ table_size }
     , disk{ filename, epoch_ }
-    , hlog{ log_size, epoch_, disk, disk.log(), log_mutable_fraction, pre_allocate_log }
+    , hlog{ filename.empty() /*hasNoBackingStorage*/, log_size, epoch_, disk, disk.log(), log_mutable_fraction, pre_allocate_log }
     , system_state_{ Action::None, Phase::REST, 1 }
     , num_pending_ios{ 0 } {
     if(!Utility::IsPowerOfTwo(table_size)) {


### PR DESCRIPTION
It seems that when there is less than kHeaderSize immutable pages in log,
we will not be able to dump the in-memory log into disk when the in-memory
log is full. Added a check to enforce this requirement.

A complication is compaction logic. In compaction logic, the logic makes
sure that nothing will be dumped to disk, so it provides no backing storage
path (the root_directory is "") and the requirement does not apply.
So we will only throw error if root_directory is not "".