### PR TITLE
[C#] Support FasterLog scan from different process

### DIFF
--- a/cs/samples/FasterLogPubSub/Program.cs
+++ b/cs/samples/FasterLogPubSub/Program.cs
@@ -12,7 +12,7 @@ namespace FasterLogPubSub
 {
     class Program
     {
-        const int commitPeriodMs = 5000;
+        const int commitPeriodMs = 2000;
         const int restorePeriodMs = 1000;
         static string path = Path.GetTempPath() + "FasterLogPubSub\\";
 
@@ -101,11 +101,11 @@ namespace FasterLogPubSub
             var device = Devices.CreateLogDevice(path + "mylog");
 
             // MemorySizeBits = 0 indicates 
-            var log = new FasterLog(new FasterLogSettings { LogDevice = device, MemorySizeBits = 0, PageSizeBits = 9, MutableFraction = 0.5, SegmentSizeBits = 9 });
+            var log = new FasterLog(new FasterLogSettings { LogDevice = device, ReadOnlyMode = true, PageSizeBits = 9, SegmentSizeBits = 9 });
             var recover = RecoverAsync(log, cancellationToken);
 
             // Required to use SingleBuffering for tailing
-            using var iter = log.Scan(log.BeginAddress, long.MaxValue, null, true, ScanBufferingMode.SinglePageBuffering);
+            using var iter = log.Scan(log.BeginAddress, long.MaxValue);
 
             await foreach (var (result, length, currentAddress, nextAddress) in iter.GetAsyncEnumerable(cancellationToken))
             {

--- a/cs/samples/FasterLogPubSub/Program.cs
+++ b/cs/samples/FasterLogPubSub/Program.cs
@@ -28,10 +28,10 @@ namespace FasterLogPubSub
             var commiter = CommitterAsync(log, cts.Token);
 
             // Consumer on SAME FasterLog instance
-            // var consumer = ConsumerAsync(log, true, cts.Token);
+            var consumer = ConsumerAsync(log, true, cts.Token);
 
-            // Consumer on SEPARATE read-only FasterLog instance
-            var consumer = SeparateConsumerAsync(cts.Token);
+            // Uncomment below to run consumer on SEPARATE read-only FasterLog instance
+            // var consumer = SeparateConsumerAsync(cts.Token);
             
             Console.CancelKeyPress += (o, eventArgs) =>
             {

--- a/cs/samples/FasterLogPubSub/Program.cs
+++ b/cs/samples/FasterLogPubSub/Program.cs
@@ -99,12 +99,9 @@ namespace FasterLogPubSub
         static async Task SeparateConsumerAsync(CancellationToken cancellationToken)
         {
             var device = Devices.CreateLogDevice(path + "mylog");
-
-            // MemorySizeBits = 0 indicates 
             var log = new FasterLog(new FasterLogSettings { LogDevice = device, ReadOnlyMode = true, PageSizeBits = 9, SegmentSizeBits = 9 });
-            var recover = RecoverAsync(log, cancellationToken);
+            var _ = RecoverAsync(log, cancellationToken);
 
-            // Required to use SingleBuffering for tailing
             using var iter = log.Scan(log.BeginAddress, long.MaxValue);
 
             await foreach (var (result, length, currentAddress, nextAddress) in iter.GetAsyncEnumerable(cancellationToken))

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -537,11 +537,6 @@ namespace FASTER.core
             if (SegmentSize < PageSize)
                 throw new FasterException("Segment must be at least of page size");
 
-            if (BufferSize < 1)
-            {
-                throw new FasterException("Log buffer must be of size at least 1 page");
-            }
-
             PageStatusIndicator = new FullPageStatus[BufferSize];
             PendingFlush = new PendingFlushList[BufferSize];
             for (int i = 0; i < BufferSize; i++)
@@ -562,15 +557,18 @@ namespace FASTER.core
 
             bufferPool = new SectorAlignedBufferPool(1, sectorSize);
 
-            long tailPage = firstValidAddress >> LogPageSizeBits;
-            int tailPageIndex = (int)(tailPage % BufferSize);
-            AllocatePage(tailPageIndex);
-
-            // Allocate next page as well
-            int nextPageIndex = (int)(tailPage + 1) % BufferSize;
-            if ((!IsAllocated(nextPageIndex)))
+            if (BufferSize > 0)
             {
-                AllocatePage(nextPageIndex);
+                long tailPage = firstValidAddress >> LogPageSizeBits;
+                int tailPageIndex = (int)(tailPage % BufferSize);
+                AllocatePage(tailPageIndex);
+
+                // Allocate next page as well
+                int nextPageIndex = (int)(tailPage + 1) % BufferSize;
+                if ((!IsAllocated(nextPageIndex)))
+                {
+                    AllocatePage(nextPageIndex);
+                }
             }
 
             if (PreallocateLog)

--- a/cs/src/core/Index/FasterLog/FasterLog.cs
+++ b/cs/src/core/Index/FasterLog/FasterLog.cs
@@ -135,7 +135,7 @@ namespace FASTER.core
             if (logSettings.ReadOnlyMode)
             {
                 readOnlyMode = true;
-                allocator.HeadAddress = int.MaxValue;
+                allocator.HeadAddress = long.MaxValue;
             }
 
             Restore(out RecoveredIterators);

--- a/cs/src/core/Index/FasterLog/FasterLogSettings.cs
+++ b/cs/src/core/Index/FasterLog/FasterLogSettings.cs
@@ -82,6 +82,11 @@ namespace FASTER.core
         /// </summary>
         public double MutableFraction = 0;
 
+        /// <summary>
+        /// Use FasterLog as read-only iterator/viewer of log being committed by another instance
+        /// </summary>
+        public bool ReadOnlyMode = false;
+
         internal LogSettings GetLogSettings()
         {
             return new LogSettings
@@ -89,7 +94,7 @@ namespace FASTER.core
                 LogDevice = LogDevice,
                 PageSizeBits = PageSizeBits,
                 SegmentSizeBits = SegmentSizeBits,
-                MemorySizeBits = MemorySizeBits,
+                MemorySizeBits = ReadOnlyMode ? 0 : MemorySizeBits,
                 CopyReadsToTail = false,
                 MutableFraction = MutableFraction,
                 ObjectLogDevice = null,


### PR DESCRIPTION
* Enables capability for a different process to consume (iterate or tailing scan) FasterLog in read-only mode
* With this, we can have one committing process and another consuming process for the log entries
* The way this is accomplished is by allowing the read-only iterating instance to continuously "recover" using the commits written out by the primary FasterLog writer
* When used with `AzureStorageDevice`, the enqueuing/committing process and the consuming process may be on different machines, and approximately emulates Kafka/EventHubs behavior.

Sample usage: [here](https://github.com/microsoft/FASTER/blob/fasterlog-separate-scan/cs/samples/FasterLogPubSub/Program.cs)

Inline sample:
```cs
static async Task SeparateConsumerAsync(CancellationToken cancellationToken)
{
    var device = Devices.CreateLogDevice(path + "mylog");
    var log = new FasterLog(new FasterLogSettings { LogDevice = device, ReadOnlyMode = true, PageSizeBits = 9, SegmentSizeBits = 9 });
    var _ = RecoverAsync(log, cancellationToken);

    using var iter = log.Scan(log.BeginAddress, long.MaxValue);

    await foreach (var (result, length, currentAddress, nextAddress) in iter.GetAsyncEnumerable(cancellationToken))
    {
        Console.WriteLine($"Consuming {Encoding.UTF8.GetString(result)}");
        iter.CompleteUntil(nextAddress);
    }
}

static async Task RecoverAsync(FasterLog log, CancellationToken cancellationToken)
{
    while (!cancellationToken.IsCancellationRequested)
    {
        await Task.Delay(TimeSpan.FromMilliseconds(restorePeriodMs), cancellationToken);

        Console.WriteLine("Restoring ...");

        log.RecoverReadOnly();
    }
}
```
Fix https://github.com/microsoft/FASTER/issues/332
