### PR TITLE
[C#] Fix StackOverflow during CompleteCheckpointAsync

### DIFF
--- a/cs/samples/StoreDiskReadBenchmark/Types.cs
+++ b/cs/samples/StoreDiskReadBenchmark/Types.cs
@@ -81,7 +81,8 @@ namespace StoreDiskReadBenchmark
         {
             if (status != Status.OK || output.value.vfield1 != key.key)
             {
-                throw new Exception("Wrong value found");
+                if (!Program.simultaneousReadWrite)
+                    throw new Exception("Wrong value found");
             }
         }
     }

--- a/cs/src/core/Epochs/LightEpoch.cs
+++ b/cs/src/core/Epochs/LightEpoch.cs
@@ -191,7 +191,7 @@ namespace FASTER.core
                     }
                 }
                 Resume();
-                Suspend();
+                Release();
             }
         }
 
@@ -215,8 +215,9 @@ namespace FASTER.core
                         var trigger_action = drainList[i].action;
                         drainList[i].action = null;
                         drainList[i].epoch = int.MaxValue;
+                        Interlocked.Decrement(ref drainCount);
                         trigger_action();
-                        if (Interlocked.Decrement(ref drainCount) == 0) break;
+                        if (drainCount == 0) break;
                     }
                 }
             }

--- a/cs/src/core/Index/Interfaces/IFunctions.cs
+++ b/cs/src/core/Index/Interfaces/IFunctions.cs
@@ -1,8 +1,25 @@
-﻿using System;
+﻿using Microsoft.Win32;
+using System;
 using System.Collections.Generic;
 
 namespace FASTER.core
 {
+    /// <summary>
+    /// Lazy ref-get for given type (performs lazy allocation)
+    /// </summary>
+    /// <typeparam name="Value"></typeparam>
+    public struct LazyRef<Value>
+    {
+        /// <summary>
+        /// Get value ref (after allocating)
+        /// </summary>
+        /// <returns></returns>
+        public ref Value Get()
+        {
+            throw new NotImplementedException();
+        }
+    }
+
     /// <summary>
     /// Callback functions to FASTER
     /// </summary>
@@ -70,6 +87,18 @@ namespace FASTER.core
         /// <param name="oldValue"></param>
         /// <param name="newValue"></param>
         void CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue);
+
+
+        /// <summary>
+        /// Copy-update with conditional allocation for RMW. Return false
+        /// to fall through to normal CopyUpdate
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="input"></param>
+        /// <param name="oldValue"></param>
+        /// <param name="newValue"></param>
+        /// <returns></returns>
+        // bool ConditionalCopyUpdater(ref Key key, ref Input input, ref Value oldValue, LazyRef<Value> newValue);
 
         /// <summary>
         /// In-place update for RMW

--- a/cs/src/core/Index/Synchronization/StateTransitions.cs
+++ b/cs/src/core/Index/Synchronization/StateTransitions.cs
@@ -23,10 +23,10 @@ namespace FASTER.core
 
     internal enum Phase : int {
         IN_PROGRESS, 
-        WAIT_PENDING, 
-        WAIT_FLUSH, 
-        PERSISTENCE_CALLBACK, 
+        WAIT_PENDING,
         WAIT_INDEX_CHECKPOINT,
+        WAIT_FLUSH,
+        PERSISTENCE_CALLBACK, 
         REST,
         PREP_INDEX_CHECKPOINT, 
         PREPARE,


### PR DESCRIPTION
* Avoid recursive call in SuspendDrain to prevent stack overflow
* Change epoch draining code to first decrement drainCount, then perform trigger_action. This should be safe, and improve performance as well.

CC @tli2

Fix https://github.com/microsoft/FASTER/issues/341