### PR TITLE
[C#] Recovery improvements

### DIFF
--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -1118,6 +1118,7 @@ namespace FASTER.core
         /// <param name="tailAddress"></param>
         /// <param name="headAddress"></param>
         /// <param name="beginAddress"></param>
+        /// <param name="readonlyAddress"></param>
         public void RecoveryReset(long tailAddress, long headAddress, long beginAddress, long readonlyAddress)
         {
             long tailPage = GetPage(tailAddress);

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -1118,7 +1118,7 @@ namespace FASTER.core
         /// <param name="tailAddress"></param>
         /// <param name="headAddress"></param>
         /// <param name="beginAddress"></param>
-        public void RecoveryReset(long tailAddress, long headAddress, long beginAddress)
+        public void RecoveryReset(long tailAddress, long headAddress, long beginAddress, long readonlyAddress)
         {
             long tailPage = GetPage(tailAddress);
             long offsetInPage = GetOffsetInPage(tailAddress);
@@ -1136,9 +1136,9 @@ namespace FASTER.core
             HeadAddress = headAddress;
             SafeHeadAddress = headAddress;
             ClosedUntilAddress = headAddress;
-            FlushedUntilAddress = tailAddress;
-            ReadOnlyAddress = tailAddress;
-            SafeReadOnlyAddress = tailAddress;
+            FlushedUntilAddress = readonlyAddress;
+            ReadOnlyAddress = readonlyAddress;
+            SafeReadOnlyAddress = readonlyAddress;
 
             // for the last page which contains tailoffset, it must be open
             pageIndex = GetPageIndexForAddress(tailAddress);

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -257,9 +257,6 @@ namespace FASTER.core
         // Used as an atomic counter to check if resizing is complete
         internal long numPendingChunksToBeSplit;
 
-        // Epoch set for resizing
-        internal int resizeEpoch;
-
         internal LightEpoch epoch;
 
         internal ResizeInfo resizeInfo;

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -306,7 +306,7 @@ namespace FASTER.core
             }
 
             minTableSize = size;
-            resizeInfo = default(ResizeInfo);
+            resizeInfo = default;
             resizeInfo.status = ResizeOperationStatus.DONE;
             resizeInfo.version = 0;
             Initialize(resizeInfo.version, size, sector_size);
@@ -382,7 +382,7 @@ namespace FASTER.core
 
                 if (target_entry_word == 0)
                 {
-                    entry = default(HashBucketEntry);
+                    entry = default;
                     return false;
                 }
                 bucket = (HashBucket*)overflowBucketsAllocator.GetPhysicalAddress(target_entry_word);
@@ -405,7 +405,7 @@ namespace FASTER.core
 
 
                 // Install tentative tag in free slot
-                entry = default(HashBucketEntry);
+                entry = default;
                 entry.Tag = tag;
                 entry.Address = Constants.kTempInvalidAddress;
                 entry.Pending = false;
@@ -448,7 +448,7 @@ namespace FASTER.core
                         continue;
                     }
 
-                    HashBucketEntry entry = default(HashBucketEntry);
+                    HashBucketEntry entry = default;
                     entry.word = target_entry_word;
                     if (tag == entry.Tag)
                     {
@@ -488,7 +488,7 @@ namespace FASTER.core
                         continue;
                     }
 
-                    HashBucketEntry entry = default(HashBucketEntry);
+                    HashBucketEntry entry = default;
                     entry.word = target_entry_word;
                     if (tag == entry.Tag)
                     {
@@ -596,7 +596,7 @@ namespace FASTER.core
                             // Install succeeded
                             bucket = physicalBucketAddress;
                             slot = 0;
-                            entry = default(HashBucketEntry);
+                            entry = default;
                             return recordExists;
                         }
                     }
@@ -606,7 +606,7 @@ namespace FASTER.core
                         {
                             bucket = entry_slot_bucket;
                         }
-                        entry = default(HashBucketEntry);
+                        entry = default;
                         break;
                     }
                 }
@@ -647,7 +647,7 @@ namespace FASTER.core
                         continue;
                     }
 
-                    HashBucketEntry entry = default(HashBucketEntry);
+                    HashBucketEntry entry = default;
                     entry.word = target_entry_word;
                     if (tag == entry.Tag)
                     {
@@ -723,7 +723,7 @@ namespace FASTER.core
         /// 
         /// </summary>
         /// <param name="version"></param>
-        protected virtual string _DumpDistribution(int version)
+        protected virtual string DumpDistributionInternal(int version)
         {
             var table_size_ = state[version].size;
             var ptable_ = state[version].tableAligned;
@@ -776,7 +776,7 @@ namespace FASTER.core
         /// </summary>
         public string DumpDistribution()
         {
-            return _DumpDistribution(resizeInfo.version);
+            return DumpDistributionInternal(resizeInfo.version);
         }
 
     }

--- a/cs/src/core/Index/FasterLog/FasterLog.cs
+++ b/cs/src/core/Index/FasterLog/FasterLog.cs
@@ -912,7 +912,7 @@ namespace FASTER.core
 
                     recoveredIterators = info.Iterators;
 
-                    allocator.RestoreHybridLog(info.FlushedUntilAddress, headAddress, info.BeginAddress);
+                    allocator.RestoreHybridLog(info.BeginAddress, headAddress, info.FlushedUntilAddress, info.FlushedUntilAddress);
                     CommittedUntilAddress = info.FlushedUntilAddress;
                     CommittedBeginAddress = info.BeginAddress;
                     SafeTailAddress = info.FlushedUntilAddress;

--- a/cs/src/core/Index/Interfaces/NullFasterSession.cs
+++ b/cs/src/core/Index/Interfaces/NullFasterSession.cs
@@ -2,7 +2,7 @@
 {
     struct NullFasterSession : IFasterSession
     {
-        public static readonly NullFasterSession Instance = default;
+        public static readonly NullFasterSession Instance = new NullFasterSession();
 
         public void CheckpointCompletionCallback(string guid, CommitPoint commitPoint)
         {

--- a/cs/src/core/Index/Interfaces/NullFasterSession.cs
+++ b/cs/src/core/Index/Interfaces/NullFasterSession.cs
@@ -2,7 +2,7 @@
 {
     struct NullFasterSession : IFasterSession
     {
-        public static readonly NullFasterSession Instance;
+        public static readonly NullFasterSession Instance = default;
 
         public void CheckpointCompletionCallback(string guid, CommitPoint commitPoint)
         {

--- a/cs/src/core/Index/Recovery/IndexRecovery.cs
+++ b/cs/src/core/Index/Recovery/IndexRecovery.cs
@@ -69,7 +69,7 @@ namespace FASTER.core
         }
 
         //Main Index Recovery Functions
-        private CountdownEvent mainIndexRecoveryEvent;
+        protected CountdownEvent mainIndexRecoveryEvent;
 
         private void BeginMainIndexRecovery(
                                 int version,

--- a/cs/src/core/Index/Recovery/IndexRecovery.cs
+++ b/cs/src/core/Index/Recovery/IndexRecovery.cs
@@ -68,7 +68,9 @@ namespace FASTER.core
             return completed1 && completed2;
         }
 
-        //Main Index Recovery Functions
+        /// <summary>
+        /// Main Index Recovery Functions
+        /// </summary>
         protected CountdownEvent mainIndexRecoveryEvent;
 
         private void BeginMainIndexRecovery(
@@ -93,7 +95,7 @@ namespace FASTER.core
             for (int index = 0; index < numChunks; index++)
             {
                 long chunkStartBucket = (long)start + (index * chunkSize);
-                HashIndexPageAsyncReadResult result = default(HashIndexPageAsyncReadResult);
+                HashIndexPageAsyncReadResult result = default;
                 result.chunkIndex = index;
                 device.ReadAsync(numBytesRead, (IntPtr)chunkStartBucket, chunkSize, AsyncPageReadCallback, result);
                 numBytesRead += chunkSize;
@@ -124,7 +126,7 @@ namespace FASTER.core
 
         internal void DeleteTentativeEntries()
         {
-            HashBucketEntry entry = default(HashBucketEntry);
+            HashBucketEntry entry = default;
 
             int version = resizeInfo.version;
             var table_size_ = state[version].size;

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -172,7 +172,7 @@ namespace FASTER.core
 
             long fromAddress;
 
-            if (!recoveredICInfo.IsDefault() && hlog.FlushedUntilAddress != hlog.GetFirstValidLogicalAddress(0))
+            if (!recoveredICInfo.IsDefault() && mainIndexRecoveryEvent != null)
             {
                 Debug.WriteLine("Ignoring index checkpoint as we have already recovered index previously");
                 recoveredICInfo = default;
@@ -230,7 +230,10 @@ namespace FASTER.core
                 if (headAddress < recoveredHLCInfo.info.headAddress)
                     headAddress = recoveredHLCInfo.info.headAddress;
             }
-            
+
+            if (hlog.FlushedUntilAddress > scanFromAddress)
+                scanFromAddress = hlog.FlushedUntilAddress;
+
             // Make index consistent for version v
             if (recoveredHLCInfo.info.useSnapshotFile == 0)
             {

--- a/cs/test/AsyncLargeObjectTests.cs
+++ b/cs/test/AsyncLargeObjectTests.cs
@@ -21,7 +21,7 @@ namespace FASTER.test.async
         private FasterKV<MyKey, MyLargeValue> fht2;
         private IDevice log, objlog;
         private string test_path;
-        private MyLargeFunctions functions = new MyLargeFunctions();
+        private readonly MyLargeFunctions functions = new MyLargeFunctions();
 
         [SetUp]
         public void Setup()

--- a/cs/test/AsyncTests.cs
+++ b/cs/test/AsyncTests.cs
@@ -20,7 +20,7 @@ namespace FASTER.test.async
     {
         private FasterKV<AdId, NumClicks> fht1;
         private FasterKV<AdId, NumClicks> fht2;
-        private SimpleFunctions functions = new SimpleFunctions();
+        private readonly SimpleFunctions functions = new SimpleFunctions();
         private IDevice log;
 
 

--- a/cs/test/GenericDiskDeleteTests.cs
+++ b/cs/test/GenericDiskDeleteTests.cs
@@ -71,11 +71,7 @@ namespace FASTER.test
 
             for (int i = 0; i < totalRecords; i++)
             {
-                var input = new MyInput();
-                var output = new MyOutput();
                 var key1 = new MyKey { key = i };
-                var value = new MyValue { value = i };
-
                 session.Delete(ref key1, 0, 0);
             }
 
@@ -84,7 +80,6 @@ namespace FASTER.test
                 var input = new MyInput();
                 var output = new MyOutput();
                 var key1 = new MyKey { key = i };
-                var value = new MyValue { value = i };
 
                 var status = session.Read(ref key1, ref input, ref output, 1, 0);
                 

--- a/cs/test/RecoveryChecks.cs
+++ b/cs/test/RecoveryChecks.cs
@@ -1,0 +1,198 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using FASTER.core;
+using System.IO;
+using NUnit.Framework;
+using FASTER.test.recovery.sumstore;
+using System.Diagnostics;
+using System.Net;
+
+namespace FASTER.test.recovery
+{
+
+    [TestFixture]
+    public class RecoveryChecks
+    {
+        IDevice log;
+        FasterKV<long, long> fht1;
+        const int numOps = 5000;
+        AdId[] inputArray;
+        string path;
+
+        [SetUp]
+        public void Setup()
+        {
+            inputArray = new AdId[numOps];
+            for (int i = 0; i < numOps; i++)
+            {
+                inputArray[i].adId = i;
+            }
+
+            path = TestContext.CurrentContext.TestDirectory + "\\RecoveryChecks\\";
+            log = Devices.CreateLogDevice(path + "hlog.log", deleteOnClose: true);
+            Directory.CreateDirectory(path);
+            fht1 = new FasterKV<long, long>
+                (1L << 10,
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20 },
+                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                );
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            fht1.Dispose();
+            log.Dispose();
+            new DirectoryInfo(path).Delete(true);
+        }
+
+
+        [Test]
+        public void RecoveryCheck1([Values] CheckpointType checkpointType)
+        {
+            using var s1 = fht1.NewSession(new SimpleFunctions<long, long>());
+            for (long key = 0; key < 1000; key++)
+            {
+                s1.Upsert(ref key, ref key);
+            }
+            fht1.TakeHybridLogCheckpointAsync(checkpointType).GetAwaiter().GetResult();
+
+            using var fht2 = new FasterKV<long, long>
+                (1L << 10,
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20 },
+                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                );
+            fht2.Recover();
+
+            Assert.IsTrue(fht1.Log.HeadAddress == fht2.Log.HeadAddress);
+            Assert.IsTrue(fht1.Log.ReadOnlyAddress == fht2.Log.ReadOnlyAddress);
+            Assert.IsTrue(fht1.Log.TailAddress == fht2.Log.TailAddress);
+
+            using var s2 = fht2.NewSession(new SimpleFunctions<long, long>());
+            for (long key = 0; key < 1000; key++)
+            {
+                long output = default;
+                var status = s2.Read(ref key, ref output);
+                Assert.IsTrue(status == Status.OK && output == key);
+            }
+        }
+
+        [Test]
+        public void RecoveryCheck2([Values] CheckpointType checkpointType)
+        {
+            using var s1 = fht1.NewSession(new SimpleFunctions<long, long>());
+
+            using var fht2 = new FasterKV<long, long>
+                (1L << 10,
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20 },
+                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                );
+
+            for (int i = 0; i < 5; i++)
+            {
+                for (long key = 1000*i; key < 1000 * i + 1000; key++)
+                {
+                    s1.Upsert(ref key, ref key);
+                }
+                fht1.TakeHybridLogCheckpointAsync(checkpointType).GetAwaiter().GetResult();
+
+                fht2.Recover();
+
+                Assert.IsTrue(fht1.Log.HeadAddress == fht2.Log.HeadAddress);
+                Assert.IsTrue(fht1.Log.ReadOnlyAddress == fht2.Log.ReadOnlyAddress);
+                Assert.IsTrue(fht1.Log.TailAddress == fht2.Log.TailAddress);
+
+                using var s2 = fht2.NewSession(new SimpleFunctions<long, long>());
+                for (long key = 0; key < 1000 * i + 1000; key++)
+                {
+                    long output = default;
+                    var status = s2.Read(ref key, ref output);
+                    Assert.IsTrue(status == Status.OK && output == key);
+                }
+            }
+        }
+
+        [Test]
+        public void RecoveryCheck3([Values] CheckpointType checkpointType)
+        {
+            using var s1 = fht1.NewSession(new SimpleFunctions<long, long>());
+
+            using var fht2 = new FasterKV<long, long>
+                (1L << 10,
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20 },
+                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                );
+
+            for (int i = 0; i < 5; i++)
+            {
+                for (long key = 1000 * i; key < 1000 * i + 1000; key++)
+                {
+                    s1.Upsert(ref key, ref key);
+                }
+                fht1.TakeFullCheckpointAsync(checkpointType).GetAwaiter().GetResult();
+
+                fht2.Recover();
+
+                Assert.IsTrue(fht1.Log.HeadAddress == fht2.Log.HeadAddress);
+                Assert.IsTrue(fht1.Log.ReadOnlyAddress == fht2.Log.ReadOnlyAddress);
+                Assert.IsTrue(fht1.Log.TailAddress == fht2.Log.TailAddress);
+
+                using var s2 = fht2.NewSession(new SimpleFunctions<long, long>());
+                for (long key = 0; key < 1000 * i + 1000; key++)
+                {
+                    long output = default;
+                    var status = s2.Read(ref key, ref output);
+                    Assert.IsTrue(status == Status.OK && output == key);
+                }
+            }
+        }
+
+        [Test]
+        public void RecoveryCheck4([Values] CheckpointType checkpointType)
+        {
+            using var s1 = fht1.NewSession(new SimpleFunctions<long, long>());
+
+            using var fht2 = new FasterKV<long, long>
+                (1L << 10,
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20 },
+                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                );
+
+            for (int i = 0; i < 5; i++)
+            {
+                for (long key = 1000 * i; key < 1000 * i + 1000; key++)
+                {
+                    s1.Upsert(ref key, ref key);
+                }
+
+                if (i == 0)
+                    fht1.TakeIndexCheckpointAsync().GetAwaiter().GetResult();
+
+                fht1.TakeHybridLogCheckpointAsync(checkpointType).GetAwaiter().GetResult();
+
+                fht2.Recover();
+
+                Assert.IsTrue(fht1.Log.HeadAddress == fht2.Log.HeadAddress);
+                Assert.IsTrue(fht1.Log.ReadOnlyAddress == fht2.Log.ReadOnlyAddress);
+                Assert.IsTrue(fht1.Log.TailAddress == fht2.Log.TailAddress);
+
+                using var s2 = fht2.NewSession(new SimpleFunctions<long, long>());
+                for (long key = 0; key < 1000 * i + 1000; key++)
+                {
+                    long output = default;
+                    var status = s2.Read(ref key, ref output);
+                    Assert.IsTrue(status == Status.OK && output == key);
+                }
+            }
+        }
+
+
+    }
+}

--- a/cs/test/SessionFASTERTests.cs
+++ b/cs/test/SessionFASTERTests.cs
@@ -41,10 +41,83 @@ namespace FASTER.test.async
         [Test]
         public void SessionTest1()
         {
-            using (var session = fht.NewSession(new Functions()))
+            using var session = fht.NewSession(new Functions());
+            InputStruct input = default;
+            OutputStruct output = default;
+
+            var key1 = new KeyStruct { kfield1 = 13, kfield2 = 14 };
+            var value = new ValueStruct { vfield1 = 23, vfield2 = 24 };
+
+            session.Upsert(ref key1, ref value, Empty.Default, 0);
+            var status = session.Read(ref key1, ref input, ref output, Empty.Default, 0);
+
+            if (status == Status.PENDING)
             {
-                InputStruct input = default(InputStruct);
-                OutputStruct output = default(OutputStruct);
+                session.CompletePending(true);
+            }
+            else
+            {
+                Assert.IsTrue(status == Status.OK);
+            }
+
+            Assert.IsTrue(output.value.vfield1 == value.vfield1);
+            Assert.IsTrue(output.value.vfield2 == value.vfield2);
+        }
+
+
+        [Test]
+        public void SessionTest2()
+        {
+            using var session1 = fht.NewSession(new Functions());
+            using var session2 = fht.NewSession(new Functions());
+            InputStruct input = default;
+            OutputStruct output = default;
+
+            var key1 = new KeyStruct { kfield1 = 14, kfield2 = 15 };
+            var value1 = new ValueStruct { vfield1 = 24, vfield2 = 25 };
+            var key2 = new KeyStruct { kfield1 = 15, kfield2 = 16 };
+            var value2 = new ValueStruct { vfield1 = 25, vfield2 = 26 };
+
+            session1.Upsert(ref key1, ref value1, Empty.Default, 0);
+            session2.Upsert(ref key2, ref value2, Empty.Default, 0);
+
+            var status = session1.Read(ref key1, ref input, ref output, Empty.Default, 0);
+
+            if (status == Status.PENDING)
+            {
+                session1.CompletePending(true);
+            }
+            else
+            {
+                Assert.IsTrue(status == Status.OK);
+            }
+
+            Assert.IsTrue(output.value.vfield1 == value1.vfield1);
+            Assert.IsTrue(output.value.vfield2 == value1.vfield2);
+
+            status = session2.Read(ref key2, ref input, ref output, Empty.Default, 0);
+
+            if (status == Status.PENDING)
+            {
+                session2.CompletePending(true);
+            }
+            else
+            {
+                Assert.IsTrue(status == Status.OK);
+            }
+
+            Assert.IsTrue(output.value.vfield1 == value2.vfield1);
+            Assert.IsTrue(output.value.vfield2 == value2.vfield2);
+        }
+
+        [Test]
+        public void SessionTest3()
+        {
+            using var session = fht.NewSession(new Functions());
+            Task.CompletedTask.ContinueWith((t) =>
+            {
+                InputStruct input = default;
+                OutputStruct output = default;
 
                 var key1 = new KeyStruct { kfield1 = 13, kfield2 = 14 };
                 var value = new ValueStruct { vfield1 = 23, vfield2 = 24 };
@@ -63,27 +136,23 @@ namespace FASTER.test.async
 
                 Assert.IsTrue(output.value.vfield1 == value.vfield1);
                 Assert.IsTrue(output.value.vfield2 == value.vfield2);
-            }
+            }).Wait();
         }
 
-
         [Test]
-        public void SessionTest2()
+        public void SessionTest4()
         {
-            using (var session1 = fht.NewSession(new Functions()))
-            using (var session2 = fht.NewSession(new Functions()))
+            using var session1 = fht.NewSession(new Functions());
+            using var session2 = fht.NewSession(new Functions());
+            var t1 = Task.CompletedTask.ContinueWith((t) =>
             {
-                InputStruct input = default(InputStruct);
-                OutputStruct output = default(OutputStruct);
+                InputStruct input = default;
+                OutputStruct output = default;
 
                 var key1 = new KeyStruct { kfield1 = 14, kfield2 = 15 };
                 var value1 = new ValueStruct { vfield1 = 24, vfield2 = 25 };
-                var key2 = new KeyStruct { kfield1 = 15, kfield2 = 16 };
-                var value2 = new ValueStruct { vfield1 = 25, vfield2 = 26 };
 
                 session1.Upsert(ref key1, ref value1, Empty.Default, 0);
-                session2.Upsert(ref key2, ref value2, Empty.Default, 0);
-
                 var status = session1.Read(ref key1, ref input, ref output, Empty.Default, 0);
 
                 if (status == Status.PENDING)
@@ -97,8 +166,19 @@ namespace FASTER.test.async
 
                 Assert.IsTrue(output.value.vfield1 == value1.vfield1);
                 Assert.IsTrue(output.value.vfield2 == value1.vfield2);
+            });
 
-                status = session2.Read(ref key2, ref input, ref output, Empty.Default, 0);
+            var t2 = Task.CompletedTask.ContinueWith((t) =>
+            {
+                InputStruct input = default;
+                OutputStruct output = default;
+
+                var key2 = new KeyStruct { kfield1 = 15, kfield2 = 16 };
+                var value2 = new ValueStruct { vfield1 = 25, vfield2 = 26 };
+
+                session2.Upsert(ref key2, ref value2, Empty.Default, 0);
+
+                var status = session2.Read(ref key2, ref input, ref output, Empty.Default, 0);
 
                 if (status == Status.PENDING)
                 {
@@ -111,108 +191,19 @@ namespace FASTER.test.async
 
                 Assert.IsTrue(output.value.vfield1 == value2.vfield1);
                 Assert.IsTrue(output.value.vfield2 == value2.vfield2);
-            }
-        }
+            });
 
-        [Test]
-        public void SessionTest3()
-        {
-            using (var session = fht.NewSession(new Functions()))
-            {
-                Task.CompletedTask.ContinueWith((t) =>
-                {
-                    InputStruct input = default(InputStruct);
-                    OutputStruct output = default(OutputStruct);
-
-                    var key1 = new KeyStruct { kfield1 = 13, kfield2 = 14 };
-                    var value = new ValueStruct { vfield1 = 23, vfield2 = 24 };
-
-                    session.Upsert(ref key1, ref value, Empty.Default, 0);
-                    var status = session.Read(ref key1, ref input, ref output, Empty.Default, 0);
-
-                    if (status == Status.PENDING)
-                    {
-                        session.CompletePending(true);
-                    }
-                    else
-                    {
-                        Assert.IsTrue(status == Status.OK);
-                    }
-
-                    Assert.IsTrue(output.value.vfield1 == value.vfield1);
-                    Assert.IsTrue(output.value.vfield2 == value.vfield2);
-                }).Wait();
-            }
-        }
-
-        [Test]
-        public void SessionTest4()
-        {
-            using (var session1 = fht.NewSession(new Functions()))
-            using (var session2 = fht.NewSession(new Functions()))
-            {
-                var t1 = Task.CompletedTask.ContinueWith((t) =>
-                {
-                    InputStruct input = default(InputStruct);
-                    OutputStruct output = default(OutputStruct);
-
-                    var key1 = new KeyStruct { kfield1 = 14, kfield2 = 15 };
-                    var value1 = new ValueStruct { vfield1 = 24, vfield2 = 25 };
-
-                    session1.Upsert(ref key1, ref value1, Empty.Default, 0);
-                    var status = session1.Read(ref key1, ref input, ref output, Empty.Default, 0);
-
-                    if (status == Status.PENDING)
-                    {
-                        session1.CompletePending(true);
-                    }
-                    else
-                    {
-                        Assert.IsTrue(status == Status.OK);
-                    }
-
-                    Assert.IsTrue(output.value.vfield1 == value1.vfield1);
-                    Assert.IsTrue(output.value.vfield2 == value1.vfield2);
-                });
-
-                var t2 = Task.CompletedTask.ContinueWith((t) =>
-                {
-                    InputStruct input = default(InputStruct);
-                    OutputStruct output = default(OutputStruct);
-
-                    var key2 = new KeyStruct { kfield1 = 15, kfield2 = 16 };
-                    var value2 = new ValueStruct { vfield1 = 25, vfield2 = 26 };
-
-                    session2.Upsert(ref key2, ref value2, Empty.Default, 0);
-
-                    var status = session2.Read(ref key2, ref input, ref output, Empty.Default, 0);
-
-                    if (status == Status.PENDING)
-                    {
-                        session2.CompletePending(true);
-                    }
-                    else
-                    {
-                        Assert.IsTrue(status == Status.OK);
-                    }
-
-                    Assert.IsTrue(output.value.vfield1 == value2.vfield1);
-                    Assert.IsTrue(output.value.vfield2 == value2.vfield2);
-                });
-
-                t1.Wait();
-                t2.Wait();
-            }
+            t1.Wait();
+            t2.Wait();
         }
 
         [Test]
         public void SessionTest5()
         {
             var session = fht.NewSession(new Functions());
-            var id = session.ID;
 
-            InputStruct input = default(InputStruct);
-            OutputStruct output = default(OutputStruct);
+            InputStruct input = default;
+            OutputStruct output = default;
 
             var key1 = new KeyStruct { kfield1 = 16, kfield2 = 17 };
             var value1 = new ValueStruct { vfield1 = 26, vfield2 = 27 };


### PR DESCRIPTION
This PR significantly speeds up recovery (from checkpoint), which is important in several scenarios.

* Allow calling recover multple times with newer hlog checkpoints
* Fix bug in index fast-forward when using snapshot checkpoints with separate index checkpoints
* Recovery from snapshot leaves the log mutable after recovery
* Avoid rescanning the log during recovery - only single scan of the log is now needed
* Only write back pages that have records that need to be marked as Invalid
* Do not write back from snapshot file to main log during recovery as it should remain as mutable unpersisted state