### PR TITLE
[C#] Remove dependency on Mono.Posix.NETStandard

### DIFF
--- a/cs/src/core/Device/ManagedLocalStorageDevice.cs
+++ b/cs/src/core/Device/ManagedLocalStorageDevice.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace FASTER.core

--- a/cs/src/core/Device/ManagedLocalStorageDevice.cs
+++ b/cs/src/core/Device/ManagedLocalStorageDevice.cs
@@ -2,17 +2,10 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Buffers;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
-
-#if DOTNETCORE
-using Mono.Unix.Native;
-#endif
 
 namespace FASTER.core
 {
@@ -333,13 +326,6 @@ namespace FASTER.core
                 GetSegmentName(segmentId), FileMode.OpenOrCreate,
                 FileAccess.Read, FileShare.ReadWrite, 512, fo);
 
-#if DOTNETCORE
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                Syscall.fcntl((int)logReadHandle.SafeFileHandle.DangerousGetHandle(), FcntlCommand.F_NOCACHE, 1);
-            }
-#endif
-
             return logReadHandle;
         }
 
@@ -355,13 +341,6 @@ namespace FASTER.core
             var logWriteHandle = new FileStream(
                 GetSegmentName(segmentId), FileMode.OpenOrCreate,
                 FileAccess.Write, FileShare.ReadWrite, 512, fo);
-
-#if DOTNETCORE
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                Syscall.fcntl((int)logWriteHandle.SafeFileHandle.DangerousGetHandle(), FcntlCommand.F_NOCACHE, 1);
-            }
-#endif
 
             if (preallocateFile && segmentSize != -1)
                 SetFileSize(logWriteHandle, segmentSize);

--- a/cs/src/core/FASTER.core.csproj
+++ b/cs/src/core/FASTER.core.csproj
@@ -54,7 +54,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="System.Interactive.Async" Version="4.1.1" />
   </ItemGroup>
 </Project>

--- a/cs/src/core/FASTER.core.nuspec
+++ b/cs/src/core/FASTER.core.nuspec
@@ -27,12 +27,10 @@
         <dependency id="System.Memory" version="4.5.4" />
         <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" />
         <dependency id="System.Interactive.Async" version="4.1.1" />
-        <dependency id="Mono.Posix.NETStandard" version="1.0.0" />
       </group>
       <group targetFramework="netstandard2.1">
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" />
         <dependency id="System.Interactive.Async" version="4.1.1" />
-        <dependency id="Mono.Posix.NETStandard" version="1.0.0" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Remove dependency on `Mono.Posix.NETStandard`. It was used only to disable file read caching on non-Windows. This "feature" does not justify adding another dependency, as it is creating issues with cross-platform Xamarin apps.