### PR TITLE
[C#] Benchmark settings to backup & restore database for quicker runs

### DIFF
--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -43,12 +43,11 @@ namespace FASTER.benchmark
         const int kPeriodicCheckpointMilliseconds = 0;
 #endif
 
-        // *** Use below settings to backup and recover database for fast benchmark repeat runs
-        // First set kBackupStoreForFastRestarts to get the backup
-        // Then reset kBackupStoreForFastRestarts and set kRestoreFromBackupForFastRestarts for fast subsequent runs
+        // *** Use these to backup and recover database for fast benchmark repeat runs
+        // Use BackupMode.Backup to create the backup, unless it was recovered during BackupMode.Recover
+        // Use BackupMode.Restore for fast subsequent runs
         // Does NOT work when periodic checkpointing is turned on
-        const bool kBackupStoreForFastRestarts = false;
-        const bool kRestoreFromBackupForFastRestarts = false;
+        readonly BackupMode backupMode;
         // ***
 
         const long kInitCount = kUseSmallData ? 2500480 : 250000000;
@@ -79,12 +78,13 @@ namespace FASTER.benchmark
 
         volatile bool done = false;
 
-        public FASTER_YcsbBenchmark(int threadCount_, int numaStyle_, string distribution_, int readPercent_)
+        public FASTER_YcsbBenchmark(int threadCount_, int numaStyle_, string distribution_, int readPercent_, int backupOptions_)
         {
             threadCount = threadCount_;
             numaStyle = numaStyle_;
             distribution = distribution_;
             readPercent = readPercent_;
+            this.backupMode = (BackupMode)backupOptions_;
 
 #if DASHBOARD
             statsWritten = new AutoResetEvent[threadCount];
@@ -226,7 +226,7 @@ namespace FASTER.benchmark
 
         public unsafe void Run()
         {
-            // Native32.AffinitizeThreadShardedNuma((uint)0, 2);
+            //Native32.AffinitizeThreadShardedNuma(0, 2);
 
             RandomGenerator rng = new RandomGenerator();
 
@@ -246,13 +246,21 @@ namespace FASTER.benchmark
             Console.WriteLine("Executing setup.");
 
             Stopwatch sw = new Stopwatch();
-            if (kRestoreFromBackupForFastRestarts && kPeriodicCheckpointMilliseconds <= 0)
+            var storeWasRecovered = false;
+            if (this.backupMode.HasFlag(BackupMode.Restore) && kPeriodicCheckpointMilliseconds <= 0)
             {
                 sw.Start();
-                store.Recover();
+                try
+                {
+                    store.Recover();
+                    storeWasRecovered = true;
+                } catch (Exception)
+                {
+                    Console.WriteLine("Unable to recover prior store; loading from data");
+                }
                 sw.Stop();
             }
-            else
+            if (!storeWasRecovered)
             {
                 // Setup the store for the YCSB benchmark.
                 for (int idx = 0; idx < threadCount; ++idx)
@@ -278,7 +286,7 @@ namespace FASTER.benchmark
             long startTailAddress = store.Log.TailAddress;
             Console.WriteLine("Start tail address = " + startTailAddress);
 
-            if (kBackupStoreForFastRestarts && kPeriodicCheckpointMilliseconds <= 0)
+            if (!storeWasRecovered && this.backupMode.HasFlag(BackupMode.Backukp) && kPeriodicCheckpointMilliseconds <= 0)
             {
                 store.TakeFullCheckpoint(out _);
                 store.CompleteCheckpointAsync().GetAwaiter().GetResult();

--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -252,17 +252,19 @@ namespace FASTER.benchmark
                 sw.Start();
                 try
                 {
+                    Console.WriteLine("Recovering FasterKV for fast restart");
                     store.Recover();
                     storeWasRecovered = true;
                 } catch (Exception)
                 {
-                    Console.WriteLine("Unable to recover prior store; loading from data");
+                    Console.WriteLine("Unable to recover prior store");
                 }
                 sw.Stop();
             }
             if (!storeWasRecovered)
             {
                 // Setup the store for the YCSB benchmark.
+                Console.WriteLine("Loading FasterKV from data");
                 for (int idx = 0; idx < threadCount; ++idx)
                 {
                     int x = idx;
@@ -288,6 +290,7 @@ namespace FASTER.benchmark
 
             if (!storeWasRecovered && this.backupMode.HasFlag(BackupMode.Backukp) && kPeriodicCheckpointMilliseconds <= 0)
             {
+                Console.WriteLine("Checkpointing FasterKV for fast restart");
                 store.TakeFullCheckpoint(out _);
                 store.CompleteCheckpointAsync().GetAwaiter().GetResult();
                 Console.WriteLine("Completed checkpoint");

--- a/cs/benchmark/Program.cs
+++ b/cs/benchmark/Program.cs
@@ -21,7 +21,11 @@ namespace FASTER.benchmark
         public int NumaStyle { get; set; }
 
         [Option('k', "backup", Required = false, Default = 0,
-             HelpText = "Enable Backup and Restore of FasterKV for fast test startup:\n0 = None\n1 = Recover FasterKV from Checkpoint\n2 = Checkpoint FasterKV if it was not Recovered\n3 = both")]
+             HelpText = "Enable Backup and Restore of FasterKV for fast test startup:" +
+                        "\n    0 = None; Populate FasterKV from data" +
+                        "\n    1 = Recover FasterKV from Checkpoint; if this fails, populate FasterKV from data" +
+                        "\n    2 = Checkpoint FasterKV (unless it was Recovered by option 1; if option 1 is not specified, this will overwrite an existing Checkpoint)" +
+                        "\n    3 = Both (Recover FasterKV if the Checkpoint is available, else populate FasterKV from data and Checkpoint it so it can be Restored in a subsequent run)")]
         public int Backup { get; set; }
 
         [Option('r', "read_percent", Required = false, Default = 50,

--- a/cs/benchmark/Program.cs
+++ b/cs/benchmark/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using CommandLine;
+using System;
 
 namespace FASTER.benchmark
 {
@@ -19,6 +20,10 @@ namespace FASTER.benchmark
              HelpText = "0 = No sharding across NUMA sockets, 1 = Sharding across NUMA sockets")]
         public int NumaStyle { get; set; }
 
+        [Option('k', "backup", Required = false, Default = 0,
+             HelpText = "Enable Backup and Restore of FasterKV for fast test startup:\n0 = None\n1 = Recover FasterKV from Checkpoint\n2 = Checkpoint FasterKV if it was not Recovered\n3 = both")]
+        public int Backup { get; set; }
+
         [Option('r', "read_percent", Required = false, Default = 50,
          HelpText = "Percentage of reads (-1 for 100% read-modify-write")]
         public int ReadPercent { get; set; }
@@ -31,6 +36,11 @@ namespace FASTER.benchmark
     enum BenchmarkType : int
     {
         Ycsb, ConcurrentDictionaryYcsb
+    };
+
+    [Flags] enum BackupMode : int
+    {
+        None, Restore, Backukp, Both
     };
 
     public class Program
@@ -48,7 +58,7 @@ namespace FASTER.benchmark
 
             if (b == BenchmarkType.Ycsb)
             {
-                var test = new FASTER_YcsbBenchmark(options.ThreadCount, options.NumaStyle, options.Distribution, options.ReadPercent);
+                var test = new FASTER_YcsbBenchmark(options.ThreadCount, options.NumaStyle, options.Distribution, options.ReadPercent, options.Backup);
                 test.Run();
             }
             else if (b == BenchmarkType.ConcurrentDictionaryYcsb)


### PR DESCRIPTION
Add command-line option `-k` / `--backup` to replace constants in `FASTER.benchmark`. Used to enable Backup and Restore of FasterKV for fast test startup. Values:

* 0 = None; Populate FasterKV from source data (the default)
* 1 = Recover FasterKV from Checkpoint; if this fails, populate FasterKV from source data
* 2 = Checkpoint FasterKV (unless it was Recovered by option 1; if option 1 is not specified, this will overwrite an existing Checkpoint)
* 3 = Both (Recover FasterKV if the Checkpoint is available, else populate FasterKV from source data and Checkpoint it so it can be Restored in a subsequent run)

These options do not apply when periodic checkpointing is turned on.