### PR TITLE
[C#] Renaming IDevice.Close to IDevice.Dispose

### DIFF
--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -353,7 +353,7 @@ namespace FASTER.benchmark
             Console.WriteLine("##, " + distribution + ", " + numaStyle + ", " + readPercent + ", "
                 + threadCount + ", " + total_ops_done / seconds + ", "
                 + (endTailAddress - startTailAddress));
-            device.Close();
+            device.Dispose();
         }
 
         private void SetupYcsb(int thread_idx)

--- a/cs/playground/ClassRecoveryDurability/Storedb.cs
+++ b/cs/playground/ClassRecoveryDurability/Storedb.cs
@@ -68,8 +68,8 @@ namespace ClassRecoveryDurablity
         public void Dispose()
         {
             db.Dispose();
-            log.Close();
-            objLog.Close();
+            log.Dispose();
+            objLog.Dispose();
         }
     }
 }

--- a/cs/samples/CacheStore/Program.cs
+++ b/cs/samples/CacheStore/Program.cs
@@ -89,8 +89,8 @@ namespace CacheStore
 
             // Clean up
             store.Dispose();
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
 
             // Delete the created files
             try { new DirectoryInfo(path).Delete(true); } catch { }

--- a/cs/samples/HelloWorld/Program.cs
+++ b/cs/samples/HelloWorld/Program.cs
@@ -76,7 +76,7 @@ namespace HelloWorld
             store.Dispose();
 
             // Close devices
-            log.Close();
+            log.Dispose();
 
             // Delete the created files
             try { new DirectoryInfo(path).Delete(true); } catch { }

--- a/cs/samples/StoreCheckpointRecover/Program.cs
+++ b/cs/samples/StoreCheckpointRecover/Program.cs
@@ -65,8 +65,8 @@ namespace StoreCheckpointRecover
             store.Dispose();
 
             // Close logs
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
 
             // Create new store
             log = Devices.CreateLogDevice(path + "hlog.log");
@@ -96,8 +96,8 @@ namespace StoreCheckpointRecover
             }
 
             store2.Dispose();
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
 
             try { new DirectoryInfo(path).Delete(true); } catch { }
 

--- a/cs/samples/StoreCustomTypes/Program.cs
+++ b/cs/samples/StoreCustomTypes/Program.cs
@@ -88,8 +88,8 @@ namespace StoreCustomTypes
             store.Dispose();
 
             // Close logs
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
 
             try { new DirectoryInfo(path).Delete(true); } catch { }
 

--- a/cs/samples/StoreVarLenTypes/Program.cs
+++ b/cs/samples/StoreVarLenTypes/Program.cs
@@ -104,7 +104,7 @@ namespace StoreVarLenTypes
 
             s.Dispose();
             store.Dispose();
-            log.Close();
+            log.Dispose();
 
             Console.WriteLine("Press <ENTER> to end");
             Console.ReadLine();

--- a/cs/src/core/Device/IDevice.cs
+++ b/cs/src/core/Device/IDevice.cs
@@ -16,7 +16,7 @@ namespace FASTER.core
     /// <summary>
     /// Interface for devices
     /// </summary>
-    public interface IDevice
+    public interface IDevice : IDisposable
     {
         /// <summary>
         /// Size of sector
@@ -162,12 +162,5 @@ namespace FASTER.core
         /// </summary>
         /// <param name="segment">index of the segment to remov</param>
         void RemoveSegment(int segment);
-
-        /* Close */
-
-        /// <summary>
-        /// Close
-        /// </summary>
-        void Close();
     }
 }

--- a/cs/src/core/Device/LocalMemoryDevice.cs
+++ b/cs/src/core/Device/LocalMemoryDevice.cs
@@ -168,7 +168,7 @@ namespace FASTER.core
         /// <summary>
         /// Close device
         /// </summary>
-        public override void Close()
+        public override void Dispose()
         {
             foreach (var q in ioQueue)
                 while (q.Count != 0) { }

--- a/cs/src/core/Device/LocalStorageDevice.cs
+++ b/cs/src/core/Device/LocalStorageDevice.cs
@@ -286,7 +286,7 @@ namespace FASTER.core
         /// <summary>
         /// Close device
         /// </summary>
-        public override void Close()
+        public override void Dispose()
         {
             foreach (var logHandle in logHandles.Values)
                 logHandle.Dispose();

--- a/cs/src/core/Device/ManagedLocalStorageDevice.cs
+++ b/cs/src/core/Device/ManagedLocalStorageDevice.cs
@@ -265,7 +265,7 @@ namespace FASTER.core
         /// <summary>
         /// 
         /// </summary>
-        public override void Close()
+        public override void Dispose()
         {
             foreach (var entry in logHandles)
             {

--- a/cs/src/core/Device/NullDevice.cs
+++ b/cs/src/core/Device/NullDevice.cs
@@ -64,9 +64,9 @@ namespace FASTER.core
         public override void RemoveSegmentAsync(int segment, AsyncCallback callback, IAsyncResult result) => callback(result);
 
         /// <summary>
-        /// <see cref="IDevice.Close"/>
+        /// <see cref="IDevice.Dispose"/>
         /// </summary>
-        public override void Close()
+        public override void Dispose()
         {
         }
     }

--- a/cs/src/core/Device/ShardedStorageDevice.cs
+++ b/cs/src/core/Device/ShardedStorageDevice.cs
@@ -145,13 +145,13 @@ namespace FASTER.core
         }
 
         /// <summary>
-        /// <see cref="IDevice.Close"/>
+        /// <see cref="IDevice.Dispose"/>
         /// </summary>
-        public override void Close()
+        public override void Dispose()
         {
             foreach (IDevice device in partitions.Devices)
             {
-                device.Close();
+                device.Dispose();
             }
         }
 

--- a/cs/src/core/Device/StorageDeviceBase.cs
+++ b/cs/src/core/Device/StorageDeviceBase.cs
@@ -266,7 +266,7 @@ namespace FASTER.core
         /// <summary>
         /// 
         /// </summary>
-        public abstract void Close();
+        public abstract void Dispose();
 
         /// <summary>
         /// Handle space utilization of limited capacity devices by invoking segment truncation if necessary

--- a/cs/src/core/Device/TieredStorageDevice.cs
+++ b/cs/src/core/Device/TieredStorageDevice.cs
@@ -63,11 +63,11 @@ namespace FASTER.core
             }
         }
 
-        public override void Close()
+        public override void Dispose()
         {
             foreach (IDevice device in devices)
             {
-                device.Close();
+                device.Dispose();
             }
         }
 

--- a/cs/src/core/Index/CheckpointManagement/DeviceLogCommitCheckpointManager.cs
+++ b/cs/src/core/Index/CheckpointManagement/DeviceLogCommitCheckpointManager.cs
@@ -85,7 +85,7 @@ namespace FASTER.core
             WriteInto(device, 0, ms.ToArray(), (int)ms.Position);
 
             if (!overwriteLogCommits)
-                device.Close();
+                device.Dispose();
 
             RemoveOutdated();
         }
@@ -93,7 +93,7 @@ namespace FASTER.core
         /// <inheritdoc />
         public void Dispose()
         {
-            singleLogCommitDevice?.Close();
+            singleLogCommitDevice?.Dispose();
             singleLogCommitDevice = null;
         }
 
@@ -130,7 +130,7 @@ namespace FASTER.core
                 ReadInto(device, 0, out body, size + sizeof(int));
             
             if (!overwriteLogCommits)
-                device.Close();
+                device.Dispose();
 
             return new Span<byte>(body).Slice(sizeof(int)).ToArray();
         }
@@ -168,7 +168,7 @@ namespace FASTER.core
             writer.Write(commitMetadata);
 
             WriteInto(device, 0, ms.ToArray(), (int)ms.Position);
-            device.Close();
+            device.Dispose();
         }
 
         /// <inheritdoc />
@@ -190,7 +190,7 @@ namespace FASTER.core
                 body = writePad;
             else
                 ReadInto(device, 0, out body, size + sizeof(int));
-            device.Close();
+            device.Dispose();
             return new Span<byte>(body).Slice(sizeof(int)).ToArray();
         }
 
@@ -206,7 +206,7 @@ namespace FASTER.core
             writer.Write(commitMetadata);
 
             WriteInto(device, 0, ms.ToArray(), (int)ms.Position);
-            device.Close();
+            device.Dispose();
         }
 
         /// <inheritdoc />
@@ -228,7 +228,7 @@ namespace FASTER.core
                 body = writePad;
             else
                 ReadInto(device, 0, out body, size + sizeof(int));
-            device.Close();
+            device.Dispose();
             return new Span<byte>(body).Slice(sizeof(int)).ToArray();
         }
 

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -405,8 +405,8 @@ namespace FASTER.core
         {
             flushedSemaphore = null;
             info = default;
-            if (snapshotFileDevice != null) snapshotFileDevice.Close();
-            if (snapshotFileObjectLogDevice != null) snapshotFileObjectLogDevice.Close();
+            if (snapshotFileDevice != null) snapshotFileDevice.Dispose();
+            if (snapshotFileObjectLogDevice != null) snapshotFileObjectLogDevice.Dispose();
         }
 
         public bool IsDefault()
@@ -555,7 +555,7 @@ namespace FASTER.core
         public void Reset()
         {
             info = default;
-            main_ht_device.Close();
+            main_ht_device.Dispose();
         }
 
         public bool IsDefault()

--- a/cs/src/core/Index/Recovery/IndexRecovery.cs
+++ b/cs/src/core/Index/Recovery/IndexRecovery.cs
@@ -45,7 +45,7 @@ namespace FASTER.core
             IsFuzzyIndexRecoveryComplete(true);
 
             // close index checkpoint files appropriately
-            info.main_ht_device.Close();
+            info.main_ht_device.Dispose();
 
             // Delete all tentative entries!
             DeleteTentativeEntries();

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -365,8 +365,8 @@ namespace FASTER.core
                 }
             }
 
-            recoveryStatus.recoveryDevice.Close();
-            recoveryStatus.objectLogRecoveryDevice.Close();
+            recoveryStatus.recoveryDevice.Dispose();
+            recoveryStatus.objectLogRecoveryDevice.Dispose();
         }
 
         private void RecoverFromPage(long startRecoveryAddress,

--- a/cs/src/devices/AzureStorageDevice/AzureStorageDevice.cs
+++ b/cs/src/devices/AzureStorageDevice/AzureStorageDevice.cs
@@ -41,7 +41,7 @@ namespace FASTER.devices
         /// <param name="blobManager">Blob manager instance</param>
         /// <param name="underLease">Whether we use leases</param>
         /// <param name="deleteOnClose">
-        /// True if the program should delete all blobs created on call to <see cref="Close">Close</see>. False otherwise. 
+        /// True if the program should delete all blobs created on call to <see cref="Dispose">Close</see>. False otherwise. 
         /// The container is not deleted even if it was created in this constructor
         /// </param>
         /// <param name="capacity">The maximum number of bytes this storage device can accommondate, or CAPACITY_UNSPECIFIED if there is no such limit </param>
@@ -70,7 +70,7 @@ namespace FASTER.devices
         /// <param name="blobManager">Blob manager instance</param>
         /// <param name="underLease">Whether we use leases</param>
         /// <param name="deleteOnClose">
-        /// True if the program should delete all blobs created on call to <see cref="Close">Close</see>. False otherwise. 
+        /// True if the program should delete all blobs created on call to <see cref="Dispose">Close</see>. False otherwise. 
         /// The container is not deleted even if it was created in this constructor
         /// </param>
         /// <param name="capacity">The maximum number of bytes this storage device can accommondate, or CAPACITY_UNSPECIFIED if there is no such limit </param>
@@ -155,9 +155,9 @@ namespace FASTER.devices
         }
 
         /// <summary>
-        /// <see cref="IDevice.Close">Inherited</see>
+        /// <see cref="IDevice.Dispose">Inherited</see>
         /// </summary>
-        public override void Close()
+        public override void Dispose()
         {
             // Unlike in LocalStorageDevice, we explicitly remove all page blobs if the deleteOnClose flag is set, instead of relying on the operating system
             // to delete files after the end of our process. This leads to potential problems if multiple instances are sharing the same underlying page blobs.

--- a/cs/test/AsyncLargeObjectTests.cs
+++ b/cs/test/AsyncLargeObjectTests.cs
@@ -95,8 +95,8 @@ namespace FASTER.test.async
             await fht1.CompleteCheckpointAsync();
 
             fht1.Dispose();
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
 
             log = Devices.CreateLogDevice(test_path + "\\LargeObjectTest.log");
             objlog = Devices.CreateLogDevice(test_path + "\\LargeObjectTest.obj.log");
@@ -130,8 +130,8 @@ namespace FASTER.test.async
 
             fht2.Dispose();
 
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
         }
     }
 }

--- a/cs/test/AsyncTests.cs
+++ b/cs/test/AsyncTests.cs
@@ -107,7 +107,7 @@ namespace FASTER.test.async
             }
 
             fht2.Dispose();
-            log.Close();
+            log.Dispose();
             new DirectoryInfo(TestContext.CurrentContext.TestDirectory + "\\checkpoints4").Delete(true);
         }
     }

--- a/cs/test/BasicDiskFASTERTests.cs
+++ b/cs/test/BasicDiskFASTERTests.cs
@@ -120,7 +120,7 @@ namespace FASTER.test
             session.Dispose();
             fht.Dispose();
             fht = null;
-            log.Close();
+            log.Dispose();
         }
     }
 }

--- a/cs/test/BasicFASTERTests.cs
+++ b/cs/test/BasicFASTERTests.cs
@@ -36,7 +36,7 @@ namespace FASTER.test
             session.Dispose();
             fht.Dispose();
             fht = null;
-            log.Close();
+            log.Dispose();
         }
 
 

--- a/cs/test/BlittableIterationTests.cs
+++ b/cs/test/BlittableIterationTests.cs
@@ -33,7 +33,7 @@ namespace FASTER.test
         {
             fht.Dispose();
             fht = null;
-            log.Close();
+            log.Dispose();
         }
 
         [Test]

--- a/cs/test/BlittableLogCompactionTests.cs
+++ b/cs/test/BlittableLogCompactionTests.cs
@@ -33,7 +33,7 @@ namespace FASTER.test
         {
             fht.Dispose();
             fht = null;
-            log.Close();
+            log.Dispose();
         }
 
         [Test]

--- a/cs/test/BlittableLogScanTests.cs
+++ b/cs/test/BlittableLogScanTests.cs
@@ -34,7 +34,7 @@ namespace FASTER.test
         {
             fht.Dispose();
             fht = null;
-            log.Close();
+            log.Dispose();
         }
 
         [Test]

--- a/cs/test/DeviceFasterLogTests.cs
+++ b/cs/test/DeviceFasterLogTests.cs
@@ -33,7 +33,7 @@ namespace FASTER.test
                     new AzureStorageNamedDeviceFactory(EMULATED_STORAGE_STRING),
                     new DefaultCheckpointNamingScheme($"{TEST_CONTAINER}/PageBlobFasterLogTest1"));
                 FasterLogTest1(logChecksum, device, checkpointManager);
-                device.Close();
+                device.Dispose();
                 checkpointManager.PurgeAll();
                 checkpointManager.Dispose();
             }

--- a/cs/test/FasterLogResumeTests.cs
+++ b/cs/test/FasterLogResumeTests.cs
@@ -30,7 +30,7 @@ namespace FASTER.test
         [TearDown]
         public void TearDown()
         {
-            device.Close();
+            device.Dispose();
 
             if (Directory.Exists(commitPath))
                 DeleteDirectory(commitPath);

--- a/cs/test/FasterLogTests.cs
+++ b/cs/test/FasterLogTests.cs
@@ -39,7 +39,7 @@ namespace FASTER.test
         public void TearDown()
         {
             manager.Dispose();
-            device.Close();
+            device.Dispose();
 
             if (Directory.Exists(commitPath))
                 DeleteDirectory(commitPath);

--- a/cs/test/FunctionPerSessionTests.cs
+++ b/cs/test/FunctionPerSessionTests.cs
@@ -124,7 +124,7 @@ namespace FASTER.test
         {
             _faster.Dispose();
             _faster = null;
-            _log.Close();
+            _log.Dispose();
         }
 
         [Test]

--- a/cs/test/GenericByteArrayTests.cs
+++ b/cs/test/GenericByteArrayTests.cs
@@ -38,8 +38,8 @@ namespace FASTER.test
             session.Dispose();
             fht.Dispose();
             fht = null;
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
         }
 
 

--- a/cs/test/GenericDiskDeleteTests.cs
+++ b/cs/test/GenericDiskDeleteTests.cs
@@ -35,8 +35,8 @@ namespace FASTER.test
             session.Dispose();
             fht.Dispose();
             fht = null;
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
         }
 
 

--- a/cs/test/GenericIterationTests.cs
+++ b/cs/test/GenericIterationTests.cs
@@ -42,8 +42,8 @@ namespace FASTER.test
             session.Dispose();
             fht.Dispose();
             fht = null;
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
         }
 
         [Test]

--- a/cs/test/GenericLogCompactionTests.cs
+++ b/cs/test/GenericLogCompactionTests.cs
@@ -42,8 +42,8 @@ namespace FASTER.test
             session.Dispose();
             fht.Dispose();
             fht = null;
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
         }
 
         [Test]

--- a/cs/test/GenericLogScanTests.cs
+++ b/cs/test/GenericLogScanTests.cs
@@ -40,8 +40,8 @@ namespace FASTER.test
         {
             fht.Dispose();
             fht = null;
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
         }
 
 

--- a/cs/test/GenericStringTests.cs
+++ b/cs/test/GenericStringTests.cs
@@ -36,8 +36,8 @@ namespace FASTER.test
             session.Dispose();
             fht.Dispose();
             fht = null;
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
         }
 
 

--- a/cs/test/LargeObjectTests.cs
+++ b/cs/test/LargeObjectTests.cs
@@ -93,8 +93,8 @@ namespace FASTER.test.largeobjects
             fht1.TakeFullCheckpoint(out Guid token);
             fht1.CompleteCheckpointAsync().GetAwaiter().GetResult();
             fht1.Dispose();
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
 
             log = Devices.CreateLogDevice(test_path + "\\LargeObjectTest.log");
             objlog = Devices.CreateLogDevice(test_path + "\\LargeObjectTest.obj.log");
@@ -128,8 +128,8 @@ namespace FASTER.test.largeobjects
 
             fht2.Dispose();
 
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
         }
     }
 }

--- a/cs/test/MiscFASTERTests.cs
+++ b/cs/test/MiscFASTERTests.cs
@@ -39,8 +39,8 @@ namespace FASTER.test
         {
             fht.Dispose();
             fht = null;
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
         }
 
 
@@ -146,7 +146,7 @@ namespace FASTER.test
             finally
             {
                 if (log != null)
-                    log.Close();
+                    log.Dispose();
             }
         }
     }

--- a/cs/test/NativeReadCacheTests.cs
+++ b/cs/test/NativeReadCacheTests.cs
@@ -34,7 +34,7 @@ namespace FASTER.test
         {
             fht.Dispose();
             fht = null;
-            log.Close();
+            log.Dispose();
         }
 
         [Test]

--- a/cs/test/ObjectFASTERTests.cs
+++ b/cs/test/ObjectFASTERTests.cs
@@ -39,7 +39,7 @@ namespace FASTER.test
         {
             fht.Dispose();
             fht = null;
-            log.Close();
+            log.Dispose();
         }
 
         [Test]

--- a/cs/test/ObjectReadCacheTests.cs
+++ b/cs/test/ObjectReadCacheTests.cs
@@ -33,8 +33,8 @@ namespace FASTER.test
         {
             fht.Dispose();
             fht = null;
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
         }
 
         [Test]

--- a/cs/test/ObjectRecoveryTest.cs
+++ b/cs/test/ObjectRecoveryTest.cs
@@ -56,8 +56,8 @@ namespace FASTER.test.recovery.objectstore
         {
             fht.Dispose();
             fht = null;
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
             DeleteDirectory(test_path);
         }
 
@@ -88,8 +88,8 @@ namespace FASTER.test.recovery.objectstore
             Populate();
             fht.Dispose();
             fht = null;
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
             Setup();
             RecoverAndTest(token, token);
         }

--- a/cs/test/ObjectRecoveryTest2.cs
+++ b/cs/test/ObjectRecoveryTest2.cs
@@ -111,8 +111,8 @@ namespace FASTER.test.recovery.objects
         {
             // Dispose FASTER instance and log
             h.Dispose();
-            log.Close();
-            objlog.Close();
+            log.Dispose();
+            objlog.Dispose();
         }
 
         private void Write(ClientSession<MyKey, MyValue, MyInput, MyOutput, MyContext, MyFunctions> session, MyContext context, FasterKV<MyKey, MyValue, MyInput, MyOutput, MyContext, MyFunctions> fht)

--- a/cs/test/RecoverContinueTests.cs
+++ b/cs/test/RecoverContinueTests.cs
@@ -61,7 +61,7 @@ namespace FASTER.test.recovery.sumstore.recover_continue
             fht1 = null;
             fht2 = null;
             fht3 = null;
-            log.Close();
+            log.Dispose();
             Directory.Delete(TestContext.CurrentContext.TestDirectory + "\\checkpoints3", true);
         }
 

--- a/cs/test/RecoveryTests.cs
+++ b/cs/test/RecoveryTests.cs
@@ -48,7 +48,7 @@ namespace FASTER.test.recovery.sumstore
         {
             fht.Dispose();
             fht = null;
-            log.Close();
+            log.Dispose();
             DeleteDirectory(test_path);
         }
 
@@ -83,7 +83,7 @@ namespace FASTER.test.recovery.sumstore
                 if (i >= indexTokens.Count) break;
                 fht.Dispose();
                 fht = null;
-                log.Close();
+                log.Dispose();
                 Setup();
                 RecoverAndTest(logTokens[i], indexTokens[i]);
             }
@@ -98,7 +98,7 @@ namespace FASTER.test.recovery.sumstore
             {
                 fht.Dispose();
                 fht = null;
-                log.Close();
+                log.Dispose();
                 Setup();
                 RecoverAndTest(token, token);
             }

--- a/cs/test/SessionFASTERTests.cs
+++ b/cs/test/SessionFASTERTests.cs
@@ -33,7 +33,7 @@ namespace FASTER.test.async
         {
             fht.Dispose();
             fht = null;
-            log.Close();
+            log.Dispose();
         }
 
 

--- a/cs/test/SharedDirectoryTests.cs
+++ b/cs/test/SharedDirectoryTests.cs
@@ -134,7 +134,7 @@ namespace FASTER.test.recovery.sumstore
             {
                 this.Faster?.Dispose();
                 this.Faster = null;
-                this.LogDevice?.Close();
+                this.LogDevice?.Dispose();
                 this.LogDevice = null;
             }
         }

--- a/cs/test/SimpleRecoveryTest.cs
+++ b/cs/test/SimpleRecoveryTest.cs
@@ -116,7 +116,7 @@ namespace FASTER.test.recovery.sumstore.simple
             }
             session2.Dispose();
 
-            log.Close();
+            log.Dispose();
             fht1.Dispose();
             fht2.Dispose();
 
@@ -186,7 +186,7 @@ namespace FASTER.test.recovery.sumstore.simple
             }
             session2.Dispose();
 
-            log.Close();
+            log.Dispose();
             fht1.Dispose();
             fht2.Dispose();
             checkpointManager.Dispose();
@@ -246,7 +246,7 @@ namespace FASTER.test.recovery.sumstore.simple
 
             Assert.AreEqual(address, fht2.Log.BeginAddress);
 
-            log.Close();
+            log.Dispose();
             fht1.Dispose();
             fht2.Dispose();
             new DirectoryInfo(TestContext.CurrentContext.TestDirectory + "\\checkpoints6").Delete(true);

--- a/cs/test/StateMachineTests.cs
+++ b/cs/test/StateMachineTests.cs
@@ -46,7 +46,7 @@ namespace FASTER.test.statemachine
         public void TearDown()
         {
             fht1.Dispose();
-            log.Close();
+            log.Dispose();
             new DirectoryInfo(TestContext.CurrentContext.TestDirectory + "\\checkpoints4").Delete(true);
         }
 

--- a/cs/test/VariableLengthIteratorTests.cs
+++ b/cs/test/VariableLengthIteratorTests.cs
@@ -67,7 +67,7 @@ namespace FASTER.test
             {
                 session.Dispose();
                 fht.Dispose();
-                log.Close();
+                log.Dispose();
             }
 
             void Set(long keyValue, int length, int tag)

--- a/cs/test/VariableLengthStructFASTERTests.cs
+++ b/cs/test/VariableLengthStructFASTERTests.cs
@@ -73,7 +73,7 @@ namespace FASTER.test
             s.Dispose();
             fht.Dispose();
             fht = null;
-            log.Close();
+            log.Dispose();
         }
 
         [Test]
@@ -145,7 +145,7 @@ namespace FASTER.test
             s.Dispose();
             fht.Dispose();
             fht = null;
-            log.Close();
+            log.Dispose();
         }
         
     }


### PR DESCRIPTION
`IDevice` now implements `IDisposable` instead of having a custom `Close` operation.

This is a **breaking change** in order to introduce uniformity in the new API.

Users simply have to rename `Close` to `Dispose` in their code.