### PR TITLE
[C#] Support variable length Input

### DIFF
--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -191,7 +191,7 @@ namespace FASTER.core
         /// <summary>
         /// Buffer pool
         /// </summary>
-        protected SectorAlignedBufferPool bufferPool;
+        internal SectorAlignedBufferPool bufferPool;
 
         /// <summary>
         /// Read cache

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -350,7 +350,7 @@ namespace FASTER.core
         /// <param name="callback"></param>
         /// <param name="context"></param>
         /// <param name="result"></param>
-        protected override void AsyncReadRecordObjectsToMemory(long fromLogical, int numBytes, DeviceIOCompletionCallback callback, AsyncIOContext<Key, Value> context, SectorAlignedMemory result = default(SectorAlignedMemory))
+        protected override void AsyncReadRecordObjectsToMemory(long fromLogical, int numBytes, DeviceIOCompletionCallback callback, AsyncIOContext<Key, Value> context, SectorAlignedMemory result = default)
         {
             throw new InvalidOperationException("AsyncReadRecordObjectsToMemory invalid for BlittableAllocator");
         }

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -41,7 +41,7 @@ namespace FASTER.core
             FasterKV<Key, Value>.FasterExecutionContext<Input, Output, Context> ctx,
             Functions functions,
             bool supportAsync,
-            InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
+            SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
         {
             this.fht = fht;
             this.ctx = ctx;
@@ -50,7 +50,7 @@ namespace FASTER.core
             LatestCommitPoint = new CommitPoint { UntilSerialNo = -1, ExcludedSerialNos = null };
             FasterSession = new AsyncFasterSession(this);
 
-            this.variableLengthStruct = inputVariableLengthStructSettings?.valueLength;
+            this.variableLengthStruct = sessionVariableLengthStructSettings?.valueLength;
             if (this.variableLengthStruct == default)
             {
                 if (fht.hlog is VariableLengthBlittableAllocator<Key, Value> allocator)
@@ -65,7 +65,7 @@ namespace FASTER.core
                     Debug.WriteLine("Warning: Session param of variableLengthStruct provided for non-varlen allocator");
             }
 
-            this.inputVariableLengthStruct = inputVariableLengthStructSettings?.inputLength;
+            this.inputVariableLengthStruct = sessionVariableLengthStructSettings?.inputLength;
 
             // Session runs on a single thread
             if (!supportAsync)

--- a/cs/src/core/ClientSession/FASTERClientSession.cs
+++ b/cs/src/core/ClientSession/FASTERClientSession.cs
@@ -42,12 +42,12 @@ namespace FASTER.core
             /// <param name="functions">Callback functions</param>
             /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
             /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-            /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
+            /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(Functions functions, string sessionId = null, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
+            public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(Functions functions, string sessionId = null, bool threadAffinitized = false, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
-                return _fasterKV.NewSession<Input, Output, Context, Functions>(functions, sessionId, threadAffinitized, inputVariableLengthStructSettings);
+                return _fasterKV.NewSession<Input, Output, Context, Functions>(functions, sessionId, threadAffinitized, sessionVariableLengthStructSettings);
             }
 
             /// <summary>
@@ -58,12 +58,12 @@ namespace FASTER.core
             /// <param name="sessionId">ID/name of previous session to resume</param>
             /// <param name="commitPoint">Prior commit point of durability for session</param>
             /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-            /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
+            /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(Functions functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
+            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(Functions functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
-                return _fasterKV.ResumeSession<Input, Output, Context, Functions>(functions, sessionId, out commitPoint, threadAffinitized, inputVariableLengthStructSettings);
+                return _fasterKV.ResumeSession<Input, Output, Context, Functions>(functions, sessionId, out commitPoint, threadAffinitized, sessionVariableLengthStructSettings);
             }
 
             /// <summary>
@@ -71,15 +71,15 @@ namespace FASTER.core
             /// </summary>
             /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
             /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-            /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
+            /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(string sessionId = null, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
+            public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(string sessionId = null, bool threadAffinitized = false, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
                 if (_functions == null)
                     throw new FasterException("Functions not provided for session");
 
-                return _fasterKV.NewSession<Input, Output, Context, Functions>((Functions)_functions, sessionId, threadAffinitized, inputVariableLengthStructSettings);
+                return _fasterKV.NewSession<Input, Output, Context, Functions>((Functions)_functions, sessionId, threadAffinitized, sessionVariableLengthStructSettings);
             }
 
             /// <summary>
@@ -89,15 +89,15 @@ namespace FASTER.core
             /// <param name="sessionId">ID/name of previous session to resume</param>
             /// <param name="commitPoint">Prior commit point of durability for session</param>
             /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-            /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
+            /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
+            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
                 if (_functions == null)
                     throw new FasterException("Functions not provided for session");
 
-                return _fasterKV.ResumeSession<Input, Output, Context, Functions>((Functions)_functions, sessionId, out commitPoint, threadAffinitized, inputVariableLengthStructSettings);
+                return _fasterKV.ResumeSession<Input, Output, Context, Functions>((Functions)_functions, sessionId, out commitPoint, threadAffinitized, sessionVariableLengthStructSettings);
             }
         }
 
@@ -132,11 +132,11 @@ namespace FASTER.core
         /// <param name="functions">Callback functions</param>
         /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
         /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-        /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
+        /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
-        public ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> NewSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions, string sessionId = null, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
+        public ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> NewSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions, string sessionId = null, bool threadAffinitized = false, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
         {
-            return NewSession<Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>>(functions, sessionId, threadAffinitized, inputVariableLengthStructSettings);
+            return NewSession<Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>>(functions, sessionId, threadAffinitized, sessionVariableLengthStructSettings);
         }
 
         /// <summary>
@@ -145,9 +145,9 @@ namespace FASTER.core
         /// <param name="functions">Callback functions</param>
         /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
         /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-        /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
+        /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
-        public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Input, Output, Context, Functions>(Functions functions, string sessionId = null, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
+        public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Input, Output, Context, Functions>(Functions functions, string sessionId = null, bool threadAffinitized = false, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
             where Functions : IFunctions<Key, Value, Input, Output, Context>
         {
             if (functions == null)
@@ -169,7 +169,7 @@ namespace FASTER.core
             if (_activeSessions == null)
                 Interlocked.CompareExchange(ref _activeSessions, new Dictionary<string, IClientSession>(), null);
 
-            var session = new ClientSession<Key, Value, Input, Output, Context, Functions>(this, ctx, functions, !threadAffinitized, inputVariableLengthStructSettings);
+            var session = new ClientSession<Key, Value, Input, Output, Context, Functions>(this, ctx, functions, !threadAffinitized, sessionVariableLengthStructSettings);
             lock (_activeSessions)
                 _activeSessions.Add(sessionId, session);
             return session;
@@ -184,11 +184,11 @@ namespace FASTER.core
         /// <param name="sessionId">ID/name of previous session to resume</param>
         /// <param name="commitPoint">Prior commit point of durability for session</param>
         /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-        /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
+        /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
-        public ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> ResumeSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
+        public ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> ResumeSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
         {
-            return ResumeSession<Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>>(functions, sessionId, out commitPoint, threadAffinitized, inputVariableLengthStructSettings);
+            return ResumeSession<Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>>(functions, sessionId, out commitPoint, threadAffinitized, sessionVariableLengthStructSettings);
         }
 
         /// <summary>
@@ -199,10 +199,10 @@ namespace FASTER.core
         /// <param name="sessionId">ID/name of previous session to resume</param>
         /// <param name="commitPoint">Prior commit point of durability for session</param>
         /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-        /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
+        /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
 
-        public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Input, Output, Context, Functions>(Functions functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
+        public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Input, Output, Context, Functions>(Functions functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
             where Functions : IFunctions<Key, Value, Input, Output, Context>
         {
             if (functions == null)
@@ -216,7 +216,7 @@ namespace FASTER.core
                 throw new Exception($"Unable to find session {sessionId} to recover");
 
 
-            var session = new ClientSession<Key, Value, Input, Output, Context, Functions>(this, ctx, functions, !threadAffinitized, inputVariableLengthStructSettings);
+            var session = new ClientSession<Key, Value, Input, Output, Context, Functions>(this, ctx, functions, !threadAffinitized, sessionVariableLengthStructSettings);
 
             if (_activeSessions == null)
                 Interlocked.CompareExchange(ref _activeSessions, new Dictionary<string, IClientSession>(), null);

--- a/cs/src/core/ClientSession/FASTERClientSession.cs
+++ b/cs/src/core/ClientSession/FASTERClientSession.cs
@@ -42,12 +42,12 @@ namespace FASTER.core
             /// <param name="functions">Callback functions</param>
             /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
             /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-            /// <param name="variableLengthStruct">Implementation of input-specific length computation for variable-length structs</param>
+            /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(Functions functions, string sessionId = null, bool threadAffinitized = false, IVariableLengthStruct<Value, Input> variableLengthStruct = null)
+            public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(Functions functions, string sessionId = null, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
-                return _fasterKV.NewSession<Input, Output, Context, Functions>(functions, sessionId, threadAffinitized, variableLengthStruct);
+                return _fasterKV.NewSession<Input, Output, Context, Functions>(functions, sessionId, threadAffinitized, inputVariableLengthStructSettings);
             }
 
             /// <summary>
@@ -58,12 +58,12 @@ namespace FASTER.core
             /// <param name="sessionId">ID/name of previous session to resume</param>
             /// <param name="commitPoint">Prior commit point of durability for session</param>
             /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-            /// <param name="variableLengthStruct">Implementation of input-specific length computation for variable-length structs</param>
+            /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(Functions functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, IVariableLengthStruct<Value, Input> variableLengthStruct = null)
+            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(Functions functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
-                return _fasterKV.ResumeSession<Input, Output, Context, Functions>(functions, sessionId, out commitPoint, threadAffinitized, variableLengthStruct);
+                return _fasterKV.ResumeSession<Input, Output, Context, Functions>(functions, sessionId, out commitPoint, threadAffinitized, inputVariableLengthStructSettings);
             }
 
             /// <summary>
@@ -71,15 +71,15 @@ namespace FASTER.core
             /// </summary>
             /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
             /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-            /// <param name="variableLengthStruct">Implementation of input-specific length computation for variable-length structs</param>
+            /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(string sessionId = null, bool threadAffinitized = false, IVariableLengthStruct<Value, Input> variableLengthStruct = null)
+            public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(string sessionId = null, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
                 if (_functions == null)
                     throw new FasterException("Functions not provided for session");
 
-                return _fasterKV.NewSession<Input, Output, Context, Functions>((Functions)_functions, sessionId, threadAffinitized, variableLengthStruct);
+                return _fasterKV.NewSession<Input, Output, Context, Functions>((Functions)_functions, sessionId, threadAffinitized, inputVariableLengthStructSettings);
             }
 
             /// <summary>
@@ -89,15 +89,15 @@ namespace FASTER.core
             /// <param name="sessionId">ID/name of previous session to resume</param>
             /// <param name="commitPoint">Prior commit point of durability for session</param>
             /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-            /// <param name="variableLengthStruct">Implementation of input-specific length computation for variable-length structs</param>
+            /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, IVariableLengthStruct<Value, Input> variableLengthStruct = null)
+            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
                 if (_functions == null)
                     throw new FasterException("Functions not provided for session");
 
-                return _fasterKV.ResumeSession<Input, Output, Context, Functions>((Functions)_functions, sessionId, out commitPoint, threadAffinitized, variableLengthStruct);
+                return _fasterKV.ResumeSession<Input, Output, Context, Functions>((Functions)_functions, sessionId, out commitPoint, threadAffinitized, inputVariableLengthStructSettings);
             }
         }
 
@@ -132,11 +132,11 @@ namespace FASTER.core
         /// <param name="functions">Callback functions</param>
         /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
         /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-        /// <param name="variableLengthStruct">Implementation of input-specific length computation for variable-length structs</param>
+        /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
-        public ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> NewSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions, string sessionId = null, bool threadAffinitized = false, IVariableLengthStruct<Value, Input> variableLengthStruct = null)
+        public ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> NewSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions, string sessionId = null, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
         {
-            return NewSession<Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>>(functions, sessionId, threadAffinitized, variableLengthStruct);
+            return NewSession<Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>>(functions, sessionId, threadAffinitized, inputVariableLengthStructSettings);
         }
 
         /// <summary>
@@ -145,9 +145,9 @@ namespace FASTER.core
         /// <param name="functions">Callback functions</param>
         /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
         /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-        /// <param name="variableLengthStruct">Implementation of input-specific length computation for variable-length structs</param>
+        /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
-        public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Input, Output, Context, Functions>(Functions functions, string sessionId = null, bool threadAffinitized = false, IVariableLengthStruct<Value, Input> variableLengthStruct = null)
+        public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Input, Output, Context, Functions>(Functions functions, string sessionId = null, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
             where Functions : IFunctions<Key, Value, Input, Output, Context>
         {
             if (functions == null)
@@ -169,7 +169,7 @@ namespace FASTER.core
             if (_activeSessions == null)
                 Interlocked.CompareExchange(ref _activeSessions, new Dictionary<string, IClientSession>(), null);
 
-            var session = new ClientSession<Key, Value, Input, Output, Context, Functions>(this, ctx, functions, !threadAffinitized, variableLengthStruct);
+            var session = new ClientSession<Key, Value, Input, Output, Context, Functions>(this, ctx, functions, !threadAffinitized, inputVariableLengthStructSettings);
             lock (_activeSessions)
                 _activeSessions.Add(sessionId, session);
             return session;
@@ -184,11 +184,11 @@ namespace FASTER.core
         /// <param name="sessionId">ID/name of previous session to resume</param>
         /// <param name="commitPoint">Prior commit point of durability for session</param>
         /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-        /// <param name="variableLengthStruct">Implementation of input-specific length computation for variable-length structs</param>
+        /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
-        public ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> ResumeSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, IVariableLengthStruct<Value, Input> variableLengthStruct = null)
+        public ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> ResumeSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
         {
-            return ResumeSession<Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>>(functions, sessionId, out commitPoint, threadAffinitized, variableLengthStruct);
+            return ResumeSession<Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>>(functions, sessionId, out commitPoint, threadAffinitized, inputVariableLengthStructSettings);
         }
 
         /// <summary>
@@ -199,10 +199,10 @@ namespace FASTER.core
         /// <param name="sessionId">ID/name of previous session to resume</param>
         /// <param name="commitPoint">Prior commit point of durability for session</param>
         /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-        /// <param name="variableLengthStruct">Implementation of input-specific length computation for variable-length structs</param>
+        /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
 
-        public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Input, Output, Context, Functions>(Functions functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, IVariableLengthStruct<Value, Input> variableLengthStruct = null)
+        public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Input, Output, Context, Functions>(Functions functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
             where Functions : IFunctions<Key, Value, Input, Output, Context>
         {
             if (functions == null)
@@ -216,7 +216,7 @@ namespace FASTER.core
                 throw new Exception($"Unable to find session {sessionId} to recover");
 
 
-            var session = new ClientSession<Key, Value, Input, Output, Context, Functions>(this, ctx, functions, !threadAffinitized, variableLengthStruct);
+            var session = new ClientSession<Key, Value, Input, Output, Context, Functions>(this, ctx, functions, !threadAffinitized, inputVariableLengthStructSettings);
 
             if (_activeSessions == null)
                 Interlocked.CompareExchange(ref _activeSessions, new Dictionary<string, IClientSession>(), null);

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -71,7 +71,7 @@ namespace FASTER.core
             internal OperationType type;
             internal IHeapContainer<Key> key;
             internal IHeapContainer<Value> value;
-            internal Input input;
+            internal IHeapContainer<Input> input;
             internal Output output;
             internal Context userContext;
 

--- a/cs/src/core/Index/Common/HeapContainer.cs
+++ b/cs/src/core/Index/Common/HeapContainer.cs
@@ -48,7 +48,7 @@ namespace FASTER.core
     /// <typeparam name="T"></typeparam>
     internal class VarLenHeapContainer<T> : IHeapContainer<T>
     {
-        private SectorAlignedMemory mem;
+        readonly SectorAlignedMemory mem;
 
         public unsafe VarLenHeapContainer(ref T obj, IVariableLengthStruct<T> varLenStruct, SectorAlignedBufferPool pool)
         {

--- a/cs/src/core/Index/Common/VariableLengthStruct.cs
+++ b/cs/src/core/Index/Common/VariableLengthStruct.cs
@@ -66,6 +66,24 @@ namespace FASTER.core
     }
 
     /// <summary>
+    /// Input-specific settings for variable length values
+    /// </summary>
+    /// <typeparam name="Value"></typeparam>
+    /// <typeparam name="Input"></typeparam>
+    public class InputVariableLengthStructSettings<Value, Input>
+    {
+        /// <summary>
+        /// Key length
+        /// </summary>
+        public IVariableLengthStruct<Value, Input> valueLength;
+
+        /// <summary>
+        /// Value length
+        /// </summary>
+        public IVariableLengthStruct<Input> inputLength;
+    }
+
+    /// <summary>
     /// Input-specific interface for variable length in-place objects
     /// modeled as structs, in FASTER
     /// </summary>

--- a/cs/src/core/Index/Common/VariableLengthStruct.cs
+++ b/cs/src/core/Index/Common/VariableLengthStruct.cs
@@ -66,11 +66,11 @@ namespace FASTER.core
     }
 
     /// <summary>
-    /// Input-specific settings for variable length values
+    /// Session-specific settings for variable length structs
     /// </summary>
     /// <typeparam name="Value"></typeparam>
     /// <typeparam name="Input"></typeparam>
-    public class InputVariableLengthStructSettings<Value, Input>
+    public class SessionVariableLengthStructSettings<Value, Input>
     {
         /// <summary>
         /// Key length

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -190,7 +190,7 @@ namespace FASTER.core
             {
                 pendingContext.type = OperationType.READ;
                 pendingContext.key = hlog.GetKeyContainer(ref key);
-                pendingContext.input = input;
+                pendingContext.input = fasterSession.GetHeapContainer(ref input);
                 pendingContext.output = output;
                 pendingContext.userContext = userContext;
                 pendingContext.entry.word = entry.word;
@@ -780,7 +780,7 @@ namespace FASTER.core
             {
                 pendingContext.type = OperationType.RMW;
                 pendingContext.key = hlog.GetKeyContainer(ref key);
-                pendingContext.input = input;
+                pendingContext.input = fasterSession.GetHeapContainer(ref input);
                 pendingContext.userContext = userContext;
                 pendingContext.entry.word = entry.word;
                 pendingContext.logicalAddress = logicalAddress;
@@ -1185,7 +1185,7 @@ namespace FASTER.core
                 if (hlog.GetInfoFromBytePointer(request.record.GetValidPointer()).Tombstone)
                     return OperationStatus.NOTFOUND;
 
-                fasterSession.SingleReader(ref pendingContext.key.Get(), ref pendingContext.input,
+                fasterSession.SingleReader(ref pendingContext.key.Get(), ref pendingContext.input.Get(),
                                        ref hlog.GetContextRecordValue(ref request), ref pendingContext.output);
 
                 if (CopyReadsToTail || UseReadCache)
@@ -1391,7 +1391,7 @@ namespace FASTER.core
 
                 if ((request.logicalAddress >= hlog.BeginAddress) && !hlog.GetInfoFromBytePointer(request.record.GetValidPointer()).Tombstone)
                 {
-                    if (!fasterSession.NeedCopyUpdate(ref key, ref pendingContext.input, ref hlog.GetContextRecordValue(ref request)))
+                    if (!fasterSession.NeedCopyUpdate(ref key, ref pendingContext.input.Get(), ref hlog.GetContextRecordValue(ref request)))
                     {
                         return OperationStatus.SUCCESS;
                     }
@@ -1399,12 +1399,12 @@ namespace FASTER.core
 
                 if ((request.logicalAddress < hlog.BeginAddress) || (hlog.GetInfoFromBytePointer(request.record.GetValidPointer()).Tombstone))
                 {
-                    recordSize = hlog.GetInitialRecordSize(ref key, ref pendingContext.input, fasterSession);
+                    recordSize = hlog.GetInitialRecordSize(ref key, ref pendingContext.input.Get(), fasterSession);
                 }
                 else
                 {
                     physicalAddress = (long)request.record.GetValidPointer();
-                    recordSize = hlog.GetRecordSize(physicalAddress, ref pendingContext.input, fasterSession);
+                    recordSize = hlog.GetRecordSize(physicalAddress, ref pendingContext.input.Get(), fasterSession);
                 }
                 BlockAllocate(recordSize, out long newLogicalAddress, sessionCtx, fasterSession);
                 var newPhysicalAddress = hlog.GetPhysicalAddress(newLogicalAddress);
@@ -1415,14 +1415,14 @@ namespace FASTER.core
                 if ((request.logicalAddress < hlog.BeginAddress) || (hlog.GetInfoFromBytePointer(request.record.GetValidPointer()).Tombstone))
                 {
                     fasterSession.InitialUpdater(ref key,
-                                             ref pendingContext.input,
+                                             ref pendingContext.input.Get(),
                                              ref hlog.GetValue(newPhysicalAddress));
                     status = OperationStatus.NOTFOUND;
                 }
                 else
                 {
                     fasterSession.CopyUpdater(ref key,
-                                          ref pendingContext.input,
+                                          ref pendingContext.input.Get(),
                                           ref hlog.GetContextRecordValue(ref request),
                                           ref hlog.GetValue(newPhysicalAddress));
                     status = OperationStatus.SUCCESS;
@@ -1452,7 +1452,7 @@ namespace FASTER.core
 
             OperationStatus internalStatus;
             do
-                internalStatus = InternalRMW(ref pendingContext.key.Get(), ref pendingContext.input, ref pendingContext.userContext, ref pendingContext, fasterSession, opCtx, pendingContext.serialNum);
+                internalStatus = InternalRMW(ref pendingContext.key.Get(), ref pendingContext.input.Get(), ref pendingContext.userContext, ref pendingContext, fasterSession, opCtx, pendingContext.serialNum);
             while (internalStatus == OperationStatus.RETRY_NOW);
             return internalStatus;
         }
@@ -1512,7 +1512,7 @@ namespace FASTER.core
                     {
                         case OperationType.READ:
                             internalStatus = InternalRead(ref pendingContext.key.Get(),
-                                                          ref pendingContext.input,
+                                                          ref pendingContext.input.Get(),
                                                           ref pendingContext.output,
                                                           ref pendingContext.userContext,
                                                           ref pendingContext, fasterSession, currentCtx, pendingContext.serialNum);
@@ -1530,7 +1530,7 @@ namespace FASTER.core
                             break;
                         case OperationType.RMW:
                             internalStatus = InternalRMW(ref pendingContext.key.Get(),
-                                                         ref pendingContext.input,
+                                                         ref pendingContext.input.Get(),
                                                          ref pendingContext.userContext,
                                                          ref pendingContext, fasterSession, currentCtx, pendingContext.serialNum);
                             break;

--- a/cs/src/core/Index/FASTER/FASTERLegacy.cs
+++ b/cs/src/core/Index/FASTER/FASTERLegacy.cs
@@ -404,6 +404,11 @@ namespace FASTER.core
             {
                 _fasterKV._functions.UpsertCompletionCallback(ref key, ref value, ctx);
             }
+
+            public IHeapContainer<Input> GetHeapContainer(ref Input input)
+            {
+                return new StandardHeapContainer<Input>(ref input);
+            }
         }
     }
 

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -221,7 +221,7 @@ namespace FASTER.core
                 switch (pendingContext.type)
                 {
                     case OperationType.RMW:
-                        internalStatus = InternalRMW(ref key, ref pendingContext.input, ref pendingContext.userContext, ref pendingContext, fasterSession, currentCtx, pendingContext.serialNum);
+                        internalStatus = InternalRMW(ref key, ref pendingContext.input.Get(), ref pendingContext.userContext, ref pendingContext, fasterSession, currentCtx, pendingContext.serialNum);
                         break;
                     case OperationType.UPSERT:
                         internalStatus = InternalUpsert(ref key, ref pendingContext.value.Get(), ref pendingContext.userContext, ref pendingContext, fasterSession, currentCtx, pendingContext.serialNum);
@@ -255,7 +255,7 @@ namespace FASTER.core
                 {
                     case OperationType.RMW:
                         fasterSession.RMWCompletionCallback(ref key,
-                                                ref pendingContext.input,
+                                                ref pendingContext.input.Get(),
                                                 pendingContext.userContext, status);
                         break;
                     case OperationType.UPSERT:
@@ -387,7 +387,7 @@ namespace FASTER.core
                 if (pendingContext.type == OperationType.READ)
                 {
                     fasterSession.ReadCompletionCallback(ref key,
-                                                     ref pendingContext.input,
+                                                     ref pendingContext.input.Get(),
                                                      ref pendingContext.output,
                                                      pendingContext.userContext,
                                                      status);
@@ -395,7 +395,7 @@ namespace FASTER.core
                 else
                 {
                     fasterSession.RMWCompletionCallback(ref key,
-                                                    ref pendingContext.input,
+                                                    ref pendingContext.input.Get(),
                                                     pendingContext.userContext,
                                                     status);
                 }

--- a/cs/src/core/Index/Interfaces/IFasterKV.cs
+++ b/cs/src/core/Index/Interfaces/IFasterKV.cs
@@ -20,9 +20,9 @@ namespace FASTER.core
         /// <param name="functions">Callback functions.</param>
         /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
         /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-        /// <param name="variableLengthStruct">Implementation of input-specific length computation for variable-length structs</param>
+        /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
-        ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Input, Output, Context, Functions>(Functions functions, string sessionId = null, bool threadAffinitized = false, IVariableLengthStruct<Value, Input> variableLengthStruct = null)
+        ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Input, Output, Context, Functions>(Functions functions, string sessionId = null, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
             where Functions : IFunctions<Key, Value, Input, Output, Context>;
 
         /// <summary>
@@ -33,9 +33,9 @@ namespace FASTER.core
         /// <param name="sessionId">ID/name of previous session to resume</param>
         /// <param name="commitPoint">Prior commit point of durability for session</param>
         /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-        /// <param name="variableLengthStruct">Implementation of input-specific length computation for variable-length structs</param>
+        /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
-        ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Input, Output, Context, Functions>(Functions functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, IVariableLengthStruct<Value, Input> variableLengthStruct = null)
+        ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Input, Output, Context, Functions>(Functions functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
             where Functions : IFunctions<Key, Value, Input, Output, Context>;
 
         #endregion

--- a/cs/src/core/Index/Interfaces/IFasterKV.cs
+++ b/cs/src/core/Index/Interfaces/IFasterKV.cs
@@ -20,9 +20,9 @@ namespace FASTER.core
         /// <param name="functions">Callback functions.</param>
         /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
         /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-        /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
+        /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
-        ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Input, Output, Context, Functions>(Functions functions, string sessionId = null, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
+        ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Input, Output, Context, Functions>(Functions functions, string sessionId = null, bool threadAffinitized = false, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
             where Functions : IFunctions<Key, Value, Input, Output, Context>;
 
         /// <summary>
@@ -33,9 +33,9 @@ namespace FASTER.core
         /// <param name="sessionId">ID/name of previous session to resume</param>
         /// <param name="commitPoint">Prior commit point of durability for session</param>
         /// <param name="threadAffinitized">For advanced users. Specifies whether session holds the thread epoch across calls. Do not use with async code. Ensure thread calls session Refresh periodically to move the system epoch forward.</param>
-        /// <param name="inputVariableLengthStructSettings">Input-specific variable-length struct settings</param>
+        /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
-        ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Input, Output, Context, Functions>(Functions functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, InputVariableLengthStructSettings<Value, Input> inputVariableLengthStructSettings = null)
+        ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Input, Output, Context, Functions>(Functions functions, string sessionId, out CommitPoint commitPoint, bool threadAffinitized = false, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
             where Functions : IFunctions<Key, Value, Input, Output, Context>;
 
         #endregion

--- a/cs/src/core/Index/Interfaces/IFasterSession.cs
+++ b/cs/src/core/Index/Interfaces/IFasterSession.cs
@@ -21,5 +21,6 @@
     /// <typeparam name="Context"></typeparam>
     internal interface IFasterSession<Key, Value, Input, Output, Context> : IFunctions<Key, Value, Input, Output, Context>, IFasterSession, IVariableLengthStruct<Value, Input>
     {
+        IHeapContainer<Input> GetHeapContainer(ref Input input);
     }
 }


### PR DESCRIPTION
Add support for variable-length `Input` type when creating a new session, via `SessionVariableLengthStructSettings` parameter.