### PR TITLE
[C#] Remove generic type constraint + add DataContract serializer

### DIFF
--- a/cs/playground/ClassCache/Types.cs
+++ b/cs/playground/ClassCache/Types.cs
@@ -34,12 +34,12 @@ namespace ClassCache
 
     public class CacheKeySerializer : BinaryObjectSerializer<CacheKey>
     {
-        public override void Deserialize(ref CacheKey obj)
+        public override void Deserialize(out CacheKey obj)
         {
             obj = new CacheKey(reader.ReadInt64());
         }
 
-        public override void Serialize(ref CacheKey obj)
+        public override void Serialize(in CacheKey obj)
         {
             writer.Write(obj.key);
         }
@@ -59,12 +59,12 @@ namespace ClassCache
 
     public class CacheValueSerializer : BinaryObjectSerializer<CacheValue>
     {
-        public override void Deserialize(ref CacheValue obj)
+        public override void Deserialize(out CacheValue obj)
         {
             obj = new CacheValue(reader.ReadInt64());
         }
 
-        public override void Serialize(ref CacheValue obj)
+        public override void Serialize(in CacheValue obj)
         {
             writer.Write(obj.value);
         }

--- a/cs/playground/ClassCache/Types.cs
+++ b/cs/playground/ClassCache/Types.cs
@@ -36,7 +36,7 @@ namespace ClassCache
     {
         public override void Deserialize(ref CacheKey obj)
         {
-            obj.key = reader.ReadInt64();
+            obj = new CacheKey(reader.ReadInt64());
         }
 
         public override void Serialize(ref CacheKey obj)
@@ -61,7 +61,7 @@ namespace ClassCache
     {
         public override void Deserialize(ref CacheValue obj)
         {
-            obj.value = reader.ReadInt64();
+            obj = new CacheValue(reader.ReadInt64());
         }
 
         public override void Serialize(ref CacheValue obj)

--- a/cs/playground/ClassCacheMT/Types.cs
+++ b/cs/playground/ClassCacheMT/Types.cs
@@ -36,7 +36,7 @@ namespace ClassCacheMT
     {
         public override void Deserialize(ref CacheKey obj)
         {
-            obj.key = reader.ReadInt64();
+            obj = new CacheKey(reader.ReadInt64());
         }
 
         public override void Serialize(ref CacheKey obj)
@@ -61,7 +61,7 @@ namespace ClassCacheMT
     {
         public override void Deserialize(ref CacheValue obj)
         {
-            obj.value = reader.ReadInt64();
+            obj = new CacheValue(reader.ReadInt64());
         }
 
         public override void Serialize(ref CacheValue obj)

--- a/cs/playground/ClassCacheMT/Types.cs
+++ b/cs/playground/ClassCacheMT/Types.cs
@@ -34,12 +34,12 @@ namespace ClassCacheMT
 
     public class CacheKeySerializer : BinaryObjectSerializer<CacheKey>
     {
-        public override void Deserialize(ref CacheKey obj)
+        public override void Deserialize(out CacheKey obj)
         {
             obj = new CacheKey(reader.ReadInt64());
         }
 
-        public override void Serialize(ref CacheKey obj)
+        public override void Serialize(in CacheKey obj)
         {
             writer.Write(obj.key);
         }
@@ -59,12 +59,12 @@ namespace ClassCacheMT
 
     public class CacheValueSerializer : BinaryObjectSerializer<CacheValue>
     {
-        public override void Deserialize(ref CacheValue obj)
+        public override void Deserialize(out CacheValue obj)
         {
             obj = new CacheValue(reader.ReadInt64());
         }
 
-        public override void Serialize(ref CacheValue obj)
+        public override void Serialize(in CacheValue obj)
         {
             writer.Write(obj.value);
         }

--- a/cs/playground/ClassRecoveryDurablity/Types.cs
+++ b/cs/playground/ClassRecoveryDurablity/Types.cs
@@ -36,7 +36,7 @@ namespace ClassRecoveryDurablity
 
         public class StoreKeySerializer : BinaryObjectSerializer<StoreKey>
         {
-            public override void Deserialize(ref StoreKey obj)
+            public override void Deserialize(out StoreKey obj)
             {
                 obj = new StoreKey();
                 var bytesr = new byte[4];
@@ -53,7 +53,7 @@ namespace ClassRecoveryDurablity
                 reader.Read(obj.key, 0, size);
             }
 
-            public override void Serialize(ref StoreKey obj)
+            public override void Serialize(in StoreKey obj)
             {
                 var bytes = System.Text.Encoding.UTF8.GetBytes(obj.tableType);
                 var len = BitConverter.GetBytes(bytes.Length);
@@ -76,7 +76,7 @@ namespace ClassRecoveryDurablity
 
         public class StoreValueSerializer : BinaryObjectSerializer<StoreValue>
         {
-            public override void Deserialize(ref StoreValue obj)
+            public override void Deserialize(out StoreValue obj)
             {
                 obj = new StoreValue();
                 var bytesr = new byte[4];
@@ -85,7 +85,7 @@ namespace ClassRecoveryDurablity
                 obj.value = reader.ReadBytes(size);
             }
 
-            public override void Serialize(ref StoreValue obj)
+            public override void Serialize(in StoreValue obj)
             {
                 var len = BitConverter.GetBytes(obj.value.Length);
                 writer.Write(len);

--- a/cs/playground/ClassRecoveryDurablity/Types.cs
+++ b/cs/playground/ClassRecoveryDurablity/Types.cs
@@ -38,6 +38,7 @@ namespace ClassRecoveryDurablity
         {
             public override void Deserialize(ref StoreKey obj)
             {
+                obj = new StoreKey();
                 var bytesr = new byte[4];
                 reader.Read(bytesr, 0, 4);
                 var sizet = BitConverter.ToInt32(bytesr);
@@ -77,6 +78,7 @@ namespace ClassRecoveryDurablity
         {
             public override void Deserialize(ref StoreValue obj)
             {
+                obj = new StoreValue();
                 var bytesr = new byte[4];
                 reader.Read(bytesr, 0, 4);
                 int size = BitConverter.ToInt32(bytesr);

--- a/cs/playground/ClassSample/Program.cs
+++ b/cs/playground/ClassSample/Program.cs
@@ -28,12 +28,12 @@ namespace ClassSample
 
     public class MyKeySerializer : BinaryObjectSerializer<MyKey>
     {
-        public override void Serialize(ref MyKey key)
+        public override void Serialize(in MyKey key)
         {
             writer.Write(key.key);
         }
 
-        public override void Deserialize(ref MyKey key)
+        public override void Deserialize(out MyKey key)
         {
             key = new MyKey();
             key.key = reader.ReadInt32();
@@ -48,12 +48,12 @@ namespace ClassSample
 
     public class MyValueSerializer : BinaryObjectSerializer<MyValue>
     {
-        public override void Serialize(ref MyValue value)
+        public override void Serialize(in MyValue value)
         {
             writer.Write(value.value);
         }
 
-        public override void Deserialize(ref MyValue value)
+        public override void Deserialize(out MyValue value)
         {
             value = new MyValue();
             value.value = reader.ReadInt32();

--- a/cs/playground/ClassSample/Program.cs
+++ b/cs/playground/ClassSample/Program.cs
@@ -35,6 +35,7 @@ namespace ClassSample
 
         public override void Deserialize(ref MyKey key)
         {
+            key = new MyKey();
             key.key = reader.ReadInt32();
         }
     }
@@ -54,6 +55,7 @@ namespace ClassSample
 
         public override void Deserialize(ref MyValue value)
         {
+            value = new MyValue();
             value.value = reader.ReadInt32();
         }
     }

--- a/cs/playground/FasterKVAsyncSample/Types.cs
+++ b/cs/playground/FasterKVAsyncSample/Types.cs
@@ -36,7 +36,7 @@ namespace FasterKVAsyncSample
     {
         public override void Deserialize(ref CacheKey obj)
         {
-            obj.key = reader.ReadInt64();
+            obj = new CacheKey(reader.ReadInt64());
         }
 
         public override void Serialize(ref CacheKey obj)
@@ -61,7 +61,7 @@ namespace FasterKVAsyncSample
     {
         public override void Deserialize(ref CacheValue obj)
         {
-            obj.value = reader.ReadInt64();
+            obj = new CacheValue(reader.ReadInt64());
         }
 
         public override void Serialize(ref CacheValue obj)

--- a/cs/playground/FasterKVAsyncSample/Types.cs
+++ b/cs/playground/FasterKVAsyncSample/Types.cs
@@ -34,12 +34,12 @@ namespace FasterKVAsyncSample
 
     public class CacheKeySerializer : BinaryObjectSerializer<CacheKey>
     {
-        public override void Deserialize(ref CacheKey obj)
+        public override void Deserialize(out CacheKey obj)
         {
             obj = new CacheKey(reader.ReadInt64());
         }
 
-        public override void Serialize(ref CacheKey obj)
+        public override void Serialize(in CacheKey obj)
         {
             writer.Write(obj.key);
         }
@@ -59,12 +59,12 @@ namespace FasterKVAsyncSample
 
     public class CacheValueSerializer : BinaryObjectSerializer<CacheValue>
     {
-        public override void Deserialize(ref CacheValue obj)
+        public override void Deserialize(out CacheValue obj)
         {
             obj = new CacheValue(reader.ReadInt64());
         }
 
-        public override void Serialize(ref CacheValue obj)
+        public override void Serialize(in CacheValue obj)
         {
             writer.Write(obj.value);
         }

--- a/cs/playground/PeriodicCompaction/Types.cs
+++ b/cs/playground/PeriodicCompaction/Types.cs
@@ -34,12 +34,12 @@ namespace PeriodicCompaction
 
     public class CacheKeySerializer : BinaryObjectSerializer<CacheKey>
     {
-        public override void Deserialize(ref CacheKey obj)
+        public override void Deserialize(out CacheKey obj)
         {
             obj = new CacheKey(reader.ReadInt64());
         }
 
-        public override void Serialize(ref CacheKey obj)
+        public override void Serialize(in CacheKey obj)
         {
             writer.Write(obj.key);
         }
@@ -59,12 +59,12 @@ namespace PeriodicCompaction
 
     public class CacheValueSerializer : BinaryObjectSerializer<CacheValue>
     {
-        public override void Deserialize(ref CacheValue obj)
+        public override void Deserialize(out CacheValue obj)
         {
             obj = new CacheValue(reader.ReadInt64());
         }
 
-        public override void Serialize(ref CacheValue obj)
+        public override void Serialize(in CacheValue obj)
         {
             writer.Write(obj.value);
         }

--- a/cs/playground/PeriodicCompaction/Types.cs
+++ b/cs/playground/PeriodicCompaction/Types.cs
@@ -36,7 +36,7 @@ namespace PeriodicCompaction
     {
         public override void Deserialize(ref CacheKey obj)
         {
-            obj.key = reader.ReadInt64();
+            obj = new CacheKey(reader.ReadInt64());
         }
 
         public override void Serialize(ref CacheKey obj)
@@ -61,7 +61,7 @@ namespace PeriodicCompaction
     {
         public override void Deserialize(ref CacheValue obj)
         {
-            obj.value = reader.ReadInt64();
+            obj = new CacheValue(reader.ReadInt64());
         }
 
         public override void Serialize(ref CacheValue obj)

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -39,8 +39,6 @@ namespace FASTER.core
     /// <typeparam name="Key"></typeparam>
     /// <typeparam name="Value"></typeparam>
     public unsafe abstract partial class AllocatorBase<Key, Value> : IDisposable
-        where Key : new()
-        where Value : new()
     {
         /// <summary>
         /// Epoch information

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -11,8 +11,6 @@ using System.Runtime.InteropServices;
 namespace FASTER.core
 {
     public unsafe sealed class BlittableAllocator<Key, Value> : AllocatorBase<Key, Value>
-        where Key : new()
-        where Value : new()
     {
         // Circular buffer definition
         private byte[][] values;

--- a/cs/src/core/Allocator/BlittableScanIterator.cs
+++ b/cs/src/core/Allocator/BlittableScanIterator.cs
@@ -11,8 +11,6 @@ namespace FASTER.core
     /// Scan iterator for hybrid log
     /// </summary>
     public sealed class BlittableScanIterator<Key, Value> : IFasterScanIterator<Key, Value>
-        where Key : new()
-        where Value : new()
     {
         private readonly int frameSize;
         private readonly BlittableAllocator<Key, Value> hlog;

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -23,8 +23,6 @@ namespace FASTER.core
 
 
     public unsafe sealed class GenericAllocator<Key, Value> : AllocatorBase<Key, Value>
-        where Key : new()
-        where Value : new()
     {
         // Circular buffer definition
         internal Record<Key, Value>[][] values;
@@ -48,12 +46,18 @@ namespace FASTER.core
 
             if ((!keyBlittable) && (settings.LogDevice as NullDevice == null) && ((SerializerSettings == null) || (SerializerSettings.keySerializer == null)))
             {
-                throw new FasterException("Key is not blittable, but no serializer specified via SerializerSettings");
+                Debug.WriteLine("Key is not blittable, but no serializer specified via SerializerSettings. Using (slow) DataContractSerializer as default.");
+                if (SerializerSettings == null)
+                    SerializerSettings = new SerializerSettings<Key, Value>();
+                SerializerSettings.keySerializer = () => new DefaultObjectSerializer<Key>();
             }
 
             if ((!valueBlittable) && (settings.LogDevice as NullDevice == null) && ((SerializerSettings == null) || (SerializerSettings.valueSerializer == null)))
             {
-                throw new FasterException("Value is not blittable, but no serializer specified via SerializerSettings");
+                Debug.WriteLine("Value is not blittable, but no serializer specified via SerializerSettings. Using (slow) DataContractSerializer as default.");
+                if (SerializerSettings == null)
+                    SerializerSettings = new SerializerSettings<Key, Value>();
+                SerializerSettings.valueSerializer = () => new DefaultObjectSerializer<Value>();
             }
 
             values = new Record<Key, Value>[BufferSize][];
@@ -725,7 +729,6 @@ namespace FASTER.core
                             stream.Seek(streamStartPos + key_addr->Address - start_addr, SeekOrigin.Begin);
                         }
 
-                        src[ptr / recordSize].key = new Key();
                         keySerializer.Deserialize(ref src[ptr/recordSize].key);
                     }
                     else
@@ -744,7 +747,6 @@ namespace FASTER.core
                                 stream.Seek(streamStartPos + value_addr->Address - start_addr, SeekOrigin.Begin);
                             }
 
-                            src[ptr / recordSize].value = new Value();
                             valueSerializer.Deserialize(ref src[ptr / recordSize].value);
                         }
                         else
@@ -886,8 +888,6 @@ namespace FASTER.core
 
             if (KeyHasObjects())
             {
-                ctx.key = new Key();
-
                 var keySerializer = SerializerSettings.keySerializer();
                 keySerializer.BeginDeserialize(ms);
                 keySerializer.Deserialize(ref ctx.key);
@@ -896,8 +896,6 @@ namespace FASTER.core
 
             if (ValueHasObjects() && !GetInfoFromBytePointer(record).Tombstone)
             {
-                ctx.value = new Value();
-
                 var valueSerializer = SerializerSettings.valueSerializer();
                 valueSerializer.BeginDeserialize(ms);
                 valueSerializer.Deserialize(ref ctx.value);

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -49,7 +49,7 @@ namespace FASTER.core
                 Debug.WriteLine("Key is not blittable, but no serializer specified via SerializerSettings. Using (slow) DataContractSerializer as default.");
                 if (SerializerSettings == null)
                     SerializerSettings = new SerializerSettings<Key, Value>();
-                SerializerSettings.keySerializer = () => new DefaultObjectSerializer<Key>();
+                SerializerSettings.keySerializer = () => new DataContractObjectSerializer<Key>();
             }
 
             if ((!valueBlittable) && (settings.LogDevice as NullDevice == null) && ((SerializerSettings == null) || (SerializerSettings.valueSerializer == null)))
@@ -57,7 +57,7 @@ namespace FASTER.core
                 Debug.WriteLine("Value is not blittable, but no serializer specified via SerializerSettings. Using (slow) DataContractSerializer as default.");
                 if (SerializerSettings == null)
                     SerializerSettings = new SerializerSettings<Key, Value>();
-                SerializerSettings.valueSerializer = () => new DefaultObjectSerializer<Value>();
+                SerializerSettings.valueSerializer = () => new DataContractObjectSerializer<Value>();
             }
 
             values = new Record<Key, Value>[BufferSize][];

--- a/cs/src/core/Allocator/GenericScanIterator.cs
+++ b/cs/src/core/Allocator/GenericScanIterator.cs
@@ -11,8 +11,6 @@ namespace FASTER.core
     /// Scan iterator for hybrid log
     /// </summary>
     public sealed class GenericScanIterator<Key, Value> : IFasterScanIterator<Key, Value>
-        where Key : new()
-        where Value : new()
     {
         private readonly int frameSize;
         private readonly GenericAllocator<Key, Value> hlog;

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -11,8 +11,6 @@ using System.Threading;
 namespace FASTER.core
 {
     public unsafe sealed class VariableLengthBlittableAllocator<Key, Value> : AllocatorBase<Key, Value>
-        where Key : new()
-        where Value : new()
     {
         public const int kRecordAlignment = 8; // RecordInfo has a long field, so it should be aligned to 8-bytes
 

--- a/cs/src/core/Allocator/VarLenBlittableScanIterator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableScanIterator.cs
@@ -11,8 +11,6 @@ namespace FASTER.core
     /// Scan iterator for hybrid log
     /// </summary>
     public sealed class VariableLengthBlittableScanIterator<Key, Value> : IFasterScanIterator<Key, Value>
-        where Key : new()
-        where Value : new()
     {
         private readonly int frameSize;
         private readonly VariableLengthBlittableAllocator<Key, Value> hlog;

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -22,8 +22,6 @@ namespace FASTER.core
     /// <typeparam name="Context"></typeparam>
     /// <typeparam name="Functions"></typeparam>
     public sealed class ClientSession<Key, Value, Input, Output, Context, Functions> : IClientSession, IDisposable
-        where Key : new()
-        where Value : new()
         where Functions : IFunctions<Key, Value, Input, Output, Context>
     {
         private readonly FasterKV<Key, Value> fht;

--- a/cs/src/core/ClientSession/FASTERAsync.cs
+++ b/cs/src/core/ClientSession/FASTERAsync.cs
@@ -18,8 +18,6 @@ namespace FASTER.core
     /// <typeparam name="Key">Key</typeparam>
     /// <typeparam name="Value">Value</typeparam>
     public partial class FasterKV<Key, Value> : FasterBase, IFasterKV<Key, Value>
-        where Key : new()
-        where Value : new()
     {
 
         /// <summary>

--- a/cs/src/core/ClientSession/FASTERClientSession.cs
+++ b/cs/src/core/ClientSession/FASTERClientSession.cs
@@ -10,8 +10,6 @@ using System.Threading;
 namespace FASTER.core
 {
     public unsafe partial class FasterKV<Key, Value> : FasterBase, IFasterKV<Key, Value>
-        where Key : new()
-        where Value : new()
     {
         internal Dictionary<string, IClientSession> _activeSessions = new Dictionary<string, IClientSession>();
 

--- a/cs/src/core/Device/LocalMemoryDevice.cs
+++ b/cs/src/core/Device/LocalMemoryDevice.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -28,6 +29,7 @@ namespace FASTER.core
         private readonly ConcurrentQueue<IORequestLocalMemory>[] ioQueue;
         private readonly Thread[] ioProcessors;
         private readonly int parallelism;
+        private readonly long sz_segment;
         private bool terminated;
 
         /// <summary>
@@ -43,6 +45,7 @@ namespace FASTER.core
             if (capacity == Devices.CAPACITY_UNSPECIFIED) throw new Exception("Local memory device must have a capacity!");
             Console.WriteLine("LocalMemoryDevice: Creating a " + capacity + " sized local memory device.");
             num_segments = (int) (capacity / sz_segment);
+            this.sz_segment = sz_segment;
             
             ram_segments = new byte*[num_segments];
             ram_segment_handles = new GCHandle[num_segments];
@@ -124,6 +127,8 @@ namespace FASTER.core
                                       DeviceIOCompletionCallback callback,
                                       object context)
         {
+            Debug.Assert(destinationAddress + numBytesToWrite <= (ulong)sz_segment, "Out of space in segment - LocalMemoryDevice does not support variable-sized segments needed for the object log");
+
             // We ensure capability of writing to next segment, because there is no
             // extra buffer space allocated in this device
             HandleCapacity(segmentId + 1);

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -64,8 +64,6 @@ namespace FASTER.core
     }
 
     public partial class FasterKV<Key, Value> : FasterBase, IFasterKV<Key, Value>
-        where Key : new()
-        where Value : new()
     {
         internal struct PendingContext<Input, Output, Context>
         {

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -14,8 +14,6 @@ namespace FASTER.core
 {
     public partial class FasterKV<Key, Value> : FasterBase,
         IFasterKV<Key, Value>
-        where Key : new()
-        where Value : new()
     {
         internal readonly AllocatorBase<Key, Value> hlog;
         private readonly AllocatorBase<Key, Value> readcache;
@@ -83,7 +81,14 @@ namespace FASTER.core
             {
                 if (typeof(IFasterEqualityComparer<Key>).IsAssignableFrom(typeof(Key)))
                 {
-                    this.comparer = new Key() as IFasterEqualityComparer<Key>;
+                    if (default(Key) != null)
+                    {
+                        this.comparer = default(Key) as IFasterEqualityComparer<Key>;
+                    }
+                    else if (typeof(Key).GetConstructor(Type.EmptyTypes) != null)
+                    {
+                        this.comparer = Activator.CreateInstance(typeof(Key)) as IFasterEqualityComparer<Key>;
+                    }
                 }
                 else
                 {

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -12,8 +12,6 @@ using System.Threading.Tasks;
 namespace FASTER.core
 {
     public unsafe partial class FasterKV<Key, Value> : FasterBase, IFasterKV<Key, Value>
-        where Key : new()
-        where Value : new()
     {
         internal enum LatchOperation : byte
         {

--- a/cs/src/core/Index/FASTER/FASTERIterator.cs
+++ b/cs/src/core/Index/FASTER/FASTERIterator.cs
@@ -7,8 +7,6 @@ using System;
 namespace FASTER.core
 {
     public partial class FasterKV<Key, Value> : FasterBase, IFasterKV<Key, Value>
-        where Key : new()
-        where Value : new()
     {
 
         /// <summary>
@@ -75,8 +73,6 @@ namespace FASTER.core
 
 
     internal sealed class FasterKVIterator<Key, Value, Functions, CompactionFunctions> : IFasterScanIterator<Key, Value>
-        where Key : new()
-        where Value : new()
         where Functions : IFunctions<Key, Value, Empty, Empty, Empty>
         where CompactionFunctions : ICompactionFunctions<Key, Value>
     {

--- a/cs/src/core/Index/FASTER/FASTERLegacy.cs
+++ b/cs/src/core/Index/FASTER/FASTERLegacy.cs
@@ -21,8 +21,6 @@ namespace FASTER.core
     /// <typeparam name="Functions">Functions</typeparam>
     //[Obsolete("Use FasteKV that provides functions with sessions")]
     public partial class FasterKV<Key, Value, Input, Output, Context, Functions> : IDisposable, IFasterKV<Key, Value, Input, Output, Context, Functions>
-        where Key : new()
-        where Value : new()
         where Functions : IFunctions<Key, Value, Input, Output, Context>
     {
         private FastThreadLocal<FasterKV<Key, Value>.FasterExecutionContext<Input, Output, Context>> _threadCtx;

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -11,8 +11,6 @@ using System.Threading.Tasks;
 namespace FASTER.core
 {
     public partial class FasterKV<Key, Value> : FasterBase, IFasterKV<Key, Value>
-        where Key : new()
-        where Value : new()
     {
         internal CommitPoint InternalContinue<Input, Output, Context>(string guid, out FasterExecutionContext<Input, Output, Context> ctx)
         {

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -14,8 +14,6 @@ namespace FASTER.core
     /// <typeparam name="Key"></typeparam>
     /// <typeparam name="Value"></typeparam>
     public sealed class LogAccessor<Key, Value> : IObservable<IFasterScanIterator<Key, Value>>
-        where Key : new()
-        where Value : new()
     {
         private readonly FasterKV<Key, Value> fht;
         private readonly AllocatorBase<Key, Value> allocator;

--- a/cs/src/core/Index/FASTER/LogCompactionFunctions.cs
+++ b/cs/src/core/Index/FASTER/LogCompactionFunctions.cs
@@ -9,8 +9,6 @@ using System.Runtime.CompilerServices;
 namespace FASTER.core
 {
     internal sealed class LogVariableCompactFunctions<Key, Value, CompactionFunctions> : IFunctions<Key, Value, Empty, Empty, Empty>
-        where Key : new()
-        where Value : new()
         where CompactionFunctions : ICompactionFunctions<Key, Value>
     {
         private readonly VariableLengthBlittableAllocator<Key, Value> _allocator;
@@ -37,8 +35,6 @@ namespace FASTER.core
     }
 
     internal sealed class LogCompactFunctions<Key, Value, CompactionFunctions> : IFunctions<Key, Value, Empty, Empty, Empty>
-        where Key : new()
-        where Value : new()
         where CompactionFunctions : ICompactionFunctions<Key, Value>
     {
         private readonly CompactionFunctions _functions;

--- a/cs/src/core/Index/Interfaces/DataContractObjectSerializer.cs
+++ b/cs/src/core/Index/Interfaces/DataContractObjectSerializer.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.IO;
+using System.Runtime.Serialization;
+using System.Xml;
+
+namespace FASTER.core
+{
+    /// <summary>
+    /// Serializer (for class types) based on DataContract
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public sealed class DataContractObjectSerializer<T> : BinaryObjectSerializer<T>
+    {
+        private static DataContractSerializer serializer = new DataContractSerializer(typeof(T));
+
+        /// <summary>
+        /// Deserialize
+        /// </summary>
+        /// <param name="obj"></param>
+        public override void Deserialize(ref T obj)
+        {
+            int count = reader.ReadInt32();
+            var byteArray = reader.ReadBytes(count);
+            using var ms = new MemoryStream(byteArray);
+            using (var _reader = XmlDictionaryReader.CreateBinaryReader(ms, XmlDictionaryReaderQuotas.Max))
+                obj = (T)serializer.ReadObject(_reader);
+        }
+
+        /// <summary>
+        /// Serialize
+        /// </summary>
+        /// <param name="obj"></param>
+        public override void Serialize(ref T obj)
+        {
+            using var ms = new MemoryStream();
+            using (var _writer = XmlDictionaryWriter.CreateBinaryWriter(ms, null, null, false))
+                serializer.WriteObject(_writer, obj);
+            writer.Write((int)ms.Position);
+            writer.Write(ms.ToArray());
+        }
+
+        /// <summary>
+        /// End serialize
+        /// </summary>
+        public void EndSerialize()
+        {
+            writer.Dispose();
+        }
+    }
+}

--- a/cs/src/core/Index/Interfaces/DataContractObjectSerializer.cs
+++ b/cs/src/core/Index/Interfaces/DataContractObjectSerializer.cs
@@ -13,40 +13,32 @@ namespace FASTER.core
     /// <typeparam name="T"></typeparam>
     public sealed class DataContractObjectSerializer<T> : BinaryObjectSerializer<T>
     {
-        private static DataContractSerializer serializer = new DataContractSerializer(typeof(T));
+        private readonly static DataContractSerializer serializer = new DataContractSerializer(typeof(T));
 
         /// <summary>
         /// Deserialize
         /// </summary>
         /// <param name="obj"></param>
-        public override void Deserialize(ref T obj)
+        public override void Deserialize(out T obj)
         {
             int count = reader.ReadInt32();
             var byteArray = reader.ReadBytes(count);
             using var ms = new MemoryStream(byteArray);
-            using (var _reader = XmlDictionaryReader.CreateBinaryReader(ms, XmlDictionaryReaderQuotas.Max))
-                obj = (T)serializer.ReadObject(_reader);
+            using var _reader = XmlDictionaryReader.CreateBinaryReader(ms, XmlDictionaryReaderQuotas.Max);
+            obj = (T)serializer.ReadObject(_reader);
         }
 
         /// <summary>
         /// Serialize
         /// </summary>
         /// <param name="obj"></param>
-        public override void Serialize(ref T obj)
+        public override void Serialize(in T obj)
         {
             using var ms = new MemoryStream();
             using (var _writer = XmlDictionaryWriter.CreateBinaryWriter(ms, null, null, false))
                 serializer.WriteObject(_writer, obj);
             writer.Write((int)ms.Position);
             writer.Write(ms.ToArray());
-        }
-
-        /// <summary>
-        /// End serialize
-        /// </summary>
-        public void EndSerialize()
-        {
-            writer.Dispose();
         }
     }
 }

--- a/cs/src/core/Index/Interfaces/IFasterKV.cs
+++ b/cs/src/core/Index/Interfaces/IFasterKV.cs
@@ -11,8 +11,6 @@ namespace FASTER.core
     /// Interface to FASTER key-value store
     /// </summary>
     public interface IFasterKV<Key, Value, Input, Output, Context, Functions> : IDisposable
-        where Key : new()
-        where Value : new()
         where Functions : IFunctions<Key, Value, Input, Output, Context>
     {
         #region Session Operations (Deprecated)
@@ -226,8 +224,6 @@ namespace FASTER.core
     /// Interface to FASTER key-value store
     /// </summary>
     public interface IFasterKV<Key, Value> : IDisposable
-        where Key : new()
-        where Value : new()
     {
         #region New Session Operations
 

--- a/cs/src/core/Index/Interfaces/IObjectSerializer.cs
+++ b/cs/src/core/Index/Interfaces/IObjectSerializer.cs
@@ -25,7 +25,7 @@ namespace FASTER.core
         /// Serialize object
         /// </summary>
         /// <param name="obj"></param>
-        void Serialize(ref T obj);
+        void Serialize(in T obj);
 
         /// <summary>
         /// End serialization to given stream
@@ -42,7 +42,7 @@ namespace FASTER.core
         /// Deserialize object
         /// </summary>
         /// <param name="obj"></param>
-        void Deserialize(ref T obj);
+        void Deserialize(out T obj);
 
         /// <summary>
         /// End deserialization from given stream
@@ -79,7 +79,7 @@ namespace FASTER.core
         /// Deserialize
         /// </summary>
         /// <param name="obj"></param>
-        public abstract void Deserialize(ref T obj);
+        public abstract void Deserialize(out T obj);
 
         /// <summary>
         /// End deserialize
@@ -102,7 +102,7 @@ namespace FASTER.core
         /// Serialize
         /// </summary>
         /// <param name="obj"></param>
-        public abstract void Serialize(ref T obj);
+        public abstract void Serialize(in T obj);
 
         /// <summary>
         /// End serialize

--- a/cs/src/core/Index/Interfaces/ObjectSerializer.cs
+++ b/cs/src/core/Index/Interfaces/ObjectSerializer.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+
+namespace FASTER.core
+{
+    internal static class ObjectSerializer
+    {
+        public static Func<IObjectSerializer<T>> Get<T>()
+        {
+            if (typeof(T) == typeof(string))
+                return () => (IObjectSerializer<T>)new StringBinaryObjectSerializer();
+            else if (typeof(T) == typeof(byte[]))
+                return () => (IObjectSerializer<T>)new ByteArrayBinaryObjectSerializer();
+            else
+                return () => new DataContractObjectSerializer<T>();
+        }
+    }
+
+    internal class StringBinaryObjectSerializer : BinaryObjectSerializer<string>
+    {
+        public override void Deserialize(out string obj) => obj = reader.ReadString();
+        public override void Serialize(in string obj) => writer.Write(obj);
+    }
+
+    internal class ByteArrayBinaryObjectSerializer : BinaryObjectSerializer<byte[]>
+    {
+        public override void Deserialize(out byte[] obj) => obj = reader.ReadBytes(reader.ReadInt32());
+        public override void Serialize(in byte[] obj)
+        {
+            writer.Write(obj.Length);
+            writer.Write(obj);
+        }
+    }
+}

--- a/cs/src/core/Index/Recovery/Checkpoint.cs
+++ b/cs/src/core/Index/Recovery/Checkpoint.cs
@@ -32,8 +32,6 @@ namespace FASTER.core
     }
 
     public partial class FasterKV<Key, Value>
-        where Key : new()
-        where Value : new()
     {
         
         internal TaskCompletionSource<LinkedCheckpointInfo> checkpointTcs

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -47,8 +47,6 @@ namespace FASTER.core
 
 
     public unsafe partial class FasterKV<Key, Value> : FasterBase, IFasterKV<Key, Value>
-        where Key : new()
-        where Value : new()
     {
 
         private void InternalRecoverFromLatestCheckpoints()
@@ -467,8 +465,6 @@ namespace FASTER.core
     }
 
     public unsafe abstract partial class AllocatorBase<Key, Value> : IDisposable
-        where Key : new()
-        where Value : new()
     {
         /// <summary>
         /// Restore log

--- a/cs/src/core/Index/Synchronization/FasterStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/FasterStateMachine.cs
@@ -8,8 +8,6 @@ using System.Threading.Tasks;
 namespace FASTER.core
 {
     public partial class FasterKV<Key, Value>
-        where Key : new()
-        where Value : new()
     {
         // The current system state, defined as the combination of a phase and a version number. This value
         // is observed by all sessions and a state machine communicates its progress to sessions through

--- a/cs/src/core/Index/Synchronization/FullCheckpointStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/FullCheckpointStateMachine.cs
@@ -15,8 +15,6 @@ namespace FASTER.core
         public void GlobalBeforeEnteringState<Key, Value>(
             SystemState next,
             FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new()
         {
             switch (next.phase)
             {
@@ -44,8 +42,6 @@ namespace FASTER.core
         public void GlobalAfterEnteringState<Key, Value>(
             SystemState next,
             FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new()
         {
         }
 
@@ -57,8 +53,7 @@ namespace FASTER.core
             FasterKV<Key, Value>.FasterExecutionContext<Input, Output, Context> ctx,
             FasterSession fasterSession,
             List<ValueTask> valueTasks,
-            CancellationToken token = default) where Key : new()
-            where Value : new()
+            CancellationToken token = default)
             where FasterSession : IFasterSession
         {
         }

--- a/cs/src/core/Index/Synchronization/HybridLogCheckpointTask.cs
+++ b/cs/src/core/Index/Synchronization/HybridLogCheckpointTask.cs
@@ -15,8 +15,6 @@ namespace FASTER.core
         /// <inheritdoc />
         public virtual void GlobalBeforeEnteringState<Key, Value>(SystemState next,
             FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new()
         {
             switch (next.phase)
             {
@@ -64,8 +62,6 @@ namespace FASTER.core
         /// <inheritdoc />
         public virtual void GlobalAfterEnteringState<Key, Value>(SystemState next,
             FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new()
         {
         }
 
@@ -77,8 +73,6 @@ namespace FASTER.core
             FasterSession fasterSession,
             List<ValueTask> valueTasks,
             CancellationToken token = default)
-            where Key : new()
-            where Value : new()
             where FasterSession : IFasterSession
         {
             if (current.phase != Phase.PERSISTENCE_CALLBACK) return;

--- a/cs/src/core/Index/Synchronization/ISynchronizationStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/ISynchronizationStateMachine.cs
@@ -27,9 +27,7 @@ namespace FASTER.core
         /// <typeparam name="Key"></typeparam>
         /// <typeparam name="Value"></typeparam>
         void GlobalBeforeEnteringState<Key, Value>(SystemState next,
-            FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new();
+            FasterKV<Key, Value> faster);
 
         /// <summary>
         /// This function is invoked immediately after the global state machine enters the given state.
@@ -39,9 +37,7 @@ namespace FASTER.core
         /// <typeparam name="Key"></typeparam>
         /// <typeparam name="Value"></typeparam>
         void GlobalAfterEnteringState<Key, Value>(SystemState next,
-            FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new();
+            FasterKV<Key, Value> faster);
 
         /// <summary>
         /// This function is invoked for every thread when they refresh and observe a given state.
@@ -69,8 +65,6 @@ namespace FASTER.core
             FasterSession fasterSession,
             List<ValueTask> valueTasks,
             CancellationToken token = default)
-            where Key : new()
-            where Value : new()
             where FasterSession: IFasterSession;
     }
 
@@ -91,9 +85,7 @@ namespace FASTER.core
         /// <typeparam name="Value"></typeparam>
         void GlobalBeforeEnteringState<Key, Value>(
             SystemState next,
-            FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new();
+            FasterKV<Key, Value> faster);
 
         /// <summary>
         /// This function is invoked immediately after the global state machine enters the given state.
@@ -104,9 +96,7 @@ namespace FASTER.core
         /// <typeparam name="Value"></typeparam>
         void GlobalAfterEnteringState<Key, Value>(
             SystemState next,
-            FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new();
+            FasterKV<Key, Value> faster);
 
         /// <summary>
         /// This function is invoked for every thread when they refresh and observe a given state.
@@ -135,8 +125,6 @@ namespace FASTER.core
             FasterSession fasterSession,
             List<ValueTask> valueTasks,
             CancellationToken token = default)
-            where Key : new()
-            where Value : new()
             where FasterSession: IFasterSession;
     }
 
@@ -163,8 +151,7 @@ namespace FASTER.core
 
         /// <inheritdoc />
         public void GlobalBeforeEnteringState<Key, Value>(SystemState next,
-            FasterKV<Key, Value> faster) where Key : new()
-            where Value : new()
+            FasterKV<Key, Value> faster) 
         {
             foreach (var task in tasks)
                 task.GlobalBeforeEnteringState(next, faster);
@@ -172,8 +159,7 @@ namespace FASTER.core
 
         /// <inheritdoc />
         public void GlobalAfterEnteringState<Key, Value>(SystemState next,
-            FasterKV<Key, Value> faster) where Key : new()
-            where Value : new()
+            FasterKV<Key, Value> faster)
         {
             foreach (var task in tasks)
                 task.GlobalAfterEnteringState(next, faster);
@@ -187,8 +173,7 @@ namespace FASTER.core
             FasterKV<Key, Value>.FasterExecutionContext<Input, Output, Context> ctx,
             FasterSession fasterSession,
             List<ValueTask> valueTasks,
-            CancellationToken token = default) where Key : new()
-            where Value : new()
+            CancellationToken token = default)
             where FasterSession: IFasterSession
         {
             foreach (var task in tasks)

--- a/cs/src/core/Index/Synchronization/IndexResizeStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/IndexResizeStateMachine.cs
@@ -13,8 +13,6 @@ namespace FASTER.core
         public void GlobalBeforeEnteringState<Key, Value>(
             SystemState next,
             FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new()
         {
             switch (next.phase)
             {
@@ -45,8 +43,6 @@ namespace FASTER.core
         public void GlobalAfterEnteringState<Key, Value>(
             SystemState next,
             FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new()
         {
             switch (next.phase)
             {
@@ -71,8 +67,6 @@ namespace FASTER.core
             FasterSession fasterSession,
             List<ValueTask> valueTasks,
             CancellationToken token = default)
-            where Key : new()
-            where Value : new()
             where FasterSession : IFasterSession
         {
             switch (current.phase)

--- a/cs/src/core/Index/Synchronization/IndexSnapshotStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/IndexSnapshotStateMachine.cs
@@ -15,8 +15,6 @@ namespace FASTER.core
         public void GlobalBeforeEnteringState<Key, Value>(
             SystemState next,
             FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new()
         {
             switch (next.phase)
             {
@@ -56,8 +54,6 @@ namespace FASTER.core
         public void GlobalAfterEnteringState<Key, Value>(
             SystemState next,
             FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new()
         {
         }
 
@@ -70,8 +66,6 @@ namespace FASTER.core
             FasterSession fasterSession,
             List<ValueTask> valueTasks,
             CancellationToken token = default)
-            where Key : new()
-            where Value : new()
             where FasterSession : IFasterSession
         {
             switch (current.phase)

--- a/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
@@ -15,8 +15,6 @@ namespace FASTER.core
         public void GlobalBeforeEnteringState<Key, Value>(
             SystemState next,
             FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new()
         {
         }
 
@@ -24,8 +22,6 @@ namespace FASTER.core
         public void GlobalAfterEnteringState<Key, Value>(
             SystemState start,
             FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new()
         {
         }
 
@@ -37,8 +33,6 @@ namespace FASTER.core
             FasterSession fasterSession,
             List<ValueTask> valueTasks,
             CancellationToken token = default)
-            where Key : new()
-            where Value : new()
             where FasterSession : IFasterSession
         {
             switch (current.phase)
@@ -114,8 +108,6 @@ namespace FASTER.core
         public void GlobalBeforeEnteringState<Key, Value>(
             SystemState next,
             FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new()
         {
             if (next.phase == Phase.REST)
                 // Before leaving the checkpoint, make sure all previous versions are read-only.
@@ -126,8 +118,6 @@ namespace FASTER.core
         public void GlobalAfterEnteringState<Key, Value>(
             SystemState next,
             FasterKV<Key, Value> faster)
-            where Key : new()
-            where Value : new()
         { }
 
         /// <inheritdoc />
@@ -139,8 +129,6 @@ namespace FASTER.core
             FasterSession fasterSession,
             List<ValueTask> valueTasks,
             CancellationToken token = default)
-            where Key : new()
-            where Value : new()
             where FasterSession : IFasterSession
         {
         }

--- a/cs/test/FasterLogResumeTests.cs
+++ b/cs/test/FasterLogResumeTests.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FASTER.core;
+using NUnit.Framework;
+
+namespace FASTER.test
+{
+    [TestFixture]
+    internal class FasterLogResumeTests
+    {
+        private IDevice device;
+        private string commitPath;
+
+        [SetUp]
+        public void Setup()
+        {
+            commitPath = TestContext.CurrentContext.TestDirectory + "\\" + TestContext.CurrentContext.Test.Name + "\\";
+
+            if (Directory.Exists(commitPath))
+                DeleteDirectory(commitPath);
+
+            device = Devices.CreateLogDevice(commitPath + "fasterlog.log", deleteOnClose: true);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            device.Close();
+
+            if (Directory.Exists(commitPath))
+                DeleteDirectory(commitPath);
+        }
+
+        [Test]
+        public async Task FasterLogResumePersistedReaderSpec([Values] LogChecksumType logChecksum)
+        {
+            var input1 = new byte[] { 0, 1, 2, 3 };
+            var input2 = new byte[] { 4, 5, 6, 7, 8, 9, 10 };
+            var input3 = new byte[] { 11, 12 };
+            string readerName = "abc";
+
+            using (var l = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitFile = commitPath }))
+            {
+                await l.EnqueueAsync(input1);
+                await l.EnqueueAsync(input2);
+                await l.EnqueueAsync(input3);
+                await l.CommitAsync();
+
+                using (var originalIterator = l.Scan(0, long.MaxValue, readerName))
+                {
+                    originalIterator.GetNext(out _, out _, out _, out long recoveryAddress);
+                    originalIterator.CompleteUntil(recoveryAddress);
+                    originalIterator.GetNext(out _, out _, out _, out _);  // move the reader ahead
+                    await l.CommitAsync();
+                }
+            }
+
+            using (var l = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitFile = commitPath }))
+            {
+                using (var recoveredIterator = l.Scan(0, long.MaxValue, readerName))
+                {
+                    recoveredIterator.GetNext(out byte[] outBuf, out _, out _, out _);
+                    Assert.True(input2.SequenceEqual(outBuf));  // we should have read in input2, not input1 or input3
+                }
+            }
+        }
+
+        [Test]
+        public async Task FasterLogResumePersistedReader2([Values] LogChecksumType logChecksum, [Values] bool overwriteLogCommits, [Values] bool removeOutdated)
+        {
+            var input1 = new byte[] { 0, 1, 2, 3 };
+            var input2 = new byte[] { 4, 5, 6, 7, 8, 9, 10 };
+            var input3 = new byte[] { 11, 12 };
+            string readerName = "abc";
+
+            using (var logCommitManager = new DeviceLogCommitCheckpointManager(new LocalStorageNamedDeviceFactory(), new DefaultCheckpointNamingScheme(commitPath), overwriteLogCommits, removeOutdated))
+            {
+
+                long originalCompleted;
+
+                using (var l = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitManager = logCommitManager }))
+                {
+                    await l.EnqueueAsync(input1);
+                    await l.CommitAsync();
+                    await l.EnqueueAsync(input2);
+                    await l.CommitAsync();
+                    await l.EnqueueAsync(input3);
+                    await l.CommitAsync();
+
+                    using (var originalIterator = l.Scan(0, long.MaxValue, readerName))
+                    {
+                        originalIterator.GetNext(out _, out _, out _, out long recoveryAddress);
+                        originalIterator.CompleteUntil(recoveryAddress);
+                        originalIterator.GetNext(out _, out _, out _, out _);  // move the reader ahead
+                        await l.CommitAsync();
+                        originalCompleted = originalIterator.CompletedUntilAddress;
+                    }
+                }
+
+                using (var l = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitManager = logCommitManager }))
+                {
+                    using (var recoveredIterator = l.Scan(0, long.MaxValue, readerName))
+                    {
+                        recoveredIterator.GetNext(out byte[] outBuf, out _, out _, out _);
+
+                        // we should have read in input2, not input1 or input3
+                        Assert.True(input2.SequenceEqual(outBuf), $"Original: {input2[0]}, Recovered: {outBuf[0]}, Original: {originalCompleted}, Recovered: {recoveredIterator.CompletedUntilAddress}");
+
+                        // TestContext.Progress.WriteLine($"Original: {originalCompleted}, Recovered: {recoveredIterator.CompletedUntilAddress}"); 
+                    }
+                }
+            }
+        }
+
+        private static void DeleteDirectory(string path)
+        {
+            foreach (string directory in Directory.GetDirectories(path))
+            {
+                DeleteDirectory(directory);
+            }
+
+            try
+            {
+                Directory.Delete(path, true);
+            }
+            catch (IOException)
+            {
+                try
+                {
+                    Directory.Delete(path, true);
+                }
+                catch { }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                try
+                {
+                    Directory.Delete(path, true);
+                }
+                catch { }
+            }
+        }
+    }
+}

--- a/cs/test/FasterLogTests.cs
+++ b/cs/test/FasterLogTests.cs
@@ -21,37 +21,34 @@ namespace FASTER.test
         private FasterLog log;
         private IDevice device;
         private string commitPath;
+        private DeviceLogCommitCheckpointManager manager;
 
         [SetUp]
         public void Setup()
         {
-            commitPath = new DefaultCheckpointNamingScheme().FasterLogCommitBasePath();
-            if (commitPath == "")
-                throw new Exception("Write log commits to separate folder for testing");
-            commitPath = TestContext.CurrentContext.TestDirectory + "\\" + commitPath;
+            commitPath = TestContext.CurrentContext.TestDirectory + "\\" + TestContext.CurrentContext.Test.Name +  "\\";
 
             if (Directory.Exists(commitPath))
                 DeleteDirectory(commitPath);
-            if (File.Exists(TestContext.CurrentContext.TestDirectory + "\\fasterlog.log.commit"))
-                File.Delete(TestContext.CurrentContext.TestDirectory + "\\fasterlog.log.commit");
 
-            device = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\fasterlog.log", deleteOnClose: true);
+            device = Devices.CreateLogDevice(commitPath + "fasterlog.log", deleteOnClose: true);
+            manager = new DeviceLogCommitCheckpointManager(new LocalStorageNamedDeviceFactory(deleteOnClose: true), new DefaultCheckpointNamingScheme(commitPath));
         }
 
         [TearDown]
         public void TearDown()
         {
+            manager.Dispose();
             device.Close();
+
             if (Directory.Exists(commitPath))
                 DeleteDirectory(commitPath);
-            if (File.Exists(TestContext.CurrentContext.TestDirectory + "\\fasterlog.log.commit"))
-                File.Delete(TestContext.CurrentContext.TestDirectory + "\\fasterlog.log.commit");
         }
 
         [Test]
         public void FasterLogTest1([Values]LogChecksumType logChecksum)
         {
-            log = new FasterLog(new FasterLogSettings { LogDevice = device, LogChecksum = logChecksum });
+            log = new FasterLog(new FasterLogSettings { LogDevice = device, LogChecksum = logChecksum, LogCommitManager = manager });
 
             byte[] entry = new byte[entryLength];
             for (int i = 0; i < entryLength; i++)
@@ -66,7 +63,7 @@ namespace FASTER.test
             using (var iter = log.Scan(0, long.MaxValue))
             {
                 int count = 0;
-                while (iter.GetNext(out byte[] result, out int length, out long currentAddress))
+                while (iter.GetNext(out byte[] result, out _, out _))
                 {
                     count++;
                     Assert.IsTrue(result.SequenceEqual(entry));
@@ -82,7 +79,7 @@ namespace FASTER.test
         [Test]
         public async Task FasterLogTest2([Values]LogChecksumType logChecksum)
         {
-            log = new FasterLog(new FasterLogSettings { LogDevice = device, LogChecksum = logChecksum });
+            log = new FasterLog(new FasterLogSettings { LogDevice = device, LogChecksum = logChecksum, LogCommitManager = manager });
             byte[] data1 = new byte[10000];
             for (int i = 0; i < 10000; i++) data1[i] = (byte)i;
 
@@ -124,7 +121,7 @@ namespace FASTER.test
         [Test]
         public async Task FasterLogTest3([Values]LogChecksumType logChecksum)
         {
-            log = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 14, LogChecksum = logChecksum });
+            log = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 14, LogChecksum = logChecksum, LogCommitManager = manager });
             byte[] data1 = new byte[10000];
             for (int i = 0; i < 10000; i++) data1[i] = (byte)i;
 
@@ -163,7 +160,7 @@ namespace FASTER.test
         [Test]
         public async Task FasterLogTest4([Values]LogChecksumType logChecksum)
         {
-            log = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 14, LogChecksum = logChecksum });
+            log = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 14, LogChecksum = logChecksum, LogCommitManager = manager });
             byte[] data1 = new byte[100];
             for (int i = 0; i < 100; i++) data1[i] = (byte)i;
 
@@ -199,7 +196,7 @@ namespace FASTER.test
         [Test]
         public async Task FasterLogTest5([Values]LogChecksumType logChecksum)
         {
-            log = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum });
+            log = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitManager = manager });
 
             int headerSize = logChecksum == LogChecksumType.None ? 4 : 12;
             bool _disposed = false;
@@ -229,9 +226,9 @@ namespace FASTER.test
         }
 
         [Test]
-        public async Task FasterLogTest6([Values] LogChecksumType logChecksum)
+        public void FasterLogTest6([Values] LogChecksumType logChecksum)
         {
-            log = new FasterLog(new FasterLogSettings { LogDevice = device, MemorySizeBits = 20, PageSizeBits = 14, LogChecksum = logChecksum });
+            log = new FasterLog(new FasterLogSettings { LogDevice = device, MemorySizeBits = 20, PageSizeBits = 14, LogChecksum = logChecksum, LogCommitManager = manager });
             byte[] data1 = new byte[1000];
             for (int i = 0; i < 100; i++) data1[i] = (byte)i;
 
@@ -246,110 +243,17 @@ namespace FASTER.test
 
             using (var iter = log.Scan(0, long.MaxValue, scanUncommitted: true))
             {
-                byte[] entry;
-                while (iter.GetNext(out entry, out _, out _))
+                while (iter.GetNext(out _, out _, out _))
                 {
                     log.TruncateUntil(iter.NextAddress);
                 }
                 Assert.IsTrue(iter.NextAddress == log.SafeTailAddress);
                 log.Enqueue(data1);
-                Assert.IsFalse(iter.GetNext(out entry, out _, out _));
+                Assert.IsFalse(iter.GetNext(out _, out _, out _));
                 log.RefreshUncommitted();
-                Assert.IsTrue(iter.GetNext(out entry, out _, out _));
+                Assert.IsTrue(iter.GetNext(out _, out _, out _));
             }
             log.Dispose();
-        }
-
-
-        [Test]
-        public async Task ResumePersistedReaderSpec([Values]LogChecksumType logChecksum)
-        {
-            var input1 = new byte[] { 0, 1, 2, 3 };
-            var input2 = new byte[] { 4, 5, 6, 7, 8, 9, 10 };
-            var input3 = new byte[] { 11, 12 };
-            string readerName = "abc";
-            string commitFilePath = TestContext.CurrentContext.TestDirectory + "\\fasterlog.log.commit";
-
-            using (var l = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitFile = commitFilePath }))
-            {
-                await l.EnqueueAsync(input1);
-                await l.EnqueueAsync(input2);
-                await l.EnqueueAsync(input3);
-                await l.CommitAsync();
-                long recoveryAddress;
-
-                using (var originalIterator = l.Scan(0, long.MaxValue, readerName))
-                {
-                    originalIterator.GetNext(out _, out _, out _, out recoveryAddress);
-                    originalIterator.CompleteUntil(recoveryAddress);
-                    originalIterator.GetNext(out _, out _, out _, out _);  // move the reader ahead
-                    await l.CommitAsync();
-                }
-            }
-
-            using (var l = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitFile = commitFilePath }))
-            {
-                using (var recoveredIterator = l.Scan(0, long.MaxValue, readerName))
-                {
-                    byte[] outBuf;
-                    recoveredIterator.GetNext(out outBuf, out _, out _, out _);
-                    Assert.True(input2.SequenceEqual(outBuf));  // we should have read in input2, not input1 or input3
-                }
-            }
-        }
-
-        [Test]
-        public async Task ResumePersistedReader2([Values] LogChecksumType logChecksum, [Values] bool overwriteLogCommits, [Values] bool removeOutdated)
-        {
-            var input1 = new byte[] { 0, 1, 2, 3 };
-            var input2 = new byte[] { 4, 5, 6, 7, 8, 9, 10 };
-            var input3 = new byte[] { 11, 12 };
-            string readerName = "abc";
-
-            var commitPath = TestContext.CurrentContext.TestDirectory + "\\ResumePersistedReader2";
-
-            if (Directory.Exists(commitPath))
-                DeleteDirectory(commitPath);
-
-            using (var logCommitManager = new DeviceLogCommitCheckpointManager(new LocalStorageNamedDeviceFactory(), new DefaultCheckpointNamingScheme(commitPath), overwriteLogCommits, removeOutdated))
-            {
-
-                long originalCompleted;
-
-                using (var l = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitManager = logCommitManager }))
-                {
-                    await l.EnqueueAsync(input1);
-                    await l.CommitAsync();
-                    await l.EnqueueAsync(input2);
-                    await l.CommitAsync();
-                    await l.EnqueueAsync(input3);
-                    await l.CommitAsync();
-                    long recoveryAddress;
-
-                    using (var originalIterator = l.Scan(0, long.MaxValue, readerName))
-                    {
-                        originalIterator.GetNext(out _, out _, out _, out recoveryAddress);
-                        originalIterator.CompleteUntil(recoveryAddress);
-                        originalIterator.GetNext(out _, out _, out _, out _);  // move the reader ahead
-                        await l.CommitAsync();
-                        originalCompleted = originalIterator.CompletedUntilAddress;
-                    }
-                }
-
-                using (var l = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitManager = logCommitManager }))
-                {
-                    using (var recoveredIterator = l.Scan(0, long.MaxValue, readerName))
-                    {
-                        recoveredIterator.GetNext(out byte[] outBuf, out _, out _, out _);
-
-                        // we should have read in input2, not input1 or input3
-                        Assert.True(input2.SequenceEqual(outBuf), $"Original: {input2[0]}, Recovered: {outBuf[0]}, Original: {originalCompleted}, Recovered: {recoveredIterator.CompletedUntilAddress}");
-
-                        // TestContext.Progress.WriteLine($"Original: {originalCompleted}, Recovered: {recoveredIterator.CompletedUntilAddress}"); 
-                    }
-                }
-            }
-            DeleteDirectory(commitPath);
         }
 
         private static void DeleteDirectory(string path)
@@ -365,11 +269,19 @@ namespace FASTER.test
             }
             catch (IOException)
             {
-                Directory.Delete(path, true);
+                try
+                {
+                    Directory.Delete(path, true);
+                }
+                catch { }
             }
             catch (UnauthorizedAccessException)
             {
-                Directory.Delete(path, true);
+                try
+                {
+                    Directory.Delete(path, true);
+                }
+                catch { }
             }
         }
 

--- a/cs/test/GenericByteArrayTests.cs
+++ b/cs/test/GenericByteArrayTests.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using FASTER.core;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace FASTER.test
+{
+
+    [TestFixture]
+    internal class GenericByteArrayTests
+    {
+        private FasterKV<byte[], byte[]> fht;
+        private ClientSession<byte[], byte[], byte[], byte[], Empty, IFunctions<byte[], byte[], byte[], byte[], Empty>> session;
+        private IDevice log, objlog;
+
+        [SetUp]
+        public void Setup()
+        {
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\GenericStringTests.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\GenericStringTests.obj.log", deleteOnClose: true);
+
+            fht
+                = new FasterKV<byte[], byte[]>(
+                    1L << 20, // size of hash table in #cache lines; 64 bytes per cache line
+                    new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 14, PageSizeBits = 9 }, // log device
+                    comparer: new ByteArrayEC()
+                    );
+
+            session = fht.NewSession(new MyByteArrayFuncs());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            session.Dispose();
+            fht.Dispose();
+            fht = null;
+            log.Close();
+            objlog.Close();
+        }
+
+
+        private byte[] GetByteArray(int i)
+        {
+            return BitConverter.GetBytes(i);
+        }
+
+        [Test]
+        public void GenericByteArrayTest1()
+        {
+            const int totalRecords = 2000;
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var _key = GetByteArray(i);
+                var _value = GetByteArray(i);
+                session.Upsert(ref _key, ref _value, Empty.Default, 0);
+            }
+            session.CompletePending(true);
+
+            for (int i = 0; i < totalRecords; i++)
+            {
+                byte[] input = default;
+                byte[] output = default;
+                var key = GetByteArray(i);
+                var value = GetByteArray(i);
+
+                if (session.Read(ref key, ref input, ref output, Empty.Default, 0) == Status.PENDING)
+                {
+                    session.CompletePending(true);
+                }
+                else
+                {
+                    Assert.IsTrue(output.SequenceEqual(value));
+                }
+            }
+        }
+
+        class MyByteArrayFuncs : SimpleFunctions<byte[], byte[]>
+        {
+            public override void ReadCompletionCallback(ref byte[] key, ref byte[] input, ref byte[] output, Empty ctx, Status status)
+            {
+                Assert.IsTrue(output.SequenceEqual(key));
+            }
+        }
+    }
+
+    class ByteArrayEC : IFasterEqualityComparer<byte[]>
+    {
+        public bool Equals(ref byte[] k1, ref byte[] k2)
+        {
+            return k1.SequenceEqual(k2);
+        }
+
+        public unsafe long GetHashCode64(ref byte[] k)
+        {
+            fixed (byte *b = k)
+            {
+                return Utility.HashBytes(b, k.Length);
+            }
+        }
+    }
+}

--- a/cs/test/GenericStringTests.cs
+++ b/cs/test/GenericStringTests.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using FASTER.core;
+using NUnit.Framework;
+using System;
+
+namespace FASTER.test
+{
+
+    [TestFixture]
+    internal class GenericStringTests
+    {
+        private FasterKV<string, string> fht;
+        private ClientSession<string, string, string, string, Empty, IFunctions<string, string, string, string, Empty>> session;
+        private IDevice log, objlog;
+
+        [SetUp]
+        public void Setup()
+        {
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\GenericStringTests.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\GenericStringTests.obj.log", deleteOnClose: true);
+
+            fht
+                = new FasterKV<string, string>(
+                    1L << 20, // size of hash table in #cache lines; 64 bytes per cache line
+                    new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 14, PageSizeBits = 9 } // log device
+                    );
+
+            session = fht.NewSession(new MyFuncs());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            session.Dispose();
+            fht.Dispose();
+            fht = null;
+            log.Close();
+            objlog.Close();
+        }
+
+
+        [Test]
+        public void GenericStringTest1()
+        {
+            const int totalRecords = 2000;
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var _key = $"{i}";
+                var _value = $"{i}"; ;
+                session.Upsert(ref _key, ref _value, Empty.Default, 0);
+            }
+            session.CompletePending(true);
+
+            for (int i = 0; i < totalRecords; i++)
+            {
+                string input = default;
+                string output = default;
+                var key = $"{i}";
+                var value = $"{i}";
+
+                if (session.Read(ref key, ref input, ref output, Empty.Default, 0) == Status.PENDING)
+                {
+                    session.CompletePending(true);
+                }
+                else
+                {
+                    Assert.IsTrue(output == value);
+                }
+            }
+        }
+
+        class MyFuncs : SimpleFunctions<string, string>
+        {
+            public override void ReadCompletionCallback(ref string key, ref string input, ref string output, Empty ctx, Status status)
+            {
+                Assert.IsTrue(output == key);
+            }
+        }
+    }
+}

--- a/cs/test/ObjectRecoveryTest2.cs
+++ b/cs/test/ObjectRecoveryTest2.cs
@@ -181,6 +181,7 @@ namespace FASTER.test.recovery.objects
 
         public override void Deserialize(ref MyKey key)
         {
+            key = new MyKey();
             var size = reader.ReadInt32();
             key.key = reader.ReadInt32();
             var bytes = new byte[size - 4];
@@ -201,6 +202,7 @@ namespace FASTER.test.recovery.objects
 
         public override void Deserialize(ref MyValue value)
         {
+            value = new MyValue();
             var size = reader.ReadInt32();
             var bytes = new byte[size];
             reader.Read(bytes, 0, size);

--- a/cs/test/ObjectRecoveryTest2.cs
+++ b/cs/test/ObjectRecoveryTest2.cs
@@ -171,7 +171,7 @@ namespace FASTER.test.recovery.objects
 
     public class MyKeySerializer : BinaryObjectSerializer<MyKey>
     {
-        public override void Serialize(ref MyKey key)
+        public override void Serialize(in MyKey key)
         {
             var bytes = System.Text.Encoding.UTF8.GetBytes(key.name);
             writer.Write(4 + bytes.Length);
@@ -179,7 +179,7 @@ namespace FASTER.test.recovery.objects
             writer.Write(bytes);
         }
 
-        public override void Deserialize(ref MyKey key)
+        public override void Deserialize(out MyKey key)
         {
             key = new MyKey();
             var size = reader.ReadInt32();
@@ -193,14 +193,14 @@ namespace FASTER.test.recovery.objects
 
     public class MyValueSerializer : BinaryObjectSerializer<MyValue>
     {
-        public override void Serialize(ref MyValue value)
+        public override void Serialize(in MyValue value)
         {
             var bytes = System.Text.Encoding.UTF8.GetBytes(value.value);
             writer.Write(bytes.Length);
             writer.Write(bytes);
         }
 
-        public override void Deserialize(ref MyValue value)
+        public override void Deserialize(out MyValue value)
         {
             value = new MyValue();
             var size = reader.ReadInt32();

--- a/cs/test/ObjectRecoveryTestTypes.cs
+++ b/cs/test/ObjectRecoveryTestTypes.cs
@@ -32,13 +32,13 @@ namespace FASTER.test.recovery.objectstore
 
     public class AdIdSerializer : BinaryObjectSerializer<AdId>
     {
-        public override void Deserialize(ref AdId obj)
+        public override void Deserialize(out AdId obj)
         {
             obj = new AdId();
             obj.adId = reader.ReadInt64();
         }
 
-        public override void Serialize(ref AdId obj)
+        public override void Serialize(in AdId obj)
         {
             writer.Write(obj.adId);
         }
@@ -58,13 +58,13 @@ namespace FASTER.test.recovery.objectstore
 
     public class NumClicksSerializer : BinaryObjectSerializer<NumClicks>
     {
-        public override void Deserialize(ref NumClicks obj)
+        public override void Deserialize(out NumClicks obj)
         {
             obj = new NumClicks();
             obj.numClicks = reader.ReadInt64();
         }
 
-        public override void Serialize(ref NumClicks obj)
+        public override void Serialize(in NumClicks obj)
         {
             writer.Write(obj.numClicks);
         }

--- a/cs/test/ObjectRecoveryTestTypes.cs
+++ b/cs/test/ObjectRecoveryTestTypes.cs
@@ -34,6 +34,7 @@ namespace FASTER.test.recovery.objectstore
     {
         public override void Deserialize(ref AdId obj)
         {
+            obj = new AdId();
             obj.adId = reader.ReadInt64();
         }
 
@@ -59,6 +60,7 @@ namespace FASTER.test.recovery.objectstore
     {
         public override void Deserialize(ref NumClicks obj)
         {
+            obj = new NumClicks();
             obj.numClicks = reader.ReadInt64();
         }
 

--- a/cs/test/ObjectTestTypes.cs
+++ b/cs/test/ObjectTestTypes.cs
@@ -34,13 +34,13 @@ namespace FASTER.test
 
     public class MyKeySerializer : BinaryObjectSerializer<MyKey>
     {
-        public override void Deserialize(ref MyKey obj)
+        public override void Deserialize(out MyKey obj)
         {
             obj = new MyKey();
             obj.key = reader.ReadInt32();
         }
 
-        public override void Serialize(ref MyKey obj)
+        public override void Serialize(in MyKey obj)
         {
             writer.Write(obj.key);
         }
@@ -53,13 +53,13 @@ namespace FASTER.test
 
     public class MyValueSerializer : BinaryObjectSerializer<MyValue>
     {
-        public override void Deserialize(ref MyValue obj)
+        public override void Deserialize(out MyValue obj)
         {
             obj = new MyValue();
             obj.value = reader.ReadInt32();
         }
 
-        public override void Serialize(ref MyValue obj)
+        public override void Serialize(in MyValue obj)
         {
             writer.Write(obj.value);
         }
@@ -303,14 +303,14 @@ namespace FASTER.test
 
     public class MyLargeValueSerializer : BinaryObjectSerializer<MyLargeValue>
     {
-        public override void Deserialize(ref MyLargeValue obj)
+        public override void Deserialize(out MyLargeValue obj)
         {
             obj = new MyLargeValue();
             int size = reader.ReadInt32();
             obj.value = reader.ReadBytes(size);
         }
 
-        public override void Serialize(ref MyLargeValue obj)
+        public override void Serialize(in MyLargeValue obj)
         {
             writer.Write(obj.value.Length);
             writer.Write(obj.value);

--- a/cs/test/ObjectTestTypes.cs
+++ b/cs/test/ObjectTestTypes.cs
@@ -36,6 +36,7 @@ namespace FASTER.test
     {
         public override void Deserialize(ref MyKey obj)
         {
+            obj = new MyKey();
             obj.key = reader.ReadInt32();
         }
 
@@ -54,6 +55,7 @@ namespace FASTER.test
     {
         public override void Deserialize(ref MyValue obj)
         {
+            obj = new MyValue();
             obj.value = reader.ReadInt32();
         }
 
@@ -303,6 +305,7 @@ namespace FASTER.test
     {
         public override void Deserialize(ref MyLargeValue obj)
         {
+            obj = new MyLargeValue();
             int size = reader.ReadInt32();
             obj.value = reader.ReadBytes(size);
         }

--- a/cs/test/SimpleRecoveryTest.cs
+++ b/cs/test/SimpleRecoveryTest.cs
@@ -199,7 +199,7 @@ namespace FASTER.test.recovery.sumstore.simple
         {
             log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\SimpleRecoveryTest2.log", deleteOnClose: true);
 
-            Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints5");
+            Directory.CreateDirectory(TestContext.CurrentContext.TestDirectory + "\\checkpoints6");
 
             fht1 = new FasterKV
                 <AdId, NumClicks, AdInput, Output, Empty, SimpleFunctions>


### PR DESCRIPTION
* We are removing the generic type constraint `new()` on Key and Value types in FASTER. During `Deserialize`, the user is expected to create an instance of the type being deserialized. The change is breaking for custom serializers, but is worth the benefit of relaxing type constraints.
* Changed `IObjectSerializer` `ref` params to `in` and `out` for `Serialize` and `Deserialize` respectively (breaking change for custom serializers).
* Added default serializer for generic keys and values, based on `DataContractSerializer`, in case the user does not implement `IObjectSerializer<T>`.
* Added specialized fast binary serializers for `byte[]` and `string` key/value types.
* Added tests for strings and byte arrays as key/value types.

This PR makes code like the below (specifically, we are using C# string keys directly here) work out of the box:

```cs
        static void Main()
        {
            // Create device where log will spill to disk
            var device = Devices.CreateLogDevice("foo");

            // Create simplest store instance
            using var store
                = new FasterKV<string, int>(
                    1L << 20, // size of hash table in #cache lines; 64 bytes per cache line
                    new LogSettings { LogDevice = device } // log device
                    );

            // Create new "session" to talk to store using default provided callback functions
            using var s = store.NewSession(new SimpleFunctions<string, int>());

            int key = "mykey", val = 25, inp = 0, outp = 0;

            // Synchronous upsert of value
            s.Upsert(ref key, ref val, Empty.Default, 0);
            
            // Synchronous read of value
            var status = s.Read(ref key, ref inp, ref outp, Empty.Default, 0);
            
            // Check result
            if (status != Status.OK || outp != val)
            {
                throw new Exception();
            }
        }
```