### PR TITLE
[C#] Sample for read-only secondary KV store continuously recovering to primary's log/checkpoints

### DIFF
--- a/cs/FASTER.sln
+++ b/cs/FASTER.sln
@@ -53,6 +53,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FasterLogPubSub", "samples\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureBackedStore", "samples\AzureBackedStore\AzureBackedStore.csproj", "{E2A1C205-4D35-448C-A72F-B9A4AE28EB4E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SecondaryReaderStore", "samples\SecondaryReaderStore\SecondaryReaderStore.csproj", "{EBE313E5-22D2-4C74-BA1F-16B60404B335}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -205,6 +207,14 @@ Global
 		{E2A1C205-4D35-448C-A72F-B9A4AE28EB4E}.Release|Any CPU.Build.0 = Release|x64
 		{E2A1C205-4D35-448C-A72F-B9A4AE28EB4E}.Release|x64.ActiveCfg = Release|x64
 		{E2A1C205-4D35-448C-A72F-B9A4AE28EB4E}.Release|x64.Build.0 = Release|x64
+		{EBE313E5-22D2-4C74-BA1F-16B60404B335}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{EBE313E5-22D2-4C74-BA1F-16B60404B335}.Debug|Any CPU.Build.0 = Debug|x64
+		{EBE313E5-22D2-4C74-BA1F-16B60404B335}.Debug|x64.ActiveCfg = Debug|x64
+		{EBE313E5-22D2-4C74-BA1F-16B60404B335}.Debug|x64.Build.0 = Debug|x64
+		{EBE313E5-22D2-4C74-BA1F-16B60404B335}.Release|Any CPU.ActiveCfg = Release|x64
+		{EBE313E5-22D2-4C74-BA1F-16B60404B335}.Release|Any CPU.Build.0 = Release|x64
+		{EBE313E5-22D2-4C74-BA1F-16B60404B335}.Release|x64.ActiveCfg = Release|x64
+		{EBE313E5-22D2-4C74-BA1F-16B60404B335}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -230,6 +240,7 @@ Global
 		{DACB12EB-8A64-4BB4-BFA3-0377AACD28D3} = {62BC1134-B6E1-476A-B894-7CA278A8B6DE}
 		{F6EA46D5-DD66-47F2-8FAC-370FDD733DD3} = {62BC1134-B6E1-476A-B894-7CA278A8B6DE}
 		{E2A1C205-4D35-448C-A72F-B9A4AE28EB4E} = {62BC1134-B6E1-476A-B894-7CA278A8B6DE}
+		{EBE313E5-22D2-4C74-BA1F-16B60404B335} = {62BC1134-B6E1-476A-B894-7CA278A8B6DE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A0750637-2CCB-4139-B25E-F2CE740DCFAC}

--- a/cs/samples/SecondaryReaderStore/Program.cs
+++ b/cs/samples/SecondaryReaderStore/Program.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using FASTER.core;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+
+namespace SecondaryReaderStore
+{
+    class Program
+    {
+        static FasterKV<long, long> primaryStore;
+        static FasterKV<long, long> secondaryStore;
+        const int numOps = 3000;
+        const int checkpointFreq = 500;
+
+        static void Main()
+        {
+            // Create files for storing data
+            var path = Path.GetTempPath() + "SecondaryReaderStore\\";
+            if (Directory.Exists(path))
+                new DirectoryInfo(path).Delete(true);
+
+            var log = Devices.CreateLogDevice(path + "hlog.log", deleteOnClose: true);
+
+            primaryStore = new FasterKV<long, long>
+                (1L << 10,
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20 },
+                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                );
+
+            secondaryStore = new FasterKV<long, long>
+                (1L << 10,
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20 },
+                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                );
+
+            var p = new Thread(new ThreadStart(PrimaryWriter));
+            var s = new Thread(new ThreadStart(SecondaryReader));
+
+            p.Start(); s.Start();
+            p.Join(); s.Join();
+
+            log.Dispose();
+            new DirectoryInfo(path).Delete(true);
+        }
+
+        static void PrimaryWriter()
+        {
+            using var s1 = primaryStore.NewSession(new SimpleFunctions<long, long>());
+
+            Console.WriteLine($"Upserting keys at primary starting from key 0");
+            for (long key=0; key<numOps; key++)
+            {
+                if (key > 0 && key % checkpointFreq == 0)
+                {
+                    Console.WriteLine($"Checkpointing primary until key {key - 1}");
+                    primaryStore.TakeHybridLogCheckpointAsync(CheckpointType.Snapshot).GetAwaiter().GetResult();
+                    Console.WriteLine($"Upserting keys at primary starting from {key}");
+                }
+
+                Thread.Sleep(10);
+                s1.Upsert(ref key, ref key);
+
+            }
+            Console.WriteLine($"Checkpointing primary until key {numOps - 1}");
+            primaryStore.TakeHybridLogCheckpointAsync(CheckpointType.Snapshot).GetAwaiter().GetResult();
+            Console.WriteLine("Shutting down primary");
+        }
+
+        static void SecondaryReader()
+        {
+            using var s1 = secondaryStore.NewSession(new SimpleFunctions<long, long>());
+
+            long key = 0, output = 0;
+            while (true)
+            {
+                try
+                {
+                    secondaryStore.Recover(undoFutureVersions: false); // read-only recovery, no writing back undos
+                }
+                catch
+                {
+                    Console.WriteLine("Nothing to recover to at secondary, retrying");
+                    Thread.Sleep(500);
+                    continue;
+                }
+
+                while (true)
+                {
+                    var status = s1.Read(ref key, ref output);
+                    if (status == Status.NOTFOUND)
+                    {
+                        Console.WriteLine($"Key {key} not found at secondary; performing recovery to catch up");
+                        Thread.Sleep(500);
+                        break;
+                    }
+                    if (key != output)
+                        throw new Exception($"Invalid value {output} found for key {key} at secondary");
+
+                    Console.WriteLine($"Successfully read key {key}, value {output} at secondary");
+                    key++;
+                    if (key == numOps)
+                    {
+                        Console.WriteLine("Shutting down secondary");
+                        return;
+                    }
+                }
+            }
+
+        }
+
+    }
+}

--- a/cs/samples/SecondaryReaderStore/SecondaryReaderStore.csproj
+++ b/cs/samples/SecondaryReaderStore/SecondaryReaderStore.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Platforms>x64</Platforms>
+    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\core\FASTER.core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -262,7 +262,7 @@ namespace FASTER.core
         /// <param name="callback"></param>
         /// <param name="context"></param>
         /// <param name="result"></param>
-        protected override void AsyncReadRecordObjectsToMemory(long fromLogical, int numBytes, DeviceIOCompletionCallback callback, AsyncIOContext<Key, Value> context, SectorAlignedMemory result = default(SectorAlignedMemory))
+        protected override void AsyncReadRecordObjectsToMemory(long fromLogical, int numBytes, DeviceIOCompletionCallback callback, AsyncIOContext<Key, Value> context, SectorAlignedMemory result = default)
         {
             throw new InvalidOperationException("AsyncReadRecordObjectsToMemory invalid for BlittableAllocator");
         }

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -379,10 +379,11 @@ namespace FASTER.core
         /// <summary>
         /// Recover from the latest checkpoint (blocking operation)
         /// </summary>
-        /// <param name="numPagesToPreload"></param>
-        public void Recover(int numPagesToPreload = -1)
+        /// <param name="numPagesToPreload">Number of pages to preload into memory (beyond what needs to be read for recovery)</param>
+        /// <param name="undoFutureVersions">Whether records with versions beyond checkpoint version need to be undone (and invalidated on log)</param>
+        public void Recover(int numPagesToPreload = -1, bool undoFutureVersions = true)
         {
-            InternalRecoverFromLatestCheckpoints(numPagesToPreload);
+            InternalRecoverFromLatestCheckpoints(numPagesToPreload, undoFutureVersions);
         }
 
         /// <summary>
@@ -390,9 +391,10 @@ namespace FASTER.core
         /// </summary>
         /// <param name="fullCheckpointToken">Token</param>
         /// <param name="numPagesToPreload">Number of pages to preload into memory after recovery</param>
-        public void Recover(Guid fullCheckpointToken, int numPagesToPreload = -1)
+        /// <param name="undoFutureVersions">Whether records with versions beyond checkpoint version need to be undone (and invalidated on log)</param>
+        public void Recover(Guid fullCheckpointToken, int numPagesToPreload = -1, bool undoFutureVersions = true)
         {
-            InternalRecover(fullCheckpointToken, fullCheckpointToken, numPagesToPreload);
+            InternalRecover(fullCheckpointToken, fullCheckpointToken, numPagesToPreload, undoFutureVersions);
         }
 
         /// <summary>
@@ -401,9 +403,10 @@ namespace FASTER.core
         /// <param name="indexCheckpointToken"></param>
         /// <param name="hybridLogCheckpointToken"></param>
         /// <param name="numPagesToPreload">Number of pages to preload into memory after recovery</param>
-        public void Recover(Guid indexCheckpointToken, Guid hybridLogCheckpointToken, int numPagesToPreload = -1)
+        /// <param name="undoFutureVersions">Whether records with versions beyond checkpoint version need to be undone (and invalidated on log)</param>
+        public void Recover(Guid indexCheckpointToken, Guid hybridLogCheckpointToken, int numPagesToPreload = -1, bool undoFutureVersions = true)
         {
-            InternalRecover(indexCheckpointToken, hybridLogCheckpointToken, numPagesToPreload);
+            InternalRecover(indexCheckpointToken, hybridLogCheckpointToken, numPagesToPreload, undoFutureVersions);
         }
 
         /// <summary>

--- a/cs/src/core/Index/Interfaces/IFasterKV.cs
+++ b/cs/src/core/Index/Interfaces/IFasterKV.cs
@@ -73,14 +73,16 @@ namespace FASTER.core
         /// Recover from last successful index and log checkpoint
         /// </summary>
         /// <param name="numPagesToPreload">Number of pages to preload into memory after recovery</param>
-        void Recover(int numPagesToPreload = -1);
+        /// <param name="undoFutureVersions">Whether records with versions beyond checkpoint version need to be undone (and invalidated on log)</param>
+        void Recover(int numPagesToPreload = -1, bool undoFutureVersions = true);
 
         /// <summary>
         /// Recover using full checkpoint token
         /// </summary>
         /// <param name="fullcheckpointToken"></param>
         /// <param name="numPagesToPreload">Number of pages to preload into memory after recovery</param>
-        void Recover(Guid fullcheckpointToken, int numPagesToPreload = -1);
+        /// <param name="undoFutureVersions">Whether records with versions beyond checkpoint version need to be undone (and invalidated on log)</param>
+        void Recover(Guid fullcheckpointToken, int numPagesToPreload = -1, bool undoFutureVersions = true);
 
         /// <summary>
         /// Recover using a separate index and log checkpoint token
@@ -88,7 +90,8 @@ namespace FASTER.core
         /// <param name="indexToken"></param>
         /// <param name="hybridLogToken"></param>
         /// <param name="numPagesToPreload">Number of pages to preload into memory after recovery</param>
-        void Recover(Guid indexToken, Guid hybridLogToken, int numPagesToPreload = -1);
+        /// <param name="undoFutureVersions">Whether records with versions beyond checkpoint version need to be undone (and invalidated on log)</param>
+        void Recover(Guid indexToken, Guid hybridLogToken, int numPagesToPreload = -1, bool undoFutureVersions = true);
 
         /// <summary>
         /// Complete ongoing checkpoint (spin-wait)


### PR DESCRIPTION
* Sample to show read-only secondary reader store constantly catching up to primary store
* Add recovery option to recover without writing undo (useful for read-only secondaries)