### PR TITLE
[C#] Allow log compaction to non-record-boundary addresses

### DIFF
--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -751,10 +751,7 @@ namespace FASTER.core
                 return 0;
 
             // Determine insertion index.
-            // ReSharper disable once CSharpWarnings::CS0420
-#pragma warning disable 420
             localTailPageOffset.PageAndOffset = Interlocked.Add(ref TailPageOffset.PageAndOffset, numSlots);
-#pragma warning restore 420
 
             int page = localTailPageOffset.Page;
             int offset = localTailPageOffset.Offset - numSlots;

--- a/cs/src/core/Allocator/BlittableScanIterator.cs
+++ b/cs/src/core/Allocator/BlittableScanIterator.cs
@@ -28,6 +28,11 @@ namespace FASTER.core
         public long CurrentAddress => currentAddress;
 
         /// <summary>
+        /// Next address
+        /// </summary>
+        public long NextAddress => nextAddress;
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="hlog"></param>

--- a/cs/src/core/Allocator/GenericScanIterator.cs
+++ b/cs/src/core/Allocator/GenericScanIterator.cs
@@ -30,6 +30,11 @@ namespace FASTER.core
         public long CurrentAddress => currentAddress;
 
         /// <summary>
+        /// Next address
+        /// </summary>
+        public long NextAddress => nextAddress;
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="hlog"></param>

--- a/cs/src/core/Allocator/IFasterScanIterator.cs
+++ b/cs/src/core/Allocator/IFasterScanIterator.cs
@@ -65,5 +65,10 @@ namespace FASTER.core
         /// Current address
         /// </summary>
         long CurrentAddress { get; }
+
+        /// <summary>
+        /// Next address
+        /// </summary>
+        long NextAddress { get; }
     }
 }

--- a/cs/src/core/Allocator/VarLenBlittableScanIterator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableScanIterator.cs
@@ -28,6 +28,11 @@ namespace FASTER.core
         public long CurrentAddress => currentAddress;
 
         /// <summary>
+        /// Next address
+        /// </summary>
+        public long NextAddress => nextAddress;
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="hlog"></param>

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -582,9 +582,10 @@ namespace FASTER.core
         /// <param name="shiftBeginAddress">Whether to shift begin address to untilAddress after compaction. To avoid
         /// data loss on failure, set this to false, and shift begin address only after taking a checkpoint. This
         /// ensures that records written to the tail during compaction are first made stable.</param>
-        public void Compact(long untilAddress, bool shiftBeginAddress)
+        /// <returns>Address until which compaction was done</returns>
+        public long Compact(long untilAddress, bool shiftBeginAddress)
         {
-            Compact(untilAddress, shiftBeginAddress, default(DefaultCompactionFunctions<Key, Value>));
+            return Compact(untilAddress, shiftBeginAddress, default(DefaultCompactionFunctions<Key, Value>));
         }
 
         /// <summary>
@@ -595,7 +596,8 @@ namespace FASTER.core
         /// <param name="compactionFunctions">User provided compaction functions (see <see cref="ICompactionFunctions{Key, Value}"/>).</param>
         /// data loss on failure, set this to false, and shift begin address only after taking a checkpoint. This
         /// ensures that records written to the tail during compaction are first made stable.</param>
-        public void Compact<CompactionFunctions>(long untilAddress, bool shiftBeginAddress, CompactionFunctions compactionFunctions)
+        /// <returns>Address until which compaction was done</returns>
+        public long Compact<CompactionFunctions>(long untilAddress, bool shiftBeginAddress, CompactionFunctions compactionFunctions)
             where CompactionFunctions : ICompactionFunctions<Key, Value>
         {
             if (!SupportAsync)
@@ -612,7 +614,7 @@ namespace FASTER.core
                 };
             }
 
-            fht.Log.Compact(this, functions, compactionFunctions, untilAddress, vl, shiftBeginAddress);
+            return fht.Log.Compact(this, functions, compactionFunctions, untilAddress, vl, shiftBeginAddress);
         }
 
         /// <summary>

--- a/cs/src/core/Index/FASTER/FASTERIterator.cs
+++ b/cs/src/core/Index/FASTER/FASTERIterator.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-#pragma warning disable 0162
-
-using System;
 
 namespace FASTER.core
 {
@@ -98,6 +95,8 @@ namespace FASTER.core
         }
 
         public long CurrentAddress => enumerationPhase == 0 ? iter1.CurrentAddress : iter2.CurrentAddress;
+
+        public long NextAddress => enumerationPhase == 0 ? iter1.NextAddress : iter2.NextAddress;
 
         public void Dispose()
         {

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -53,7 +53,7 @@ namespace FASTER.core
         public long BeginAddress => allocator.BeginAddress;
 
         /// <summary>
-        /// Truncate the log until, but not including, untilAddress
+        /// Truncate the log until, but not including, untilAddress. Make sure address corresponds to record boundary.
         /// </summary>
         /// <param name="untilAddress"></param>
         public void ShiftBeginAddress(long untilAddress)
@@ -146,7 +146,7 @@ namespace FASTER.core
         }
 
         /// <summary>
-        /// Scan the log given address range
+        /// Scan the log given address range, returns all records with address less than endAddress
         /// </summary>
         /// <param name="beginAddress"></param>
         /// <param name="endAddress"></param>
@@ -197,8 +197,9 @@ namespace FASTER.core
         /// <param name="shiftBeginAddress">Whether to shift begin address to untilAddress after compaction. To avoid
         /// data loss on failure, set this to false, and shift begin address only after taking a checkpoint. This
         /// ensures that records written to the tail during compaction are first made stable.</param>
+        /// <returns>Address until which compaction was done</returns>
         [Obsolete("Invoke Compact() on a client session (ClientSession) instead")]
-        public void Compact(long untilAddress, bool shiftBeginAddress)
+        public long Compact(long untilAddress, bool shiftBeginAddress)
         {
             if (allocator is VariableLengthBlittableAllocator<Key, Value> varLen)
             {
@@ -207,14 +208,14 @@ namespace FASTER.core
                 {
                     MethodInfo method = GetType().GetMethod("CompactReadOnly", BindingFlags.NonPublic | BindingFlags.Instance);
                     MethodInfo generic = method.MakeGenericMethod(typeof(Key).GetGenericArguments()[0]);
-                    generic.Invoke(this, new object[] { untilAddress, shiftBeginAddress });
+                    return (long)generic.Invoke(this, new object[] { untilAddress, shiftBeginAddress });
                 }
                 else if (typeof(Key).IsGenericType && (typeof(Key).GetGenericTypeDefinition() == typeof(Memory<>)) && Utility.IsBlittableType(typeof(Key).GetGenericArguments()[0])
                     && typeof(Value).IsGenericType && (typeof(Value).GetGenericTypeDefinition() == typeof(Memory<>)) && Utility.IsBlittableType(typeof(Value).GetGenericArguments()[0]))
                 {
                     MethodInfo method = GetType().GetMethod("CompactMemory", BindingFlags.NonPublic | BindingFlags.Instance);
                     MethodInfo generic = method.MakeGenericMethod(typeof(Key).GetGenericArguments()[0]);
-                    generic.Invoke(this, new object[] { untilAddress, shiftBeginAddress });
+                    return (long)generic.Invoke(this, new object[] { untilAddress, shiftBeginAddress });
                 }
                 else
                 {
@@ -225,12 +226,12 @@ namespace FASTER.core
                         valueLength = varLen.ValueLength,
                     };
 
-                    Compact(functions, default(DefaultVariableCompactionFunctions<Key, Value>), untilAddress, variableLengthStructSettings, shiftBeginAddress);
+                    return Compact(functions, default(DefaultVariableCompactionFunctions<Key, Value>), untilAddress, variableLengthStructSettings, shiftBeginAddress);
                 }
             }
             else
             {
-                Compact(new LogCompactFunctions<Key, Value, DefaultCompactionFunctions<Key, Value>>(default), default(DefaultCompactionFunctions<Key, Value>), untilAddress, null, shiftBeginAddress);
+                return Compact(new LogCompactFunctions<Key, Value, DefaultCompactionFunctions<Key, Value>>(default), default(DefaultCompactionFunctions<Key, Value>), untilAddress, null, shiftBeginAddress);
             }
         }
 
@@ -242,8 +243,9 @@ namespace FASTER.core
         /// <param name="shiftBeginAddress">Whether to shift begin address to untilAddress after compaction. To avoid
         /// data loss on failure, set this to false, and shift begin address only after taking a checkpoint. This
         /// ensures that records written to the tail during compaction are first made stable.</param>
+        /// <returns>Address until which compaction was done</returns>
         [Obsolete("Invoke Compact() on a client session (ClientSession) instead")]
-        public void Compact<CompactionFunctions>(CompactionFunctions compactionFunctions, long untilAddress, bool shiftBeginAddress)
+        public long Compact<CompactionFunctions>(CompactionFunctions compactionFunctions, long untilAddress, bool shiftBeginAddress)
             where CompactionFunctions : ICompactionFunctions<Key, Value>
         {
             if (allocator is VariableLengthBlittableAllocator<Key, Value> varLen)
@@ -255,23 +257,23 @@ namespace FASTER.core
                     valueLength = varLen.ValueLength,
                 };
 
-                Compact(functions, compactionFunctions, untilAddress, variableLengthStructSettings, shiftBeginAddress);
+                return Compact(functions, compactionFunctions, untilAddress, variableLengthStructSettings, shiftBeginAddress);
             }
             else
             {
-                Compact(new LogCompactFunctions<Key, Value, CompactionFunctions>(compactionFunctions), compactionFunctions, untilAddress, null, shiftBeginAddress);
+                return Compact(new LogCompactFunctions<Key, Value, CompactionFunctions>(compactionFunctions), compactionFunctions, untilAddress, null, shiftBeginAddress);
             }
         }
 
-        private unsafe void Compact<Functions, CompactionFunctions>(Functions functions, CompactionFunctions cf, long untilAddress, VariableLengthStructSettings<Key, Value> variableLengthStructSettings, bool shiftBeginAddress)
+        private unsafe long Compact<Functions, CompactionFunctions>(Functions functions, CompactionFunctions cf, long untilAddress, VariableLengthStructSettings<Key, Value> variableLengthStructSettings, bool shiftBeginAddress)
             where Functions : IFunctions<Key, Value, Empty, Empty, Empty>
             where CompactionFunctions : ICompactionFunctions<Key, Value>
         {
             using var fhtSession = fht.NewSession<Empty, Empty, Empty, Functions>(functions);
-            Compact(fhtSession, functions, cf, untilAddress, variableLengthStructSettings, shiftBeginAddress);
+            return Compact(fhtSession, functions, cf, untilAddress, variableLengthStructSettings, shiftBeginAddress);
         }
 
-        internal unsafe void Compact<Input, Output, Context, Functions, CompactionFunctions>(
+        internal unsafe long Compact<Input, Output, Context, Functions, CompactionFunctions>(
             ClientSession<Key, Value, Input, Output, Context, Functions> fhtSession,
             Functions functions, CompactionFunctions cf, long untilAddress, VariableLengthStructSettings<Key, Value> variableLengthStructSettings, bool shiftBeginAddress)
             where Functions : IFunctions<Key, Value, Input, Output, Context>
@@ -294,6 +296,8 @@ namespace FASTER.core
                         else
                             tempKvSession.Upsert(ref key, ref value, default, 0);
                     }
+                    // Ensure address is at record boundary
+                    untilAddress = originalUntilAddress = iter1.NextAddress;
                 }
 
                 // TODO: Scan until SafeReadOnlyAddress
@@ -338,6 +342,8 @@ namespace FASTER.core
 
             if (shiftBeginAddress)
                 ShiftBeginAddress(originalUntilAddress);
+
+            return originalUntilAddress;
         }
 
         private void LogScanForValidity<Input, Output, Context, Functions>(ref long untilAddress, ref long scanUntil, ClientSession<Key, Value, Input, Output, Context, Functions> tempKvSession)
@@ -359,7 +365,7 @@ namespace FASTER.core
         }
 
 #pragma warning disable IDE0051 // Remove unused private members
-        private void CompactReadOnly<T>(long untilAddress, bool shiftBeginAddress) where T : unmanaged
+        private long CompactReadOnly<T>(long untilAddress, bool shiftBeginAddress) where T : unmanaged
         {
             if (allocator is VariableLengthBlittableAllocator<ReadOnlyMemory<T>, Memory<T>> varLen)
             {
@@ -370,11 +376,12 @@ namespace FASTER.core
                     valueLength = varLen.ValueLength,
                 };
 
-                (this as LogAccessor<ReadOnlyMemory<T>, Memory<T>>).Compact(functions, default(DefaultReadOnlyMemoryCompactionFunctions<T>), untilAddress, variableLengthStructSettings, shiftBeginAddress);
+                return (this as LogAccessor<ReadOnlyMemory<T>, Memory<T>>).Compact(functions, default(DefaultReadOnlyMemoryCompactionFunctions<T>), untilAddress, variableLengthStructSettings, shiftBeginAddress);
             }
+            throw new FasterException("Unexpected condition during log compaction");
         }
 
-        private void CompactMemory<T>(long untilAddress, bool shiftBeginAddress)
+        private long CompactMemory<T>(long untilAddress, bool shiftBeginAddress)
             where T : unmanaged
         {
             if (allocator is VariableLengthBlittableAllocator<Memory<T>, Memory<T>> varLen)
@@ -386,8 +393,9 @@ namespace FASTER.core
                     valueLength = varLen.ValueLength,
                 };
 
-                (this as LogAccessor<Memory<T>, Memory<T>>).Compact(functions, default(DefaultMemoryCompactionFunctions<T>), untilAddress, variableLengthStructSettings, shiftBeginAddress);
+                return (this as LogAccessor<Memory<T>, Memory<T>>).Compact(functions, default(DefaultMemoryCompactionFunctions<T>), untilAddress, variableLengthStructSettings, shiftBeginAddress);
             }
+            throw new FasterException("Unexpected condition during log compaction");
         }
 #pragma warning restore IDE0051 // Remove unused private members
     }

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -53,11 +53,15 @@ namespace FASTER.core
         public long BeginAddress => allocator.BeginAddress;
 
         /// <summary>
-        /// Truncate the log until, but not including, untilAddress. Make sure address corresponds to record boundary.
+        /// Truncate the log until, but not including, untilAddress. Make sure address corresponds to record boundary if snapToPageStart is set to false.
         /// </summary>
-        /// <param name="untilAddress"></param>
-        public void ShiftBeginAddress(long untilAddress)
+        /// <param name="untilAddress">Address to shift begin address until</param>
+        /// <param name="snapToPageStart">Whether given address should be snapped to nearest earlier page start address</param>
+        public void ShiftBeginAddress(long untilAddress, bool snapToPageStart = false)
         {
+            if (snapToPageStart)
+                untilAddress &= ~allocator.PageSizeMask;
+
             allocator.ShiftBeginAddress(untilAddress);
         }
 

--- a/cs/test/BlittableLogCompactionTests.cs
+++ b/cs/test/BlittableLogCompactionTests.cs
@@ -57,7 +57,7 @@ namespace FASTER.test
                 session.Upsert(ref key1, ref value, 0, 0);
             }
 
-            session.Compact(compactUntil, true);
+            compactUntil = session.Compact(compactUntil, true);
             Assert.IsTrue(fht.Log.BeginAddress == compactUntil);
 
             // Read 2000 keys - all should be present
@@ -112,7 +112,7 @@ namespace FASTER.test
             fht.Log.Flush(true);
 
             var tail = fht.Log.TailAddress;
-            session.Compact(compactUntil, true);
+            compactUntil = session.Compact(compactUntil, true);
             Assert.IsTrue(fht.Log.BeginAddress == compactUntil);
             Assert.IsTrue(fht.Log.TailAddress == tail);
 
@@ -165,7 +165,7 @@ namespace FASTER.test
             }
 
             var tail = fht.Log.TailAddress;
-            session.Compact(compactUntil, true);
+            compactUntil = session.Compact(compactUntil, true);
             Assert.IsTrue(fht.Log.BeginAddress == compactUntil);
 
             // Read 2000 keys - all should be present
@@ -220,7 +220,7 @@ namespace FASTER.test
             var tail = fht.Log.TailAddress;
 
             // Only leave records with even vfield1
-            session.Compact(compactUntil, true, default(EvenCompactionFunctions));
+            compactUntil = session.Compact(compactUntil, true, default(EvenCompactionFunctions));
             Assert.IsTrue(fht.Log.BeginAddress == compactUntil);
 
             // Read 2000 keys - all should be present

--- a/cs/test/GenericLogCompactionTests.cs
+++ b/cs/test/GenericLogCompactionTests.cs
@@ -64,7 +64,7 @@ namespace FASTER.test
                 session.Upsert(ref key1, ref value, 0, 0);
             }
 
-            session.Compact(compactUntil, true);
+            compactUntil = session.Compact(compactUntil, true);
             Assert.IsTrue(fht.Log.BeginAddress == compactUntil);
 
             // Read 2000 keys - all should be present
@@ -116,7 +116,7 @@ namespace FASTER.test
             fht.Log.Flush(true);
 
             var tail = fht.Log.TailAddress;
-            session.Compact(compactUntil, true);
+            compactUntil = session.Compact(compactUntil, true);
             Assert.IsTrue(fht.Log.BeginAddress == compactUntil);
             Assert.IsTrue(fht.Log.TailAddress == tail);
 
@@ -163,7 +163,7 @@ namespace FASTER.test
                 }
             }
 
-            session.Compact(compactUntil, true);
+            compactUntil = session.Compact(compactUntil, true);
             Assert.IsTrue(fht.Log.BeginAddress == compactUntil);
 
             // Read 2000 keys - all should be present
@@ -211,7 +211,7 @@ namespace FASTER.test
                 session.Upsert(ref key1, ref value, 0, 0);
             }
 
-            session.Compact(compactUntil, true, default(EvenCompactionFunctions));
+            compactUntil = session.Compact(compactUntil, true, default(EvenCompactionFunctions));
             Assert.IsTrue(fht.Log.BeginAddress == compactUntil);
 
             // Read 2000 keys - all should be present

--- a/cs/test/MemoryLogCompactionTests.cs
+++ b/cs/test/MemoryLogCompactionTests.cs
@@ -42,13 +42,9 @@ namespace FASTER.test
 
             const int totalRecords = 2000;
             var start = fht.Log.TailAddress;
-            long compactUntil = 0;
 
             for (int i = 0; i < totalRecords; i++)
             {
-                if (i == 1000)
-                    compactUntil = fht.Log.TailAddress;
-
                 key.Span.Fill(i);
                 value.Span.Fill(i);
                 session.Upsert(key, value);
@@ -63,7 +59,9 @@ namespace FASTER.test
                 session.Delete(key); // tombstone inserted
             }
 
-            session.Compact(compactUntil, true);
+            // Compact 20% of log:
+            var compactUntil = fht.Log.BeginAddress + (fht.Log.TailAddress - fht.Log.BeginAddress) / 5;
+            compactUntil = session.Compact(compactUntil, true);
 
             Assert.IsTrue(fht.Log.BeginAddress == compactUntil);
 


### PR DESCRIPTION
`session.Compact` can now accept addresses that are not at strict record boundaries. It will return the actual address until which compaction was completed (next nearest record boundary).

For example, you can compact 20% of the log as follows:

```cs
  long compactUntil = store.Log.BeginAddress + (store.Log.TailAddress - store.Log.BeginAddress) / 5;
  compactUntil = session.Compact(compactUntil, shiftBeginAddress: false);
  await store.TakeHybridLogCheckpointAsync(CheckpointType.FoldOver);
  store.Log.ShiftBeginAddress(compactUntil);
```

See documentation [here](https://github.com/microsoft/FASTER/blob/master/docs/cs/FasterKV.md#log-compaction).

Also, added option to `ShiftBeginAddress`, to snap given address to nearest earlier page start.