### PR TITLE
[C#] Allow recovery without index checkpoint

### DIFF
--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -484,6 +484,10 @@ namespace FASTER.core
         /// <param name="flushCallback"></param>
         public AllocatorBase(LogSettings settings, IFasterEqualityComparer<Key> comparer, Action<long, long> evictCallback, LightEpoch epoch, Action<CommitInfo> flushCallback)
         {
+            if (settings.LogDevice == null)
+            {
+                throw new FasterException("LogSettings.LogDevice needs to be specified (e.g., use Devices.CreateLogDevice, AzureStorageDevice, or NullDevice)");
+            }
             if (evictCallback != null)
             {
                 ReadCache = true;

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -42,6 +42,11 @@ namespace FASTER.core
         public GenericAllocator(LogSettings settings, SerializerSettings<Key, Value> serializerSettings, IFasterEqualityComparer<Key> comparer, Action<long, long> evictCallback = null, LightEpoch epoch = null, Action<CommitInfo> flushCallback = null)
             : base(settings, comparer, evictCallback, epoch, flushCallback)
         {
+            if (settings.ObjectLogDevice == null)
+            {
+                throw new FasterException("LogSettings.ObjectLogDevice needs to be specified (e.g., use Devices.CreateLogDevice, AzureStorageDevice, or NullDevice)");
+            }
+
             SerializerSettings = serializerSettings;
 
             if ((!keyBlittable) && (settings.LogDevice as NullDevice == null) && ((SerializerSettings == null) || (SerializerSettings.keySerializer == null)))

--- a/cs/src/core/Device/Devices.cs
+++ b/cs/src/core/Device/Devices.cs
@@ -26,9 +26,6 @@ namespace FASTER.core
         /// <returns>Device instance</returns>
         public static IDevice CreateLogDevice(string logPath, bool preallocateFile = false, bool deleteOnClose = false, long capacity = CAPACITY_UNSPECIFIED, bool recoverDevice = false)
         {
-            if (string.IsNullOrWhiteSpace(logPath))
-                return new NullDevice();
-
             IDevice logDevice;
 
 #if DOTNETCORE

--- a/cs/src/core/Index/Common/LogSettings.cs
+++ b/cs/src/core/Index/Common/LogSettings.cs
@@ -32,12 +32,12 @@ namespace FASTER.core
         /// <summary>
         /// Device used for main hybrid log
         /// </summary>
-        public IDevice LogDevice = new NullDevice();
+        public IDevice LogDevice;
 
         /// <summary>
         /// Device used for serialized heap objects in hybrid log
         /// </summary>
-        public IDevice ObjectLogDevice = new NullDevice();
+        public IDevice ObjectLogDevice;
 
         /// <summary>
         /// Size of a segment (group of pages), in bits

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -144,6 +144,7 @@ namespace FASTER.core
                         readcache = new VariableLengthBlittableAllocator<Key, Value>(
                             new LogSettings
                             {
+                                LogDevice = new NullDevice(),
                                 PageSizeBits = logSettings.ReadCacheSettings.PageSizeBits,
                                 MemorySizeBits = logSettings.ReadCacheSettings.MemorySizeBits,
                                 SegmentSizeBits = logSettings.ReadCacheSettings.MemorySizeBits,
@@ -162,6 +163,7 @@ namespace FASTER.core
                         readcache = new BlittableAllocator<Key, Value>(
                             new LogSettings
                             {
+                                LogDevice = new NullDevice(),
                                 PageSizeBits = logSettings.ReadCacheSettings.PageSizeBits,
                                 MemorySizeBits = logSettings.ReadCacheSettings.MemorySizeBits,
                                 SegmentSizeBits = logSettings.ReadCacheSettings.MemorySizeBits,
@@ -183,6 +185,8 @@ namespace FASTER.core
                     readcache = new GenericAllocator<Key, Value>(
                         new LogSettings
                         {
+                            LogDevice = new NullDevice(),
+                            ObjectLogDevice = new NullDevice(),
                             PageSizeBits = logSettings.ReadCacheSettings.PageSizeBits,
                             MemorySizeBits = logSettings.ReadCacheSettings.MemorySizeBits,
                             SegmentSizeBits = logSettings.ReadCacheSettings.MemorySizeBits,

--- a/cs/src/core/Index/FASTER/FASTERIterator.cs
+++ b/cs/src/core/Index/FASTER/FASTERIterator.cs
@@ -92,7 +92,7 @@ namespace FASTER.core
             this.cf = cf;
             enumerationPhase = 0;
             fhtSession = fht.NewSession<Empty, Empty, Empty, Functions>(functions);
-            tempKv = new FasterKV<Key, Value>(fht.IndexSize, new LogSettings { MutableFraction = 1 }, comparer: fht.Comparer, variableLengthStructSettings: variableLengthStructSettings);
+            tempKv = new FasterKV<Key, Value>(fht.IndexSize, new LogSettings { LogDevice = new NullDevice(), ObjectLogDevice = new NullDevice(), MutableFraction = 1 }, comparer: fht.Comparer, variableLengthStructSettings: variableLengthStructSettings);
             tempKvSession = tempKv.NewSession<Empty, Empty, Empty, Functions>(functions);
             iter1 = fht.Log.Scan(fht.Log.BeginAddress, untilAddress);
         }

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -253,7 +253,7 @@ namespace FASTER.core
             var originalUntilAddress = untilAddress;
 
             using (var fhtSession = fht.NewSession<Empty, Empty, Empty, Functions>(functions))
-            using (var tempKv = new FasterKV<Key, Value>(fht.IndexSize, new LogSettings(), comparer: fht.Comparer, variableLengthStructSettings: variableLengthStructSettings))
+            using (var tempKv = new FasterKV<Key, Value>(fht.IndexSize, new LogSettings { LogDevice = new NullDevice(), ObjectLogDevice = new NullDevice() }, comparer: fht.Comparer, variableLengthStructSettings: variableLengthStructSettings))
             using (var tempKvSession = tempKv.NewSession<Empty, Empty, Empty, Functions>(functions))
             {
                 using (var iter1 = fht.Log.Scan(fht.Log.BeginAddress, untilAddress))

--- a/cs/src/core/Index/Recovery/IndexRecovery.cs
+++ b/cs/src/core/Index/Recovery/IndexRecovery.cs
@@ -27,7 +27,9 @@ namespace FASTER.core
         {
             var token = info.info.token;
             var ht_version = resizeInfo.version;
-            Debug.Assert(state[ht_version].size == info.info.table_size);
+
+            if (state[ht_version].size != info.info.table_size)
+                throw new FasterException($"Incompatible hash table size during recovery; allocated {state[ht_version].size} buckets, recovering {info.info.table_size} buckets");
 
             // Create devices to read from using Async API
             info.main_ht_device = checkpointManager.GetIndexDevice(token);


### PR DESCRIPTION
* Allow recovery without index checkpoint, by simply using an empty hash table and replaying the log from the begin address
* Add checks to make sure users do not instantiate FASTER without creating log devices
