### PR TITLE
[C#] Added NeedCopyUpdate to IFunctions for RMW

### DIFF
--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -883,6 +883,9 @@ namespace FASTER.core
                 if (endAddress-startAddress > int.MaxValue)
                     throw new FasterException("Size of key-value exceeds max of 2GB: " + (endAddress - startAddress));
 
+                if (startAddress < 0)
+                    startAddress = 0;
+
                 AsyncGetFromDisk(startAddress, (int)(endAddress - startAddress), ctx, ctx.record);
                 return false;
             }

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -487,6 +487,9 @@ namespace FASTER.core
                 return _clientSession.functions.ConcurrentWriter(ref key, ref src, ref dst);
             }
 
+            public bool NeedCopyUpdate(ref Key key, ref Input input, ref Value oldValue)
+                => _clientSession.functions.NeedCopyUpdate(ref key, ref input, ref oldValue);
+
             public void CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue)
             {
                 _clientSession.functions.CopyUpdater(ref key, ref input, ref oldValue, ref newValue);

--- a/cs/src/core/Index/FASTER/FASTERLegacy.cs
+++ b/cs/src/core/Index/FASTER/FASTERLegacy.cs
@@ -339,6 +339,9 @@ namespace FASTER.core
                 return _fasterKV._functions.ConcurrentWriter(ref key, ref src, ref dst);
             }
 
+            public bool NeedCopyUpdate(ref Key key, ref Input input, ref Value oldValue)
+                => _fasterKV._functions.NeedCopyUpdate(ref key, ref input, ref oldValue);
+
             public void CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue)
             {
                 _fasterKV._functions.CopyUpdater(ref key, ref input, ref oldValue, ref newValue);

--- a/cs/src/core/Index/FASTER/LogCompactionFunctions.cs
+++ b/cs/src/core/Index/FASTER/LogCompactionFunctions.cs
@@ -23,6 +23,7 @@ namespace FASTER.core
         public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint) { }
         public void ConcurrentReader(ref Key key, ref Empty input, ref Value value, ref Empty dst) { }
         public bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst) { return _functions.CopyInPlace(ref src, ref dst, _allocator.ValueLength); }
+        public bool NeedCopyUpdate(ref Key key, ref Empty input, ref Value oldValue) => true;
         public void CopyUpdater(ref Key key, ref Empty input, ref Value oldValue, ref Value newValue) { }
         public void InitialUpdater(ref Key key, ref Empty input, ref Value value) { }
         public bool InPlaceUpdater(ref Key key, ref Empty input, ref Value value) => false;
@@ -47,6 +48,7 @@ namespace FASTER.core
         public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint) { }
         public void ConcurrentReader(ref Key key, ref Empty input, ref Value value, ref Empty dst) { }
         public bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst) { return _functions.CopyInPlace(ref src, ref dst, null); }
+        public bool NeedCopyUpdate(ref Key key, ref Empty input, ref Value oldValue) => true;
         public void CopyUpdater(ref Key key, ref Empty input, ref Value oldValue, ref Value newValue) { }
         public void InitialUpdater(ref Key key, ref Empty input, ref Value value) { }
         public bool InPlaceUpdater(ref Key key, ref Empty input, ref Value value) { return true; }

--- a/cs/src/core/Index/Interfaces/FunctionsBase.cs
+++ b/cs/src/core/Index/Interfaces/FunctionsBase.cs
@@ -25,6 +25,7 @@ namespace FASTER.core
         public virtual void SingleWriter(ref Key key, ref Value src, ref Value dst) => dst = src;
 
         public virtual void InitialUpdater(ref Key key, ref Input input, ref Value value) { }
+        public virtual bool NeedCopyUpdate(ref Key key, ref Input input, ref Value oldValue) => true;
         public virtual void CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue) { }
         public virtual bool InPlaceUpdater(ref Key key, ref Input input, ref Value value) { return true; }
 

--- a/cs/src/core/Index/Interfaces/IFunctions.cs
+++ b/cs/src/core/Index/Interfaces/IFunctions.cs
@@ -64,6 +64,18 @@ namespace FASTER.core
         void InitialUpdater(ref Key key, ref Input input, ref Value value);
 
         /// <summary>
+        /// Whether we need to invoke copy-update for RMW
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="input"></param>
+        /// <param name="oldValue"></param>
+        bool NeedCopyUpdate(ref Key key, ref Input input, ref Value oldValue)
+#if NETSTANDARD21            
+            => true
+#endif
+            ;
+
+        /// <summary>
         /// Copy-update for RMW
         /// </summary>
         /// <param name="key"></param>

--- a/cs/src/core/Index/Interfaces/TryAddFunctions.cs
+++ b/cs/src/core/Index/Interfaces/TryAddFunctions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace FASTER.core
+{
+    /// <summary>
+    /// Functions that make RMW behave as an atomic TryAdd operation, where Input is the value being added.
+    /// Return Status.NOTFOUND => TryAdd succeededed (item added).
+    /// Return Status.OK => TryAdd failed (item not added, key was already present).
+    /// </summary>
+    /// <typeparam name="Key"></typeparam>
+    /// <typeparam name="Value"></typeparam>
+    /// <typeparam name="Context"></typeparam>
+    public class TryAddFunctions<Key, Value, Context> : SimpleFunctions<Key, Value, Context>
+    {
+        /// <inheritdoc />
+        public override bool InPlaceUpdater(ref Key key, ref Value input, ref Value value) => true;
+        /// <inheritdoc />
+        public override bool NeedCopyUpdate(ref Key key, ref Value input, ref Value oldValue) => false;
+    }
+
+    /// <summary>
+    /// Functions that make RMW behave as an atomic TryAdd operation, where Input is the value being added.
+    /// Return Status.NOTFOUND => TryAdd succeededed (item added)
+    /// Return Status.OK => TryAdd failed (item not added, key was already present)
+    /// </summary>
+    /// <typeparam name="Key"></typeparam>
+    /// <typeparam name="Value"></typeparam>
+    public class TryAddFunctions<Key, Value> : TryAddFunctions<Key, Value, Empty> { }
+}

--- a/cs/test/AsyncTests.cs
+++ b/cs/test/AsyncTests.cs
@@ -171,6 +171,8 @@ namespace FASTER.test.async
             return true;
         }
 
+        public bool NeedCopyUpdate(ref AdId key, ref AdInput input, ref NumClicks oldValue) => true;
+
         public void CopyUpdater(ref AdId key, ref AdInput input, ref NumClicks oldValue, ref NumClicks newValue)
         {
             newValue.numClicks += oldValue.numClicks + input.numClicks.numClicks;

--- a/cs/test/NeedCopyUpdateTests.cs
+++ b/cs/test/NeedCopyUpdateTests.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using FASTER.core;
+using System.IO;
+using NUnit.Framework;
+
+namespace FASTER.test
+{
+
+    [TestFixture]
+    internal class NeedCopyUpdateTests
+    {
+        private FasterKV<int, RMWValue> fht;
+        private IDevice log, objlog;
+
+        [SetUp]
+        public void Setup()
+        {
+            log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\NeedCopyUpdateTests.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "\\NeedCopyUpdateTests.obj.log", deleteOnClose: true);
+
+            fht = new FasterKV<int, RMWValue>
+                (128,
+                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 15, PageSizeBits = 10 },
+                checkpointSettings: new CheckpointSettings { CheckPointType = CheckpointType.FoldOver },
+                serializerSettings: new SerializerSettings<int, RMWValue> { valueSerializer = () => new RMWValueSerializer() }
+                );
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            fht.Dispose();
+            fht = null;
+            log.Dispose();
+            objlog.Dispose();
+        }
+
+
+        [Test]
+        public void TryAddTest()
+        {
+            using var session = fht.For(new TryAddTestFunctions()).NewSession<TryAddTestFunctions>();
+
+            Status status;
+            var key = 1;
+            var value1 = new RMWValue { value = 1 };
+            var value2 = new RMWValue { value = 2 };
+
+            status = session.RMW(ref key, ref value1); // NOTFOUND + InitialUpdated
+            Assert.IsTrue(status == Status.NOTFOUND);
+            Assert.IsTrue(value1.flag); // InitialUpdater is called
+
+            status = session.RMW(ref key, ref value2); // OK + first InPlaceUpdated
+            Assert.IsTrue(status == Status.OK);
+
+            fht.Log.Flush(true);
+            status = session.RMW(ref key, ref value2); // OK + CopyUpdater
+            Assert.IsTrue(status == Status.OK);
+
+            fht.Log.FlushAndEvict(true);
+            status = session.RMW(ref key, ref value2, Status.OK, 0); // PENDING + CopyUpdater + OK
+            Assert.IsTrue(status == Status.PENDING);
+            session.CompletePending(true);
+
+            // Test stored value. Should be value1
+            var output = new RMWValue();
+            status = session.Read(ref key, ref value1, ref output, Status.OK, 0);
+            Assert.IsTrue(status == Status.PENDING);
+            session.CompletePending(true);
+
+            status = session.Delete(ref key);
+            Assert.IsTrue(status == Status.OK);
+            session.CompletePending(true);
+            fht.Log.FlushAndEvict(true);
+            status = session.RMW(ref key, ref value2, Status.NOTFOUND, 0); // PENDING + InitialUpdated + NOTFOUND
+            Assert.IsTrue(status == Status.PENDING);
+            session.CompletePending(true);
+        }
+    }
+
+    internal class RMWValue
+    {
+        public int value;
+        public bool flag;
+    }
+
+    internal class RMWValueSerializer : BinaryObjectSerializer<RMWValue>
+    {
+        public override void Serialize(ref RMWValue value)
+        {
+            writer.Write(value.value);
+        }
+
+        public override void Deserialize(out RMWValue value)
+        {
+            value = new RMWValue
+            {
+                value = reader.ReadInt32()
+            };
+        }
+    }
+
+    internal class TryAddTestFunctions : SimpleFunctions<int, RMWValue, Status>
+    {
+        public override void InitialUpdater(ref int key, ref RMWValue input, ref RMWValue value)
+        {
+            input.flag = true;
+            base.InitialUpdater(ref key, ref input, ref value);
+        }
+
+        public override bool NeedCopyUpdate(ref int key, ref RMWValue input, ref RMWValue oldValue) => false;
+
+        public override void CopyUpdater(ref int key, ref RMWValue input, ref RMWValue oldValue, ref RMWValue newValue)
+        {
+            Assert.Fail("CopyUpdater");
+        }
+
+        public override bool InPlaceUpdater(ref int key, ref RMWValue input, ref RMWValue value) => false;
+
+        public override void RMWCompletionCallback(ref int key, ref RMWValue input, Status ctx, Status status)
+        {
+            Assert.IsTrue(status == ctx);
+
+            if (status == Status.NOTFOUND)
+                Assert.IsTrue(input.flag); // InitialUpdater is called.
+        }
+
+        public override void ReadCompletionCallback(ref int key, ref RMWValue input, ref RMWValue output, Status ctx, Status status)
+        {
+            Assert.IsTrue(input.value == output.value);
+        }
+    }
+}

--- a/cs/test/ObjectRecoveryTest2.cs
+++ b/cs/test/ObjectRecoveryTest2.cs
@@ -245,6 +245,7 @@ namespace FASTER.test.recovery.objects
     public class MyFunctions : IFunctions<MyKey, MyValue, MyInput, MyOutput, MyContext>
     {
         public void InitialUpdater(ref MyKey key, ref MyInput input, ref MyValue value) => value.value = input.value;
+        public bool NeedCopyUpdate(ref MyKey key, ref MyInput input, ref MyValue oldValue) => true;
         public void CopyUpdater(ref MyKey key, ref MyInput input, ref MyValue oldValue, ref MyValue newValue) => newValue = oldValue;
         public bool InPlaceUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
         {

--- a/cs/test/ObjectRecoveryTestTypes.cs
+++ b/cs/test/ObjectRecoveryTestTypes.cs
@@ -134,6 +134,8 @@ namespace FASTER.test.recovery.objectstore
             return true;
         }
 
+        public bool NeedCopyUpdate(ref AdId key, ref Input input, ref NumClicks oldValue) => true;
+
         public void CopyUpdater(ref AdId key, ref Input input, ref NumClicks oldValue, ref NumClicks newValue)
         {
             newValue = new NumClicks { numClicks = oldValue.numClicks + input.numClicks.numClicks };

--- a/cs/test/ObjectTestTypes.cs
+++ b/cs/test/ObjectTestTypes.cs
@@ -88,6 +88,8 @@ namespace FASTER.test
             return true;
         }
 
+        public bool NeedCopyUpdate(ref MyKey key, ref MyInput input, ref MyValue oldValue) => true;
+
         public void CopyUpdater(ref MyKey key, ref MyInput input, ref MyValue oldValue, ref MyValue newValue)
         {
             newValue = new MyValue { value = oldValue.value + input.value };
@@ -155,6 +157,8 @@ namespace FASTER.test
             value.value += input.value;
             return true;
         }
+
+        public bool NeedCopyUpdate(ref MyKey key, ref MyInput input, ref MyValue oldValue) => true;
 
         public void CopyUpdater(ref MyKey key, ref MyInput input, ref MyValue oldValue, ref MyValue newValue)
         {
@@ -234,6 +238,8 @@ namespace FASTER.test
             value.value += input.value;
             return true;
         }
+
+        public bool NeedCopyUpdate(ref int key, ref MyInput input, ref MyValue oldValue) => true;
 
         public void CopyUpdater(ref int key, ref MyInput input, ref MyValue oldValue, ref MyValue newValue)
         {
@@ -345,6 +351,8 @@ namespace FASTER.test
         public void DeleteCompletionCallback(ref MyKey key, Empty ctx)
         {
         }
+
+        public bool NeedCopyUpdate(ref MyKey key, ref MyInput input, ref MyLargeValue oldValue) => true;
 
         public void CopyUpdater(ref MyKey key, ref MyInput input, ref MyLargeValue oldValue, ref MyLargeValue newValue)
         {

--- a/cs/test/RecoverContinueTests.cs
+++ b/cs/test/RecoverContinueTests.cs
@@ -233,6 +233,8 @@ namespace FASTER.test.recovery.sumstore.recover_continue
             return true;
         }
 
+        public bool NeedCopyUpdate(ref AdId key, ref AdInput input, ref NumClicks oldValue) => true;
+
         public void CopyUpdater(ref AdId key, ref AdInput input, ref NumClicks oldValue, ref NumClicks newValue)
         {
             newValue.numClicks += oldValue.numClicks + input.numClicks.numClicks;

--- a/cs/test/RecoveryTestTypes.cs
+++ b/cs/test/RecoveryTestTypes.cs
@@ -102,6 +102,8 @@ namespace FASTER.test.recovery.sumstore
             return true;
         }
 
+        public bool NeedCopyUpdate(ref AdId key, ref AdInput input, ref NumClicks oldValue) => true;
+
         public void CopyUpdater(ref AdId key, ref AdInput input, ref NumClicks oldValue, ref NumClicks newValue)
         {
             newValue.numClicks += oldValue.numClicks + input.numClicks.numClicks;

--- a/cs/test/SimpleRecoveryTest.cs
+++ b/cs/test/SimpleRecoveryTest.cs
@@ -313,6 +313,8 @@ namespace FASTER.test.recovery.sumstore.simple
             return true;
         }
 
+        public bool NeedCopyUpdate(ref AdId key, ref AdInput input, ref NumClicks oldValue) => true;
+
         public void CopyUpdater(ref AdId key, ref AdInput input, ref NumClicks oldValue, ref NumClicks newValue)
         {
             newValue.numClicks += oldValue.numClicks + input.numClicks.numClicks;

--- a/cs/test/TestTypes.cs
+++ b/cs/test/TestTypes.cs
@@ -116,6 +116,8 @@ namespace FASTER.test
             return true;
         }
 
+        public bool NeedCopyUpdate(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue) => true;
+
         public void CopyUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue, ref ValueStruct newValue)
         {
             newValue.vfield1 = oldValue.vfield1 + input.ifield1;
@@ -194,6 +196,8 @@ namespace FASTER.test
             return true;
         }
 
+        public bool NeedCopyUpdate(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue) => true;
+
         public void CopyUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue, ref ValueStruct newValue)
         {
             newValue.vfield1 = oldValue.vfield1 + input.ifield1;
@@ -269,6 +273,8 @@ namespace FASTER.test
             Interlocked.Increment(ref _inPlaceUpdaterCallCount);
             return false;
         }
+
+        public bool NeedCopyUpdate(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue) => true;
 
         public void CopyUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue, ref ValueStruct newValue)
         {

--- a/cs/test/VLTestTypes.cs
+++ b/cs/test/VLTestTypes.cs
@@ -165,6 +165,8 @@ namespace FASTER.test
             return true;
         }
 
+        public bool NeedCopyUpdate(ref Key key, ref Input input, ref VLValue oldValue) => true;
+
         public void CopyUpdater(ref Key key, ref Input input, ref VLValue oldValue, ref VLValue newValue)
         {
         }
@@ -234,6 +236,8 @@ namespace FASTER.test
         {
             return true;
         }
+
+        public bool NeedCopyUpdate(ref VLValue key, ref Input input, ref VLValue oldValue) => true;
 
         public void CopyUpdater(ref VLValue key, ref Input input, ref VLValue oldValue, ref VLValue newValue)
         {


### PR DESCRIPTION
The PR adds a `NeedCopyUpdate` callback to `IFunctions` for RMW, which the application can use to determine if they want to proceed with a log allocation + `CopyUpdater`. The default for this callback is `true`.

In order to force cascading into `NeedCopyUpdate`, application can just return `false` for `InPlaceUpdater`.

This will avoid unnecessary allocation if we do not need to `CopyUpdate`. The decision is made based on old value and input.

Example use cases:
* Implementing `TryAdd` functionality using RMW
* Implementing a `key->set|hash` structure (similar to redis set or even hash). We want to be able to prevent a copy if the item being added to a set is already present, otherwise if it is missing then we need to modify the set, so a copy is required. 

See linked issue below for more information.

Fix https://github.com/microsoft/FASTER/issues/338