### PR TITLE
Separate out Input-dependent functions by session, for variable length structs

### DIFF
--- a/cs/playground/VarLenStructSample/Types.cs
+++ b/cs/playground/VarLenStructSample/Types.cs
@@ -63,7 +63,7 @@ namespace VarLenStructSample
 
     public struct VarLenLength : IVariableLengthStruct<VarLenType>
     {
-        public int GetAverageLength()
+        public int GetInitialLength()
         {
             return 2 * sizeof(int);
         }

--- a/cs/playground/VarLenStructSample/Types.cs
+++ b/cs/playground/VarLenStructSample/Types.cs
@@ -68,17 +68,7 @@ namespace VarLenStructSample
             return 2 * sizeof(int);
         }
 
-        public int GetInitialLength<Input>(ref Input input)
-        {
-            return 2 * sizeof(int);
-        }
-
         public int GetLength(ref VarLenType t)
-        {
-            return sizeof(int) * t.length;
-        }
-
-        public int GetLength<Input>(ref VarLenType t, ref Input input)
         {
             return sizeof(int) * t.length;
         }

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -298,8 +298,10 @@ namespace FASTER.core
         /// </summary>
         /// <param name="physicalAddress"></param>
         /// <param name="input"></param>
+        /// <param name="fasterSession"></param>
         /// <returns></returns>
-        public abstract int GetRecordSize<Input>(long physicalAddress, ref Input input);
+        public abstract int GetRecordSize<Input, FasterSession>(long physicalAddress, ref Input input, FasterSession fasterSession)
+            where FasterSession : IVariableLengthStruct<Value, Input>;
 
         /// <summary>
         /// Get number of bytes required
@@ -314,14 +316,17 @@ namespace FASTER.core
         /// </summary>
         /// <returns></returns>
         public abstract int GetAverageRecordSize();
+
         /// <summary>
         /// Get initial record size
         /// </summary>
-        /// <typeparam name="Input"></typeparam>
         /// <param name="key"></param>
         /// <param name="input"></param>
+        /// <param name="fasterSession"></param>
         /// <returns></returns>
-        public abstract int GetInitialRecordSize<Input>(ref Key key, ref Input input);
+        public abstract int GetInitialRecordSize<Input, FasterSession>(ref Key key, ref Input input, FasterSession fasterSession)
+            where FasterSession : IVariableLengthStruct<Value, Input>;
+
         /// <summary>
         /// Get record size
         /// </summary>

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -67,7 +67,7 @@ namespace FASTER.core
             return recordSize;
         }
 
-        public override int GetRecordSize<Input>(long physicalAddress, ref Input input)
+        public override int GetRecordSize<Input, FasterSession>(long physicalAddress, ref Input input, FasterSession fasterSession)
         {
             return recordSize;
         }
@@ -77,7 +77,7 @@ namespace FASTER.core
             return recordSize;
         }
 
-        public override int GetInitialRecordSize<Input>(ref Key key, ref Input input)
+        public override int GetInitialRecordSize<Input, FasterSession>(ref Key key, ref Input input, FasterSession fasterSession)
         {
             return recordSize;
         }

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -141,7 +141,7 @@ namespace FASTER.core
             return recordSize;
         }
 
-        public override int GetRecordSize<Input>(long physicalAddress, ref Input input)
+        public override int GetRecordSize<Input, FasterSession>(long physicalAddress, ref Input input, FasterSession fasterSession)
         {
             return recordSize;
         }
@@ -151,7 +151,7 @@ namespace FASTER.core
             return recordSize;
         }
 
-        public override int GetInitialRecordSize<Input>(ref Key key, ref Input input)
+        public override int GetInitialRecordSize<Input, FasterSession>(ref Key key, ref Input input, FasterSession fasterSession)
         {
             return recordSize;
         }

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -121,7 +121,7 @@ namespace FASTER.core
             }
 
             // We need at least [record size] + [actual key size] + [average value size]
-            reqBytes = RecordInfo.GetLength() + KeySize(physicalAddress) + ValueLength.GetAverageLength();
+            reqBytes = RecordInfo.GetLength() + KeySize(physicalAddress) + ValueLength.GetInitialLength();
             if (availableBytes < reqBytes)
             {
                 return reqBytes;
@@ -137,8 +137,8 @@ namespace FASTER.core
         {
             return RecordInfo.GetLength() +
                 kRecordAlignment +
-                KeyLength.GetAverageLength() +
-                ValueLength.GetAverageLength();
+                KeyLength.GetInitialLength() +
+                ValueLength.GetInitialLength();
         }
 
         public override int GetInitialRecordSize<TInput, FasterSession>(ref Key key, ref TInput input, FasterSession fasterSession)

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -89,11 +89,6 @@ namespace FASTER.core
             return ValueLength.GetLength(ref GetValue(physicalAddress));
         }
 
-        private int ValueSize<Input>(long physicalAddress, ref Input input)
-        {
-            return ValueLength.GetLength(ref GetValue(physicalAddress), ref input);
-        }
-
         public override int GetRecordSize(long physicalAddress)
         {
             ref var recordInfo = ref GetInfo(physicalAddress);
@@ -105,13 +100,13 @@ namespace FASTER.core
             return size;
         }
 
-        public override int GetRecordSize<Input>(long physicalAddress, ref Input input)
+        public override int GetRecordSize<Input, FasterSession>(long physicalAddress, ref Input input, FasterSession fasterSession)
         {
             ref var recordInfo = ref GetInfo(physicalAddress);
             if (recordInfo.IsNull())
                 return RecordInfo.GetLength();
 
-            var size = RecordInfo.GetLength() + KeySize(physicalAddress) + ValueSize(physicalAddress, ref input);
+            var size = RecordInfo.GetLength() + KeySize(physicalAddress) + fasterSession.GetLength(ref GetValue(physicalAddress), ref input);
             size = (size + kRecordAlignment - 1) & (~(kRecordAlignment - 1));
             return size;
         }
@@ -146,11 +141,11 @@ namespace FASTER.core
                 ValueLength.GetAverageLength();
         }
 
-        public override int GetInitialRecordSize<TInput>(ref Key key, ref TInput input)
+        public override int GetInitialRecordSize<TInput, FasterSession>(ref Key key, ref TInput input, FasterSession fasterSession)
         {
             var actualSize = RecordInfo.GetLength() +
                 KeyLength.GetLength(ref key) +
-                ValueLength.GetInitialLength(ref input);
+                fasterSession.GetInitialLength(ref input);
 
             return (actualSize + kRecordAlignment - 1) & (~(kRecordAlignment - 1));
         }

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,6 +33,7 @@ namespace FASTER.core
         internal CommitPoint LatestCommitPoint;
 
         internal readonly Functions functions;
+        internal readonly IVariableLengthStruct<Value, Input> variableLengthStruct;
 
         internal readonly AsyncFasterSession FasterSession;
 
@@ -39,7 +41,8 @@ namespace FASTER.core
             FasterKV<Key, Value> fht,
             FasterKV<Key, Value>.FasterExecutionContext<Input, Output, Context> ctx,
             Functions functions,
-            bool supportAsync)
+            bool supportAsync,
+            IVariableLengthStruct<Value, Input> variableLengthStruct)
         {
             this.fht = fht;
             this.ctx = ctx;
@@ -47,7 +50,22 @@ namespace FASTER.core
             SupportAsync = supportAsync;
             LatestCommitPoint = new CommitPoint { UntilSerialNo = -1, ExcludedSerialNos = null };
             FasterSession = new AsyncFasterSession(this);
-            
+
+            this.variableLengthStruct = variableLengthStruct;
+            if (this.variableLengthStruct == default)
+            {
+                if (fht.hlog is VariableLengthBlittableAllocator<Key, Value> allocator)
+                {
+                    Debug.WriteLine("Warning: Session did not specify Input-specific functions for variable-length values via IVariableLengthStruct<Value, Input>");
+                    this.variableLengthStruct = new DefaultVariableLengthStruct<Value, Input>(allocator.ValueLength);
+                }
+            }
+            else
+            {
+                if (fht.hlog is VariableLengthBlittableAllocator<Key, Value>)
+                    Debug.WriteLine("Warning: Session param of variableLengthStruct provided for non-varlen allocator");
+            }
+
             // Session runs on a single thread
             if (!supportAsync)
                 UnsafeResumeThread();
@@ -504,6 +522,16 @@ namespace FASTER.core
             public void DeleteCompletionCallback(ref Key key, Context ctx)
             {
                 _clientSession.functions.DeleteCompletionCallback(ref key, ctx);
+            }
+
+            public int GetInitialLength(ref Input input)
+            {
+                return _clientSession.variableLengthStruct.GetInitialLength(ref input);
+            }
+
+            public int GetLength(ref Value t, ref Input input)
+            {
+                return _clientSession.variableLengthStruct.GetLength(ref t, ref input);
             }
 
             public void InitialUpdater(ref Key key, ref Input input, ref Value value)

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -62,7 +62,7 @@ namespace FASTER.core
             }
             else
             {
-                if (fht.hlog is VariableLengthBlittableAllocator<Key, Value>)
+                if (!(fht.hlog is VariableLengthBlittableAllocator<Key, Value>))
                     Debug.WriteLine("Warning: Session param of variableLengthStruct provided for non-varlen allocator");
             }
 

--- a/cs/src/core/Index/Common/LogSettings.cs
+++ b/cs/src/core/Index/Common/LogSettings.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace FASTER.core
 {
@@ -21,100 +22,6 @@ namespace FASTER.core
         /// Value serializer
         /// </summary>
         public Func<IObjectSerializer<Value>> valueSerializer;
-    }
-
-    /// <summary>
-    /// Interface for variable length in-place objects
-    /// modeled as structs, in FASTER
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public interface IVariableLengthStruct<T>
-    {
-        /// <summary>
-        /// Actual length of object
-        /// </summary>
-        /// <param name="t"></param>
-        /// <returns></returns>
-        int GetLength(ref T t);
-
-        /// <summary>
-        /// Actual length of object
-        /// </summary>
-        /// <param name="t"></param>
-        /// <param name="input"></param>
-        /// <returns></returns>
-        int GetLength<Input>(ref T t, ref Input input);
-
-        /// <summary>
-        /// Average length of objects, make sure this includes the object
-        /// header needed to compute the actual object length
-        /// </summary>
-        /// <returns></returns>
-        int GetAverageLength();
-
-        /// <summary>
-        /// Initial length, when populating for RMW from given input
-        /// </summary>
-        /// <typeparam name="Input"></typeparam>
-        /// <param name="input"></param>
-        /// <returns></returns>
-        int GetInitialLength<Input>(ref Input input);
-    }
-
-    /// <summary>
-    /// Length specification for fixed size (normal) structs
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public readonly struct FixedLengthStruct<T> : IVariableLengthStruct<T>
-    {
-        private static readonly int size = Utility.GetSize(default(T));
-
-        /// <summary>
-        /// Get average length
-        /// </summary>
-        /// <returns></returns>
-        public int GetAverageLength() => size;
-
-        /// <summary>
-        /// Get initial length
-        /// </summary>
-        /// <typeparam name="Input"></typeparam>
-        /// <param name="input"></param>
-        /// <returns></returns>
-        public int GetInitialLength<Input>(ref Input input) => size;
-       
-        /// <summary>
-        /// Get length
-        /// </summary>
-        /// <param name="t"></param>
-        /// <returns></returns>
-        public int GetLength(ref T t) => size;
-
-        /// <summary>
-        /// Actual length of object
-        /// </summary>
-        /// <param name="t"></param>
-        /// <param name="input"></param>
-        /// <returns></returns>
-        public int GetLength<Input>(ref T t, ref Input input) => size;
-    }
-
-    /// <summary>
-    /// Settings for variable length keys and values
-    /// </summary>
-    /// <typeparam name="Key"></typeparam>
-    /// <typeparam name="Value"></typeparam>
-    public class VariableLengthStructSettings<Key, Value>
-    {
-        /// <summary>
-        /// Key length
-        /// </summary>
-        public IVariableLengthStruct<Key> keyLength;
-
-        /// <summary>
-        /// Value length
-        /// </summary>
-        public IVariableLengthStruct<Value> valueLength;
     }
 
     /// <summary>

--- a/cs/src/core/Index/Common/VariableLengthStruct.cs
+++ b/cs/src/core/Index/Common/VariableLengthStruct.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace FASTER.core
+{
+    /// <summary>
+    /// Interface for variable length in-place objects
+    /// modeled as structs, in FASTER
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IVariableLengthStruct<T>
+    {
+        /// <summary>
+        /// Actual length of object
+        /// </summary>
+        /// <param name="t"></param>
+        /// <returns></returns>
+        int GetLength(ref T t);
+
+        /// <summary>
+        /// Average length of objects, make sure this includes the object
+        /// header needed to compute the actual object length
+        /// </summary>
+        /// <returns></returns>
+        int GetAverageLength();
+    }
+
+    /// <summary>
+    /// Length specification for fixed size (normal) structs
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal readonly struct FixedLengthStruct<T> : IVariableLengthStruct<T>
+    {
+        private static readonly int size = Utility.GetSize(default(T));
+
+        /// <summary>
+        /// Get average length
+        /// </summary>
+        /// <returns></returns>
+        public int GetAverageLength() => size;
+
+        /// <summary>
+        /// Get length
+        /// </summary>
+        /// <param name="t"></param>
+        /// <returns></returns>
+        public int GetLength(ref T t) => size;
+    }
+
+    /// <summary>
+    /// Settings for variable length keys and values
+    /// </summary>
+    /// <typeparam name="Key"></typeparam>
+    /// <typeparam name="Value"></typeparam>
+    public class VariableLengthStructSettings<Key, Value>
+    {
+        /// <summary>
+        /// Key length
+        /// </summary>
+        public IVariableLengthStruct<Key> keyLength;
+
+        /// <summary>
+        /// Value length
+        /// </summary>
+        public IVariableLengthStruct<Value> valueLength;
+    }
+
+    /// <summary>
+    /// Interface for variable length in-place objects
+    /// modeled as structs, in FASTER
+    /// </summary>
+    /// <typeparam name="Value"></typeparam>
+    /// <typeparam name="Input"></typeparam>
+    public interface IVariableLengthStruct<Value, Input>
+    {
+        /// <summary>
+        /// Length of resulting Value when performing RMW with
+        /// </summary>
+        /// <param name="t"></param>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        int GetLength(ref Value t, ref Input input);
+
+        /// <summary>
+        /// Initial length, when populating for RMW from given input
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        int GetInitialLength(ref Input input);
+    }
+
+    internal readonly struct DefaultVariableLengthStruct<T, TInput> : IVariableLengthStruct<T, TInput>
+    {
+        private readonly IVariableLengthStruct<T> variableLengthStruct;
+
+        /// <summary>
+        /// Default instance of object
+        /// </summary>
+        /// <param name="variableLengthStruct"></param>
+        public DefaultVariableLengthStruct(IVariableLengthStruct<T> variableLengthStruct)
+        {
+            this.variableLengthStruct = variableLengthStruct;
+        }
+
+        public int GetInitialLength(ref TInput input)
+        {
+            return variableLengthStruct.GetAverageLength();
+        }
+
+        public int GetLength(ref T t, ref TInput input)
+        {
+            return variableLengthStruct.GetLength(ref t);
+        }
+    }
+}

--- a/cs/src/core/Index/Common/VariableLengthStruct.cs
+++ b/cs/src/core/Index/Common/VariableLengthStruct.cs
@@ -11,18 +11,18 @@ namespace FASTER.core
     public interface IVariableLengthStruct<T>
     {
         /// <summary>
-        /// Actual length of object
+        /// Actual length of given object
         /// </summary>
         /// <param name="t"></param>
         /// <returns></returns>
         int GetLength(ref T t);
 
         /// <summary>
-        /// Average length of objects, make sure this includes the object
+        /// Initial expected length of objects, make sure this includes the object
         /// header needed to compute the actual object length
         /// </summary>
         /// <returns></returns>
-        int GetAverageLength();
+        int GetInitialLength();
     }
 
     /// <summary>
@@ -37,7 +37,7 @@ namespace FASTER.core
         /// Get average length
         /// </summary>
         /// <returns></returns>
-        public int GetAverageLength() => size;
+        public int GetInitialLength() => size;
 
         /// <summary>
         /// Get length
@@ -66,30 +66,30 @@ namespace FASTER.core
     }
 
     /// <summary>
-    /// Interface for variable length in-place objects
+    /// Input-specific interface for variable length in-place objects
     /// modeled as structs, in FASTER
     /// </summary>
-    /// <typeparam name="Value"></typeparam>
+    /// <typeparam name="T"></typeparam>
     /// <typeparam name="Input"></typeparam>
-    public interface IVariableLengthStruct<Value, Input>
+    public interface IVariableLengthStruct<T, Input>
     {
         /// <summary>
-        /// Length of resulting Value when performing RMW with
+        /// Length of resulting object when performing RMW with given input
         /// </summary>
         /// <param name="t"></param>
         /// <param name="input"></param>
         /// <returns></returns>
-        int GetLength(ref Value t, ref Input input);
+        int GetLength(ref T t, ref Input input);
 
         /// <summary>
-        /// Initial length, when populating for RMW from given input
+        /// Initial expected length of object, when populated by RMW using given input
         /// </summary>
         /// <param name="input"></param>
         /// <returns></returns>
         int GetInitialLength(ref Input input);
     }
 
-    internal readonly struct DefaultVariableLengthStruct<T, TInput> : IVariableLengthStruct<T, TInput>
+    internal readonly struct DefaultVariableLengthStruct<T, Input> : IVariableLengthStruct<T, Input>
     {
         private readonly IVariableLengthStruct<T> variableLengthStruct;
 
@@ -102,12 +102,12 @@ namespace FASTER.core
             this.variableLengthStruct = variableLengthStruct;
         }
 
-        public int GetInitialLength(ref TInput input)
+        public int GetInitialLength(ref Input input)
         {
-            return variableLengthStruct.GetAverageLength();
+            return variableLengthStruct.GetInitialLength();
         }
 
-        public int GetLength(ref T t, ref TInput input)
+        public int GetLength(ref T t, ref Input input)
         {
             return variableLengthStruct.GetLength(ref t);
         }

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -730,8 +730,8 @@ namespace FASTER.core
         CreateNewRecord:
             {
                 recordSize = (logicalAddress < hlog.BeginAddress) ?
-                                hlog.GetInitialRecordSize(ref key, ref input) :
-                                hlog.GetRecordSize(physicalAddress, ref input);
+                                hlog.GetInitialRecordSize(ref key, ref input, fasterSession) :
+                                hlog.GetRecordSize(physicalAddress, ref input, fasterSession);
                 BlockAllocate(recordSize, out long newLogicalAddress, sessionCtx, fasterSession);
                 var newPhysicalAddress = hlog.GetPhysicalAddress(newLogicalAddress);
                 RecordInfo.WriteInfo(ref hlog.GetInfo(newPhysicalAddress), sessionCtx.version,
@@ -1442,12 +1442,12 @@ namespace FASTER.core
             #region Create record in mutable region
             if ((request.logicalAddress < hlog.BeginAddress) || (hlog.GetInfoFromBytePointer(request.record.GetValidPointer()).Tombstone))
             {
-                recordSize = hlog.GetInitialRecordSize(ref key, ref pendingContext.input);
+                recordSize = hlog.GetInitialRecordSize(ref key, ref pendingContext.input, fasterSession);
             }
             else
             {
                 physicalAddress = (long)request.record.GetValidPointer();
-                recordSize = hlog.GetRecordSize(physicalAddress, ref pendingContext.input);
+                recordSize = hlog.GetRecordSize(physicalAddress, ref pendingContext.input, fasterSession);
             }
             BlockAllocate(recordSize, out long newLogicalAddress, sessionCtx, fasterSession);
             var newPhysicalAddress = hlog.GetPhysicalAddress(newLogicalAddress);

--- a/cs/src/core/Index/Interfaces/IFasterKV.cs
+++ b/cs/src/core/Index/Interfaces/IFasterKV.cs
@@ -237,8 +237,9 @@ namespace FASTER.core
         /// <param name="functions">Callback functions.</param>
         /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
         /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
+        /// <param name="variableLengthStruct">Implementation of input-specific length computation for variable-length structs</param>
         /// <returns>Session instance</returns>
-        ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Input, Output, Context, Functions>(Functions functions, string sessionId = null, bool threadAffinitized = false)
+        ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Input, Output, Context, Functions>(Functions functions, string sessionId = null, bool threadAffinitized = false, IVariableLengthStruct<Value, Input> variableLengthStruct = null)
             where Functions : IFunctions<Key, Value, Input, Output, Context>;
 
         /// <summary>
@@ -249,8 +250,9 @@ namespace FASTER.core
         /// <param name="sessionId">ID/name of previous session to resume</param>
         /// <param name="commitPoint">Prior commit point of durability for session</param>
         /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
+        /// <param name="variableLengthStruct">Implementation of input-specific length computation for variable-length structs</param>
         /// <returns>Session instance</returns>
-        ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Input, Output, Context, Functions>(Functions functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false)
+        ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Input, Output, Context, Functions>(Functions functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, IVariableLengthStruct<Value, Input> variableLengthStruct = null)
             where Functions : IFunctions<Key, Value, Input, Output, Context>;
 
         #endregion

--- a/cs/src/core/Index/Interfaces/IFasterSession.cs
+++ b/cs/src/core/Index/Interfaces/IFasterSession.cs
@@ -19,7 +19,7 @@
     /// <typeparam name="Input"></typeparam>
     /// <typeparam name="Output"></typeparam>
     /// <typeparam name="Context"></typeparam>
-    internal interface IFasterSession<Key, Value, Input, Output, Context> : IFunctions<Key, Value, Input, Output, Context>, IFasterSession
+    internal interface IFasterSession<Key, Value, Input, Output, Context> : IFunctions<Key, Value, Input, Output, Context>, IFasterSession, IVariableLengthStruct<Value, Input>
     {
     }
 }

--- a/cs/test/VLTestTypes.cs
+++ b/cs/test/VLTestTypes.cs
@@ -34,7 +34,7 @@ namespace FASTER.test
             return sizeof(long);
         }
 
-        public int GetAverageLength()
+        public int GetInitialLength()
         {
             return sizeof(long);
         }
@@ -49,7 +49,7 @@ namespace FASTER.test
         [FieldOffset(4)]
         public int field1;
 
-        public int GetAverageLength()
+        public int GetInitialLength()
         {
             return 2 * sizeof(int);
         }

--- a/cs/test/VLTestTypes.cs
+++ b/cs/test/VLTestTypes.cs
@@ -34,17 +34,7 @@ namespace FASTER.test
             return sizeof(long);
         }
 
-        public int GetLength<Input>(ref Key t, ref Input input)
-        {
-            return sizeof(long);
-        }
-
         public int GetAverageLength()
-        {
-            return sizeof(long);
-        }
-
-        public int GetInitialLength<Input>(ref Input input)
         {
             return sizeof(long);
         }
@@ -64,17 +54,7 @@ namespace FASTER.test
             return 2 * sizeof(int);
         }
 
-        public int GetInitialLength<Input>(ref Input input)
-        {
-            return 2 * sizeof(int);
-        }
-
         public int GetLength(ref VLValue t)
-        {
-            return sizeof(int) * t.length;
-        }
-
-        public int GetLength<Input>(ref VLValue t, ref Input input)
         {
             return sizeof(int) * t.length;
         }


### PR DESCRIPTION

* Allow users to specify var-len struct settings that are Input-dependent, on a per-session basis, using a new IVariableLengthStruct<T, Input>.
* Remove Input-based methods from IVariableLengthStruct<T> interface.
* Provide default implementation for the Input-dependent functions
GetLenth(Input) -> GetAverageLength()
GetLength(Value, Input) -> GetLength(Value)

Fix https://github.com/microsoft/FASTER/issues/289
