### PR TITLE
[C#] Async version of RMW that returns status

### DIFF
--- a/cs/samples/StoreAsyncApi/Program.cs
+++ b/cs/samples/StoreAsyncApi/Program.cs
@@ -82,7 +82,7 @@ namespace StoreAsyncApi
 
                         var key = new CacheKey(rand.Next());
                         var value = new CacheValue(rand.Next());
-                        await session.UpsertAsync(ref key, ref value, context);
+                        session.Upsert(ref key, ref value, context);
                         await session.WaitForCommitAsync();
 
                         Interlocked.Increment(ref numOps);
@@ -104,7 +104,7 @@ namespace StoreAsyncApi
 
                     var key = new CacheKey(rand.Next());
                     var value = new CacheValue(rand.Next());
-                    await session.UpsertAsync(ref key, ref value, context);
+                    session.Upsert(ref key, ref value, context);
 
                     if (count++ % 100 == 0)
                     {

--- a/cs/samples/StoreAsyncApi/Program.cs
+++ b/cs/samples/StoreAsyncApi/Program.cs
@@ -82,7 +82,8 @@ namespace StoreAsyncApi
 
                         var key = new CacheKey(rand.Next());
                         var value = new CacheValue(rand.Next());
-                        await session.UpsertAsync(ref key, ref value, context, true);
+                        await session.UpsertAsync(ref key, ref value, context);
+                        await session.WaitForCommitAsync();
 
                         Interlocked.Increment(ref numOps);
                     }

--- a/cs/samples/StoreDiskReadBenchmark/Program.cs
+++ b/cs/samples/StoreDiskReadBenchmark/Program.cs
@@ -88,10 +88,7 @@ namespace StoreDiskReadBenchmark
                 {
                     key = new Key(i);
                     value = new Value(i);
-                    if (useAsync)
-                        await session.UpsertAsync(ref key, ref value);
-                    else
-                        session.Upsert(ref key, ref value, Empty.Default, 0);
+                    session.Upsert(ref key, ref value, Empty.Default, 0);
                     Interlocked.Increment(ref numOps);
 
                     if (periodicCommit && i % 100 == 0)
@@ -135,7 +132,7 @@ namespace StoreDiskReadBenchmark
                         }
                         else
                         {
-                            var result = (await session.ReadAsync(ref key, ref input)).CompleteRead();
+                            var result = (await session.ReadAsync(ref key, ref input)).Complete();
                             if (result.Item1 != Status.OK || result.Item2.value.vfield1 != key.key)
                             {
                                 throw new Exception("Wrong value found");
@@ -178,7 +175,7 @@ namespace StoreDiskReadBenchmark
                         {
                             for (int j = 0; j < readBatchSize; j++)
                             {
-                                var result = (await tasks[j].Item2).CompleteRead();
+                                var result = (await tasks[j].Item2).Complete();
                                 if (result.Item1 != Status.OK || result.Item2.value.vfield1 != tasks[j].Item1)
                                 {
                                     throw new Exception($"Wrong value found. Found: {result.Item2.value.vfield1}, Expected: {tasks[j].Item1}");

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -197,23 +197,6 @@ namespace FASTER.core
         }
 
         /// <summary>
-        /// Async upsert operation, data remains uncommitted.
-        /// To ensure commit of upserted value, complete the upsert and then call WaitForCommitAsync.
-        /// UpsertAsync never actually goes async, but may do so in future.
-        /// </summary>
-        /// <param name="key"></param>
-        /// <param name="desiredValue"></param>
-        /// <param name="context"></param>
-        /// <param name="serialNo"></param>
-        /// <param name="token"></param>
-        /// <returns>ValueTask of operation status</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ValueTask<Status> UpsertAsync(ref Key key, ref Value desiredValue, Context context = default, long serialNo = 0, CancellationToken token = default)
-        {
-            return fht.UpsertAsync(this, ref key, ref desiredValue, context, serialNo, token);
-        }
-
-        /// <summary>
         /// RMW operation
         /// </summary>
         /// <param name="key"></param>
@@ -270,30 +253,6 @@ namespace FASTER.core
             {
                 if (SupportAsync) UnsafeSuspendThread();
             }
-        }
-
-        /// <summary>
-        /// Async delete operation
-        /// </summary>
-        /// <param name="key"></param>
-        /// <param name="context"></param>
-        /// <param name="serialNo"></param>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ValueTask DeleteAsync(ref Key key, Context context = default, long serialNo = 0, CancellationToken token = default)
-        {
-            var status = Delete(ref key, context, serialNo);
-
-            if (status == Status.OK)
-                return default;
-
-            return SlowDeleteAsync(this, token);
-        }
-
-        private static async ValueTask SlowDeleteAsync(ClientSession<Key, Value, Input, Output, Context, Functions> @this, CancellationToken token)
-        {
-            await @this.CompletePendingAsync(false, token);
         }
 
         /// <summary>

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -140,7 +140,7 @@ namespace FASTER.core
         /// <param name="input"></param>
         /// <param name="context"></param>
         /// <param name="token"></param>
-        /// <returns>ReadAsyncResult - call CompleteRead on the return value to complete the read operation</returns>
+        /// <returns>ReadAsyncResult - call Complete() on the return value to complete the read operation</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ValueTask<FasterKV<Key, Value>.ReadAsyncResult<Input, Output, Context, Functions>> ReadAsync(ref Key key, ref Input input, Context context = default, CancellationToken token = default)
         {
@@ -180,7 +180,7 @@ namespace FASTER.core
         /// <param name="token"></param>
         /// <returns>ValueTask of operation status</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ValueTask<Status> UpsertAsync(ref Key key, ref Value desiredValue, Context context = default, CancellationToken token = default)
+        internal ValueTask<Status> UpsertAsync(ref Key key, ref Value desiredValue, Context context = default, CancellationToken token = default)
         {
             return fht.UpsertAsync(this, ref key, ref desiredValue, context, ctx.serialNum + 1, token);
         }
@@ -235,7 +235,7 @@ namespace FASTER.core
         /// <param name="input"></param>
         /// <param name="context"></param>
         /// <param name="token"></param>
-        /// <returns>ValueTask for RMW result, user needs to await and then call CompleteRMWAsync on the result</returns>
+        /// <returns>ValueTask for RMW result, user needs to await and then call Complete() on the result</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ValueTask<FasterKV<Key, Value>.RmwAsyncResult<Input, Output, Context, Functions>> RMWAsync(ref Key key, ref Input input, Context context = default, CancellationToken token = default)
         {
@@ -512,12 +512,12 @@ namespace FASTER.core
             /// Complete the read operation, after any I/O is completed.
             /// </summary>
             /// <returns>The read result, or throws an exception if error encountered.</returns>
-            public (Status, Output) CompleteRead()
+            public (Status, Output) Complete()
             {
                 if (status != Status.PENDING)
                     return (status, output);
 
-                return readAsyncInternal.CompleteRead();
+                return readAsyncInternal.Complete();
             }
         }
 

--- a/cs/src/core/ClientSession/FASTERAsync.cs
+++ b/cs/src/core/ClientSession/FASTERAsync.cs
@@ -230,6 +230,7 @@ namespace FASTER.core
             }
             finally
             {
+                Debug.Assert(serialNo >= clientSession.ctx.serialNum, "Operation serial numbers must be non-decreasing");
                 clientSession.ctx.serialNum = serialNo;
                 if (clientSession.SupportAsync) clientSession.UnsafeSuspendThread();
             }
@@ -429,6 +430,7 @@ namespace FASTER.core
             }
             finally
             {
+                Debug.Assert(serialNo >= clientSession.ctx.serialNum, "Operation serial numbers must be non-decreasing");
                 clientSession.ctx.serialNum = serialNo;
                 if (clientSession.SupportAsync) clientSession.UnsafeSuspendThread();
             }
@@ -497,6 +499,7 @@ namespace FASTER.core
             }
             finally
             {
+                Debug.Assert(serialNo >= clientSession.ctx.serialNum, "Operation serial numbers must be non-decreasing");
                 clientSession.ctx.serialNum = serialNo;
                 if (clientSession.SupportAsync) clientSession.UnsafeSuspendThread();
             }

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -461,6 +461,7 @@ namespace FASTER.core
                 status = HandleOperationStatus(sessionCtx, sessionCtx, ref pcontext, fasterSession, internalStatus, false, out _);
             }
 
+            Debug.Assert(serialNo >= sessionCtx.serialNum, "Operation serial numbers must be non-decreasing");
             sessionCtx.serialNum = serialNo;
             return status;
         }
@@ -488,6 +489,7 @@ namespace FASTER.core
                 status = HandleOperationStatus(sessionCtx, sessionCtx, ref pcontext, fasterSession, internalStatus, false, out _);
             }
 
+            Debug.Assert(serialNo >= sessionCtx.serialNum, "Operation serial numbers must be non-decreasing");
             sessionCtx.serialNum = serialNo;
             return status;
         }
@@ -514,6 +516,7 @@ namespace FASTER.core
                 status = HandleOperationStatus(sessionCtx, sessionCtx, ref pcontext, fasterSession, internalStatus, false, out _);
             }
 
+            Debug.Assert(serialNo >= sessionCtx.serialNum, "Operation serial numbers must be non-decreasing");
             sessionCtx.serialNum = serialNo;
             return status;
         }
@@ -544,6 +547,7 @@ namespace FASTER.core
                 status = HandleOperationStatus(sessionCtx, sessionCtx, ref pcontext, fasterSession, internalStatus, false, out _);
             }
 
+            Debug.Assert(serialNo >= sessionCtx.serialNum, "Operation serial numbers must be non-decreasing");
             sessionCtx.serialNum = serialNo;
             return status;
         }

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -458,7 +458,7 @@ namespace FASTER.core
             }
             else
             {
-                status = HandleOperationStatus(sessionCtx, sessionCtx, pcontext, fasterSession, internalStatus);
+                status = HandleOperationStatus(sessionCtx, sessionCtx, ref pcontext, fasterSession, internalStatus, false, out _);
             }
 
             sessionCtx.serialNum = serialNo;
@@ -485,7 +485,7 @@ namespace FASTER.core
             }
             else
             {
-                status = HandleOperationStatus(sessionCtx, sessionCtx, pcontext, fasterSession, internalStatus);
+                status = HandleOperationStatus(sessionCtx, sessionCtx, ref pcontext, fasterSession, internalStatus, false, out _);
             }
 
             sessionCtx.serialNum = serialNo;
@@ -511,7 +511,7 @@ namespace FASTER.core
             }
             else
             {
-                status = HandleOperationStatus(sessionCtx, sessionCtx, pcontext, fasterSession, internalStatus);
+                status = HandleOperationStatus(sessionCtx, sessionCtx, ref pcontext, fasterSession, internalStatus, false, out _);
             }
 
             sessionCtx.serialNum = serialNo;
@@ -541,7 +541,7 @@ namespace FASTER.core
             }
             else
             {
-                status = HandleOperationStatus(sessionCtx, sessionCtx, pcontext, fasterSession, internalStatus);
+                status = HandleOperationStatus(sessionCtx, sessionCtx, ref pcontext, fasterSession, internalStatus, false, out _);
             }
 
             sessionCtx.serialNum = serialNo;

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -1501,7 +1501,7 @@ namespace FASTER.core
                 SynchronizeEpoch(opCtx, currentCtx, ref pendingContext, fasterSession);
             }
 
-            if (status == OperationStatus.CPR_SHIFT_DETECTED || (asyncOp && status == OperationStatus.RETRY_LATER))
+            if (status == OperationStatus.CPR_SHIFT_DETECTED || ((asyncOp || RelaxedCPR) && status == OperationStatus.RETRY_LATER))
             {
                 #region Retry as (v+1) Operation
                 var internalStatus = default(OperationStatus);
@@ -1535,7 +1535,9 @@ namespace FASTER.core
                             break;
                     }
                     Debug.Assert(internalStatus != OperationStatus.CPR_SHIFT_DETECTED);
-                } while (internalStatus == OperationStatus.RETRY_NOW || (asyncOp && internalStatus == OperationStatus.RETRY_LATER));
+                } while (internalStatus == OperationStatus.RETRY_NOW || ((asyncOp || RelaxedCPR) && internalStatus == OperationStatus.RETRY_LATER));
+                // Note that we spin in case of { async op + strict CPR } which is fine as this combination is rare/discouraged
+
                 status = internalStatus;
                 #endregion
             }

--- a/cs/src/core/Index/Interfaces/ICompactionFunctions.cs
+++ b/cs/src/core/Index/Interfaces/ICompactionFunctions.cs
@@ -10,7 +10,6 @@
         /// <summary>
         /// Checks if record in the faster log is logically deleted.
         /// If the record was deleted via <see cref="ClientSession{Key, Value, Input, Output, Context, Functions}.Delete(ref Key, Context, long)"/>
-        /// or <see cref="ClientSession{Key, Value, Input, Output, Context, Functions}.DeleteAsync(ref Key, Context, bool, System.Threading.CancellationToken)"/> 
         /// then this function is not called for such a record.
         /// </summary>
         /// <remarks>

--- a/cs/test/AsyncTests.cs
+++ b/cs/test/AsyncTests.cs
@@ -94,7 +94,7 @@ namespace FASTER.test.async
 
                 for (int key = 0; key < numOps; key++)
                 {
-                    var status = s3.Read(ref inputArray[key], ref inputArg, ref output, Empty.Default, s3.NextSerialNo);
+                    var status = s3.Read(ref inputArray[key], ref inputArg, ref output, Empty.Default, s3.SerialNo);
 
                     if (status == Status.PENDING)
                         s3.CompletePending(true);

--- a/cs/test/AsyncTests.cs
+++ b/cs/test/AsyncTests.cs
@@ -94,7 +94,7 @@ namespace FASTER.test.async
 
                 for (int key = 0; key < numOps; key++)
                 {
-                    var status = s3.Read(ref inputArray[key], ref inputArg, ref output, Empty.Default, 0);
+                    var status = s3.Read(ref inputArray[key], ref inputArg, ref output, Empty.Default, s3.NextSerialNo);
 
                     if (status == Status.PENDING)
                         s3.CompletePending(true);

--- a/cs/test/BlittableIterationTests.cs
+++ b/cs/test/BlittableIterationTests.cs
@@ -67,7 +67,7 @@ namespace FASTER.test
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
                 var value = new ValueStruct { vfield1 = 2 * i, vfield2 = i + 1 };
-                session.Upsert(ref key1, ref value, 0, 1);
+                session.Upsert(ref key1, ref value, 0);
             }
 
             count = 0;
@@ -81,12 +81,11 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords);
 
-            var serialNo = session.NextSerialNo;
             for (int i = totalRecords/2; i < totalRecords; i++)
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
                 var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
-                session.Upsert(ref key1, ref value, 0, serialNo);
+                session.Upsert(ref key1, ref value, 0);
             }
 
             count = 0;
@@ -99,12 +98,11 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords);
 
-            serialNo = session.NextSerialNo;
             for (int i = 0; i < totalRecords; i+=2)
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
                 var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
-                session.Upsert(ref key1, ref value, 0, serialNo);
+                session.Upsert(ref key1, ref value, 0);
             }
 
             count = 0;
@@ -117,12 +115,11 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords);
 
-            serialNo = session.NextSerialNo;
             for (int i = 0; i < totalRecords; i += 2)
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
                 var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
-                session.Delete(ref key1, 0, serialNo);
+                session.Delete(ref key1, 0);
             }
 
             count = 0;
@@ -135,12 +132,11 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords / 2);
 
-            serialNo = session.NextSerialNo;
             for (int i = 0; i < totalRecords; i++)
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
                 var value = new ValueStruct { vfield1 = 3 * i, vfield2 = i + 1 };
-                session.Upsert(ref key1, ref value, 0, serialNo);
+                session.Upsert(ref key1, ref value, 0);
             }
 
             count = 0;

--- a/cs/test/BlittableIterationTests.cs
+++ b/cs/test/BlittableIterationTests.cs
@@ -81,12 +81,12 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords);
 
-
+            var serialNo = session.NextSerialNo;
             for (int i = totalRecords/2; i < totalRecords; i++)
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
                 var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
-                session.Upsert(ref key1, ref value, 0, 0);
+                session.Upsert(ref key1, ref value, 0, serialNo);
             }
 
             count = 0;
@@ -99,11 +99,12 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords);
 
+            serialNo = session.NextSerialNo;
             for (int i = 0; i < totalRecords; i+=2)
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
                 var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
-                session.Upsert(ref key1, ref value, 0, 0);
+                session.Upsert(ref key1, ref value, 0, serialNo);
             }
 
             count = 0;
@@ -116,11 +117,12 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords);
 
+            serialNo = session.NextSerialNo;
             for (int i = 0; i < totalRecords; i += 2)
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
                 var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
-                session.Delete(ref key1, 0, 0);
+                session.Delete(ref key1, 0, serialNo);
             }
 
             count = 0;
@@ -133,12 +135,12 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords / 2);
 
-
+            serialNo = session.NextSerialNo;
             for (int i = 0; i < totalRecords; i++)
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
                 var value = new ValueStruct { vfield1 = 3 * i, vfield2 = i + 1 };
-                session.Upsert(ref key1, ref value, 0, 1);
+                session.Upsert(ref key1, ref value, 0, serialNo);
             }
 
             count = 0;

--- a/cs/test/FunctionPerSessionTests.cs
+++ b/cs/test/FunctionPerSessionTests.cs
@@ -137,20 +137,20 @@ namespace FASTER.test
                 var key = 101;
                 var input = 1000L;
 
-                (await adderSession.RMWAsync(ref key, ref input)).CompleteRMW();
-                (await adderSession.RMWAsync(ref key, ref input)).CompleteRMW();
-                (await adderSession.RMWAsync(ref key, ref input)).CompleteRMW();
+                (await adderSession.RMWAsync(ref key, ref input)).Complete();
+                (await adderSession.RMWAsync(ref key, ref input)).Complete();
+                (await adderSession.RMWAsync(ref key, ref input)).Complete();
 
                 Assert.AreEqual(1, _adder.InitialCount);
                 Assert.AreEqual(2, _adder.InPlaceCount);
 
                 var empty = default(Empty);
-                (await removerSession.RMWAsync(ref key, ref empty)).CompleteRMW();
+                (await removerSession.RMWAsync(ref key, ref empty)).Complete();
 
                 Assert.AreEqual(1, _remover.InPlaceCount);
 
                 var read = await readerSession.ReadAsync(ref key, ref empty);
-                var result = read.CompleteRead();
+                var result = read.Complete();
 
                 var actual = result.Item2;
                 Assert.AreEqual(2, actual.ReferenceCount);
@@ -158,9 +158,9 @@ namespace FASTER.test
 
                 _faster.Log.FlushAndEvict(true);
 
-                (await removerSession.RMWAsync(ref key, ref empty)).CompleteRMW();
+                (await removerSession.RMWAsync(ref key, ref empty)).Complete();
                 read = await readerSession.ReadAsync(ref key, ref empty);
-                result = read.CompleteRead();
+                result = read.Complete();
 
                 actual = result.Item2;
                 Assert.AreEqual(1, actual.ReferenceCount);

--- a/cs/test/FunctionPerSessionTests.cs
+++ b/cs/test/FunctionPerSessionTests.cs
@@ -137,15 +137,15 @@ namespace FASTER.test
                 var key = 101;
                 var input = 1000L;
 
-                await adderSession.RMWAsync(ref key, ref input);
-                await adderSession.RMWAsync(ref key, ref input);
-                await adderSession.RMWAsync(ref key, ref input);
+                (await adderSession.RMWAsync(ref key, ref input)).CompleteRMW();
+                (await adderSession.RMWAsync(ref key, ref input)).CompleteRMW();
+                (await adderSession.RMWAsync(ref key, ref input)).CompleteRMW();
 
                 Assert.AreEqual(1, _adder.InitialCount);
                 Assert.AreEqual(2, _adder.InPlaceCount);
 
                 var empty = default(Empty);
-                await removerSession.RMWAsync(ref key, ref empty);
+                (await removerSession.RMWAsync(ref key, ref empty)).CompleteRMW();
 
                 Assert.AreEqual(1, _remover.InPlaceCount);
 
@@ -158,7 +158,7 @@ namespace FASTER.test
 
                 _faster.Log.FlushAndEvict(true);
 
-                await removerSession.RMWAsync(ref key, ref empty);
+                (await removerSession.RMWAsync(ref key, ref empty)).CompleteRMW();
                 read = await readerSession.ReadAsync(ref key, ref empty);
                 result = read.CompleteRead();
 

--- a/cs/test/GenericIterationTests.cs
+++ b/cs/test/GenericIterationTests.cs
@@ -58,7 +58,7 @@ namespace FASTER.test
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = i };
-                session.Upsert(ref key1, ref value, 0, 0);
+                session.Upsert(ref key1, ref value, 0);
             }
 
             int count = 0;
@@ -77,7 +77,7 @@ namespace FASTER.test
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = 2 * i };
-                session.Upsert(ref key1, ref value, 0, 1);
+                session.Upsert(ref key1, ref value, 0);
             }
 
             count = 0;
@@ -91,12 +91,11 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords);
 
-            var serialNo = session.NextSerialNo;
             for (int i = totalRecords / 2; i < totalRecords; i++)
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = i };
-                session.Upsert(ref key1, ref value, 0, serialNo);
+                session.Upsert(ref key1, ref value, 0);
             }
 
             count = 0;
@@ -109,12 +108,11 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords);
 
-            serialNo = session.NextSerialNo;
             for (int i = 0; i < totalRecords; i += 2)
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = i };
-                session.Upsert(ref key1, ref value, 0, serialNo);
+                session.Upsert(ref key1, ref value, 0);
             }
 
             count = 0;
@@ -127,12 +125,11 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords);
 
-            serialNo = session.NextSerialNo;
             for (int i = 0; i < totalRecords; i += 2)
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = i };
-                session.Delete(ref key1, 0, serialNo);
+                session.Delete(ref key1, 0);
             }
 
             count = 0;
@@ -145,12 +142,11 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords / 2);
 
-            serialNo = session.NextSerialNo;
             for (int i = 0; i < totalRecords; i++)
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = 3 * i };
-                session.Upsert(ref key1, ref value, 0, serialNo);
+                session.Upsert(ref key1, ref value, 0);
             }
 
             count = 0;

--- a/cs/test/GenericIterationTests.cs
+++ b/cs/test/GenericIterationTests.cs
@@ -91,12 +91,12 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords);
 
-
+            var serialNo = session.NextSerialNo;
             for (int i = totalRecords / 2; i < totalRecords; i++)
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = i };
-                session.Upsert(ref key1, ref value, 0, 0);
+                session.Upsert(ref key1, ref value, 0, serialNo);
             }
 
             count = 0;
@@ -109,11 +109,12 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords);
 
+            serialNo = session.NextSerialNo;
             for (int i = 0; i < totalRecords; i += 2)
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = i };
-                session.Upsert(ref key1, ref value, 0, 0);
+                session.Upsert(ref key1, ref value, 0, serialNo);
             }
 
             count = 0;
@@ -126,11 +127,12 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords);
 
+            serialNo = session.NextSerialNo;
             for (int i = 0; i < totalRecords; i += 2)
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = i };
-                session.Delete(ref key1, 0, 0);
+                session.Delete(ref key1, 0, serialNo);
             }
 
             count = 0;
@@ -143,12 +145,12 @@ namespace FASTER.test
 
             Assert.IsTrue(count == totalRecords / 2);
 
-
+            serialNo = session.NextSerialNo;
             for (int i = 0; i < totalRecords; i++)
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = 3 * i };
-                session.Upsert(ref key1, ref value, 0, 1);
+                session.Upsert(ref key1, ref value, 0, serialNo);
             }
 
             count = 0;

--- a/cs/test/ObjectFASTERTests.cs
+++ b/cs/test/ObjectFASTERTests.cs
@@ -201,7 +201,7 @@ namespace FASTER.test
                 var r = await session.RMWAsync(ref key, ref input, Empty.Default);
                 while (r.status == Status.PENDING)
                 {
-                    r = await r.CompleteRMWAsync();
+                    r = await r.CompleteRMWAsync(); // test async version of RMW completion
                 }
             }
 
@@ -210,7 +210,7 @@ namespace FASTER.test
             {
                 var key = new MyKey { key = i };
                 input = new MyInput { value = 1 };
-                await session.RMWAsync(ref key, ref input, Empty.Default);
+                (await session.RMWAsync(ref key, ref input, Empty.Default)).CompleteRMW();
             }
 
             for (int i = 0; i < 2000; i++)

--- a/cs/test/ObjectFASTERTests.cs
+++ b/cs/test/ObjectFASTERTests.cs
@@ -170,7 +170,7 @@ namespace FASTER.test
             {
                 var key = new MyKey { key = i };
                 var value = new MyValue { value = i };
-                await session.UpsertAsync(ref key, ref value, Empty.Default);
+                await session.UpsertAsync(ref key, ref value);
             }
 
             var key1 = new MyKey { key = 1989 };

--- a/cs/test/ObjectFASTERTests.cs
+++ b/cs/test/ObjectFASTERTests.cs
@@ -170,26 +170,26 @@ namespace FASTER.test
             {
                 var key = new MyKey { key = i };
                 var value = new MyValue { value = i };
-                await session.UpsertAsync(ref key, ref value);
+                session.Upsert(ref key, ref value);
             }
 
             var key1 = new MyKey { key = 1989 };
             var input = new MyInput();
             var readResult = await session.ReadAsync(ref key1, ref input, Empty.Default);
-            var result = readResult.CompleteRead();
+            var result = readResult.Complete();
             Assert.IsTrue(result.Item1 == Status.OK);
             Assert.IsTrue(result.Item2.value.value == 1989);
 
             var key2 = new MyKey { key = 23 };
             readResult = await session.ReadAsync(ref key2, ref input, Empty.Default);
-            result = readResult.CompleteRead();
+            result = readResult.Complete();
 
             Assert.IsTrue(result.Item1 == Status.OK);
             Assert.IsTrue(result.Item2.value.value == 23);
 
             var key3 = new MyKey { key = 9999 };
             readResult = await session.ReadAsync(ref key3, ref input, Empty.Default);
-            result = readResult.CompleteRead();
+            result = readResult.Complete();
 
             Assert.IsTrue(result.Item1 == Status.NOTFOUND);
 
@@ -201,7 +201,7 @@ namespace FASTER.test
                 var r = await session.RMWAsync(ref key, ref input, Empty.Default);
                 while (r.status == Status.PENDING)
                 {
-                    r = await r.CompleteRMWAsync(); // test async version of RMW completion
+                    r = await r.CompleteAsync(); // test async version of RMW completion
                 }
             }
 
@@ -210,7 +210,7 @@ namespace FASTER.test
             {
                 var key = new MyKey { key = i };
                 input = new MyInput { value = 1 };
-                (await session.RMWAsync(ref key, ref input, Empty.Default)).CompleteRMW();
+                (await session.RMWAsync(ref key, ref input, Empty.Default)).Complete();
             }
 
             for (int i = 0; i < 2000; i++)
@@ -220,7 +220,7 @@ namespace FASTER.test
                 var value = new MyValue { value = i };
 
                 readResult = await session.ReadAsync(ref key, ref input, Empty.Default);
-                result = readResult.CompleteRead();
+                result = readResult.Complete();
                 Assert.IsTrue(result.Item1 == Status.OK);
                 if (i < 100 || i >= 1900)
                     Assert.IsTrue(result.Item2.value.value == value.value + 1);

--- a/cs/test/ObjectFASTERTests.cs
+++ b/cs/test/ObjectFASTERTests.cs
@@ -198,8 +198,11 @@ namespace FASTER.test
             {
                 var key = new MyKey { key = i };
                 input = new MyInput { value = 1 };
-                await session.RMWAsync(ref key, ref input, Empty.Default);
-
+                var r = await session.RMWAsync(ref key, ref input, Empty.Default);
+                while (r.status == Status.PENDING)
+                {
+                    r = await r.CompleteRMWAsync();
+                }
             }
 
             // Update first 100 using RMW from storage

--- a/cs/test/RecoverContinueTests.cs
+++ b/cs/test/RecoverContinueTests.cs
@@ -140,7 +140,7 @@ namespace FASTER.test.recovery.sumstore.recover_continue
         {
             AdInput inputArg = default;
             Output outputArg = default;
-            for (var key = 0; key < numOps; key++)
+            for (var key = fht.NextSerialNo; key < numOps; key++)
             {
                 inputArg.adId.adId = key;
                 var status = fht.Read(ref inputArg.adId, ref inputArg, ref outputArg, Empty.Default, key);

--- a/cs/test/RecoverContinueTests.cs
+++ b/cs/test/RecoverContinueTests.cs
@@ -140,10 +140,10 @@ namespace FASTER.test.recovery.sumstore.recover_continue
         {
             AdInput inputArg = default;
             Output outputArg = default;
-            for (var key = fht.NextSerialNo; key < numOps; key++)
+            for (var key = 0; key < numOps; key++)
             {
                 inputArg.adId.adId = key;
-                var status = fht.Read(ref inputArg.adId, ref inputArg, ref outputArg, Empty.Default, key);
+                var status = fht.Read(ref inputArg.adId, ref inputArg, ref outputArg, Empty.Default, fht.SerialNo);
 
                 if (status == Status.PENDING)
                     fht.CompletePending(true);

--- a/cs/test/SimpleAsyncTests.cs
+++ b/cs/test/SimpleAsyncTests.cs
@@ -58,9 +58,7 @@ namespace FASTER.test.async
 
             for (long key = 0; key < numOps; key++)
             {
-                Status status;
-                long output = default;
-                (status, output) = (await s1.ReadAsync(ref key, ref output)).Complete();
+                var (status, output) = (await s1.ReadAsync(ref key)).Complete();
                 Assert.IsTrue(status == Status.OK && output == key);
             }
         }

--- a/cs/test/SimpleAsyncTests.cs
+++ b/cs/test/SimpleAsyncTests.cs
@@ -53,14 +53,14 @@ namespace FASTER.test.async
             using var s1 = fht1.NewSession(new SimpleFunctions<long, long>());
             for (long key = 0; key < numOps; key++)
             {
-                await s1.UpsertAsync(ref key, ref key);
+                s1.Upsert(ref key, ref key);
             }
 
             for (long key = 0; key < numOps; key++)
             {
                 Status status;
                 long output = default;
-                (status, output) = (await s1.ReadAsync(ref key, ref output)).CompleteRead();
+                (status, output) = (await s1.ReadAsync(ref key, ref output)).Complete();
                 Assert.IsTrue(status == Status.OK && output == key);
             }
         }
@@ -74,12 +74,12 @@ namespace FASTER.test.async
             using var s1 = fht1.NewSession(new SimpleFunctions<long, long>((a, b) => a + b));
             for (key = 0; key < numOps; key++)
             {
-                (await s1.RMWAsync(ref key, ref key)).CompleteRMW();
+                (await s1.RMWAsync(ref key, ref key)).Complete();
             }
 
             for (key = 0; key < numOps; key++)
             {
-                (status, output) = (await s1.ReadAsync(ref key, ref output)).CompleteRead();
+                (status, output) = (await s1.ReadAsync(ref key, ref output)).Complete();
                 Assert.IsTrue(status == Status.OK && output == key);
             }
 
@@ -88,10 +88,10 @@ namespace FASTER.test.async
             var t1 = s1.RMWAsync(ref key, ref input);
             var t2 = s1.RMWAsync(ref key, ref input);
 
-            (await t1).CompleteRMW();
-            (await t2).CompleteRMW(); // should trigger RMW re-do
+            (await t1).Complete();
+            (await t2).Complete(); // should trigger RMW re-do
 
-            (status, output) = (await s1.ReadAsync(ref key, ref output)).CompleteRead();
+            (status, output) = (await s1.ReadAsync(ref key, ref output)).Complete();
             Assert.IsTrue(status == Status.OK && output == key + input + input);
         }
     }

--- a/cs/test/SimpleAsyncTests.cs
+++ b/cs/test/SimpleAsyncTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using FASTER.core;
+using System.IO;
+using NUnit.Framework;
+using FASTER.test.recovery.sumstore;
+using System.Threading.Tasks;
+
+namespace FASTER.test.async
+{
+
+    [TestFixture]
+    public class SimpleAsyncTests
+    {
+        IDevice log;
+        FasterKV<long, long> fht1;
+        const int numOps = 5000;
+        AdId[] inputArray;
+        string path;
+
+        [SetUp]
+        public void Setup()
+        {
+            inputArray = new AdId[numOps];
+            for (int i = 0; i < numOps; i++)
+            {
+                inputArray[i].adId = i;
+            }
+
+            path = TestContext.CurrentContext.TestDirectory + "\\SimpleAsyncTests\\";
+            log = Devices.CreateLogDevice(path + "hlog.log", deleteOnClose: true);
+            Directory.CreateDirectory(path);
+            fht1 = new FasterKV<long, long>
+                (1L << 10,
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 15 },
+                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                );
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            fht1.Dispose();
+            log.Dispose();
+            new DirectoryInfo(path).Delete(true);
+        }
+
+
+        [Test]
+        public async Task SimpleAsyncTest1()
+        {
+            using var s1 = fht1.NewSession(new SimpleFunctions<long, long>());
+            for (long key = 1; key < numOps; key++)
+            {
+                s1.Upsert(ref key, ref key);
+            }
+
+            for (long key = 1; key < numOps; key++)
+            {
+                Status status;
+                long output = default;
+                (status, output) = (await s1.ReadAsync(ref key, ref output)).CompleteRead();
+                Assert.IsTrue(status == Status.OK && output == key);
+            }
+        }
+    }
+}

--- a/cs/test/SimpleAsyncTests.cs
+++ b/cs/test/SimpleAsyncTests.cs
@@ -53,7 +53,7 @@ namespace FASTER.test.async
             using var s1 = fht1.NewSession(new SimpleFunctions<long, long>());
             for (long key = 0; key < numOps; key++)
             {
-                s1.Upsert(ref key, ref key);
+                await s1.UpsertAsync(ref key, ref key);
             }
 
             for (long key = 0; key < numOps; key++)

--- a/cs/test/SimpleAsyncTests.cs
+++ b/cs/test/SimpleAsyncTests.cs
@@ -51,18 +51,48 @@ namespace FASTER.test.async
         public async Task SimpleAsyncTest1()
         {
             using var s1 = fht1.NewSession(new SimpleFunctions<long, long>());
-            for (long key = 1; key < numOps; key++)
+            for (long key = 0; key < numOps; key++)
             {
                 s1.Upsert(ref key, ref key);
             }
 
-            for (long key = 1; key < numOps; key++)
+            for (long key = 0; key < numOps; key++)
             {
                 Status status;
                 long output = default;
                 (status, output) = (await s1.ReadAsync(ref key, ref output)).CompleteRead();
                 Assert.IsTrue(status == Status.OK && output == key);
             }
+        }
+
+        [Test]
+        public async Task SimpleAsyncTest2()
+        {
+            Status status;
+            long key = default, input = default, output = default;
+
+            using var s1 = fht1.NewSession(new SimpleFunctions<long, long>((a, b) => a + b));
+            for (key = 0; key < numOps; key++)
+            {
+                (await s1.RMWAsync(ref key, ref key)).CompleteRMW();
+            }
+
+            for (key = 0; key < numOps; key++)
+            {
+                (status, output) = (await s1.ReadAsync(ref key, ref output)).CompleteRead();
+                Assert.IsTrue(status == Status.OK && output == key);
+            }
+
+            key = 0;
+            input = 35;
+            var t1 = s1.RMWAsync(ref key, ref input);
+            var t2 = s1.RMWAsync(ref key, ref input);
+
+            (await t1).CompleteRMW();
+            (await t2).CompleteRMW(); // should trigger RMW re-do
+
+            (status, output) = (await s1.ReadAsync(ref key, ref output)).CompleteRead();
+            Assert.IsTrue(status == Status.OK && output == key + input + input);
         }
     }
 }

--- a/cs/test/StateMachineTests.cs
+++ b/cs/test/StateMachineTests.cs
@@ -408,7 +408,7 @@ namespace FASTER.test.statemachine
                 // Completion callback should have been called once
                 Assert.IsTrue(f.checkpointCallbackExpectation == 0);
 
-                for (int key = 0; key < numOps; key++)
+                for (var key = s3.NextSerialNo; key < numOps; key++)
                 {
                     var status = s3.Read(ref inputArray[key], ref inputArg, ref output, Empty.Default, 0);
 

--- a/cs/test/StateMachineTests.cs
+++ b/cs/test/StateMachineTests.cs
@@ -408,9 +408,9 @@ namespace FASTER.test.statemachine
                 // Completion callback should have been called once
                 Assert.IsTrue(f.checkpointCallbackExpectation == 0);
 
-                for (var key = s3.NextSerialNo; key < numOps; key++)
+                for (var key = 0; key < numOps; key++)
                 {
-                    var status = s3.Read(ref inputArray[key], ref inputArg, ref output, Empty.Default, 0);
+                    var status = s3.Read(ref inputArray[key], ref inputArg, ref output, Empty.Default, s3.SerialNo);
 
                     if (status == Status.PENDING)
                         s3.CompletePending(true);


### PR DESCRIPTION
* Async version of RMW that returns status
* Improved async Read to share code with sync path

Using async RMW:

Version 1:
```cs
var status = (await session.RMWAsync(ref key, ref input)).CompleteRMW();
```

Version 2:
```cs
var r = await session.RMWAsync(ref key, ref input);
while (r.status == Status.PENDING)
   r = await r.CompleteRMWAsync();
```

Version 2 is truly async even in the rare case that RMW completion has to go pending again. This is exceedingly rare (happens only when some other operation on the same key increments the value AND that value goes back to disk before this RMW could complete its `CompleteRMW`). Therefore we offer a easier version 1 just does this rare pending work synchronously, in order to keep a much simpler API.

Related issues and PRs:
* https://github.com/microsoft/FASTER/issues/338
* https://github.com/microsoft/FASTER/pull/248
* https://github.com/microsoft/FASTER/issues/246