### PR TITLE
Add ToC to MD files

### DIFF
--- a/docs/_docs/20-fasterkv-basics.md
+++ b/docs/_docs/20-fasterkv-basics.md
@@ -1,10 +1,38 @@
 ---
-title: "FasterKV Basics"
+title: FasterKV Basics
 permalink: /docs/fasterkv-basics/
-excerpt: "FasterKV Basics"
-last_modified_at: 2020-11-07
+excerpt: FasterKV Basics
+last_modified_at: 2020-11-07T00:00:00.000Z
 toc: true
 ---
+
+# FasterKV Basics
+
+<!-- Use markdown-toc from https://github.com/jonschlinkert to insert the Table of Contents between the toc/tocstop comments; commandline is: markdown-toc -i <this file> -->
+
+<!-- toc -->
+
+- [Introduction to FasterKV C#](#introduction-to-fasterkv-c%23)
+- [Getting FASTER](#getting-faster)
+  * [Building From Sources](#building-from-sources)
+  * [NuGet](#nuget)
+- [Basic Concepts](#basic-concepts)
+  * [FASTER Operations](#faster-operations)
+  * [Constructor](#constructor)
+    + [Constructor Parameters](#constructor-parameters)
+  * [Callback Functions](#callback-functions)
+  * [Sessions](#sessions)
+    + [Read](#read)
+    + [Upsert](#upsert)
+    + [RMW](#rmw)
+  * [Disposing](#disposing)
+- [Quick End-To-End Sample](#quick-end-to-end-sample)
+- [More Examples](#more-examples)
+- [Handling Variable Length Keys and Values](#handling-variable-length-keys-and-values)
+- [Log Compaction](#log-compaction)
+- [Checkpointing and Recovery](#checkpointing-and-recovery)
+
+<!-- tocstop -->
 
 ## Introduction to FasterKV C#
 
@@ -71,7 +99,7 @@ The total in-memory footprint of FASTER is controlled by the following parameter
 words, the size of the log is 2^B bytes, for a parameter setting of B. Note that if the log points to class key or value 
 objects, this size only includes the 8-byte reference to the object. The older part of the log is spilled to storage.
 
-Read more about managing memory in FASTER [here](../tuning).
+Read more about managing memory in FASTER in the [tuning](./23-fasterkv-tuning) guide.
 
 ### Callback Functions
 

--- a/docs/_docs/20-fasterkv-basics.md
+++ b/docs/_docs/20-fasterkv-basics.md
@@ -5,7 +5,6 @@ excerpt: FasterKV Basics
 last_modified_at: 2020-11-07T00:00:00.000Z
 toc: true
 ---
-
 # FasterKV Basics
 
 <!-- Use markdown-toc from https://github.com/jonschlinkert to insert the Table of Contents between the toc/tocstop comments; commandline is: markdown-toc -i <this file> -->
@@ -21,6 +20,8 @@ toc: true
   * [Constructor](#constructor)
     + [Constructor Parameters](#constructor-parameters)
   * [Callback Functions](#callback-functions)
+    + [IFunctions](#ifunctions)
+    + [IAdvancedFunctions](#iadvancedfunctions)
   * [Sessions](#sessions)
     + [Read](#read)
     + [Upsert](#upsert)
@@ -103,42 +104,50 @@ Read more about managing memory in FASTER in the [tuning](./23-fasterkv-tuning) 
 
 ### Callback Functions
 
-The user provides an instance of a type that implements `IFunctions<Key, Value, Input, Output, Context>`, or its corresponding 
-abstract base class `<Key, Value, Input, Output, Context>`. Apart from Key and Value, functions use three new types:
-1. `Input`: This is the type of input provided to FASTER when calling Read or RMW. It may be regarded as a parameter for the 
-Read or RMW operation. For example, with RMW, it may be the delta being accumulated into the value.
+#### IFunctions
+
+For session operations, the user provides an instance of a type that implements `IFunctions<Key, Value, Input, Output, Context>`, or one of its corresponding abstract base classes (see [FunctionsBase.cs](../../cs/src/core/Index/Interfaces/FunctionsBase.cs)):
+- `FunctionsBase<Key, Value, Input, Output, Context>`
+- `SimpleFunctions<Key, Value, Context>`, a subclass of `FunctionsBase<Key, Value, Input, Output, Context>` that uses Value for the Input and Output types.
+- `SimpleFunctions<Key, Value>`, a subclass of `SimpleFunctions<Key, Value, Context>` that uses the `Empty` struct for Context.
+
+Apart from Key and Value, the IFunctions interface is defined on three additional types:
+1. `Input`: This is the type of input provided to FASTER when calling Read or RMW. It may be regarded as a parameter for the Read or RMW operation. For example, with RMW, it may be the delta being accumulated into the value.
 2. `Output`: This is the type of the output of a Read operation. The reader copies the relevant parts of the Value to Output.
 3. `Context`: User-defined context for the operation. Use `Empty` if there is no context necesssary.
 
+`IFunctions<>` encapsulates all callbacks made by FASTER back to the caller, which are described next:
 
-`IFunctions<>` encapsulates all callbacks made by FASTER back to the caller, and are described next:
+1. SingleReader and ConcurrentReader: These are used to read from the store values and copy them to Output. Single reader can assume that there are no concurrent operations on the record.
+2. SingleWriter and ConcurrentWriter: These are used to write values to the store, from a source value. Concurrent writer can assume that there are no concurrent operations on the record.
+3. Completion callbacks: Called by FASTER when various operations complete after they have gone "pending" due to requiring IO.
+4. RMW Updaters: There are three updaters that the user specifies, InitialUpdater, InPlaceUpdater, and CopyUpdater. Together, they are used to implement the RMW operation.
 
-1. SingleReader and ConcurrentReader: These are used to read from the store values and copy them to Output. Single reader can 
-assume that there are no concurrent operations on the record.
-2. SingleWriter and ConcurrentWriter: These are used to write values to the store, from a source value. Concurrent writer can 
-assume that there are no concurrent operations on the record.
-3. Completion callbacks: Called by FASTER when various operations complete.
-4. RMW Updaters: There are three updaters that the user specifies, InitialUpdater, InPlaceUpdater, and CopyUpdater. Together, 
-they are used to implement the RMW operation.
+#### IAdvancedFunctions
 
+`IAdvancedFunctions` is a superset of `IFunctions` and provides the same methods with some additional parameters:
+- ReadCompletionCallback receives the `RecordInfo` of the record that was read.
+- Other callbacks receive the logical address of the record, which can be useful for applications such as indexing.
+
+`IAdvancedFunctions` is a separate interface; it does not inherit from `IFunctions`.
+
+As with `IFunctions`, [FunctionsBase.cs](../../cs/src/core/Index/Interfaces/FunctionsBase.cs) defines abstract base classes to provide a default implementation of `IAdvancedFunctions`, using the same names prefixed with `Advanced`.
 
 ### Sessions
 
-Once FASTER is instantiated, one issues operations to FASTER by creating logical sessions. A session represents a "mono-threaded" sequence 
-of operations issued to FASTER. There is no concurrency within a session, but different sessions may execute concurrently. Sessions do not
-need to be affinitized to threads, but if they are, FASTER can leverage the same (covered later). You create a session as follows:
+Once FASTER is instantiated, one issues operations to FASTER by creating logical sessions. A session represents a "mono-threaded" sequence of operations issued to FASTER. There is no concurrency within a session, but different sessions may execute concurrently. Sessions do not need to be affinitized to threads, but if they are, FASTER can leverage the same (covered later). You create a session as follows:
 
 ```var session = store.NewSession(new Functions());```
 
-An equivalent, but more optimized API requires you to specify the Functions type a second time (it allows us to avoid accessing the 
-session via an interface call):
+An equivalent, but more optimized API requires you to specify the Functions type a second time (it allows us to avoid accessing the session via an interface call):
 
 ```cs
 var session = store.For(new Functions()).NewSession<Functions>();
 ```
 
-You can then perform a sequence of read, upsert, and RMW operations on the session. FASTER supports sync and async versions of 
-operations. The operations are described below.
+As with the `IFunctions` and `IAdvancedFunctions` interfaces, there are separate, non-inheriting session classes that provide identical methods: `ClientSession` is returned by `NewSession` for a `Functions` class that implements `IFunctions`, and `AdvancedClientSession` is returned by `NewSession` for a `Functions` class that implements `IAdvancedFunctions`.
+
+You can then perform a sequence of read, upsert, and RMW operations on the session. FASTER supports sync and async versions of operations. The basic forms of these operations are described below; additional overloads are available.
 
 #### Read
 

--- a/docs/_docs/23-fasterkv-tuning.md
+++ b/docs/_docs/23-fasterkv-tuning.md
@@ -1,11 +1,23 @@
 ---
-title: "Tuning FasterKV"
+title: Tuning FasterKV
 permalink: /docs/fasterkv-tuning/
-excerpt: "Tuning FasterKV"
-last_modified_at: 2020-11-08
+excerpt: Tuning FasterKV
+last_modified_at: 2020-11-08T00:00:00.000Z
 toc: false
 classes: wide
 ---
+
+# Tuning FasterKV
+
+<!-- Use markdown-toc from https://github.com/jonschlinkert to insert the Table of Contents between the toc/tocstop comments; commandline is: markdown-toc -i <this file> -->
+
+<!-- toc -->
+
+- [Configuring the Hybrid Log](#configuring-the-hybrid-log)
+- [Configuring the Read Cache](#configuring-the-read-cache)
+- [Managing Hash Index Size](#managing-hash-index-size)
+
+<!-- tocstop -->
 
 ## Configuring the Hybrid Log
 
@@ -125,3 +137,4 @@ downside is more collisions and longer hash chains, leading to potentially slowe
 
 <b id="f1">[1]</b> In FASTER C++, the tag bits are read from bits 48-61 of the 64-bit hash value, instead of bits 50-63 
 in FASTER C#. Here, bit 0 stands for the least significant bit of the number.
+

--- a/docs/_docs/29-fasterkv-cpp.md
+++ b/docs/_docs/29-fasterkv-cpp.md
@@ -1,10 +1,25 @@
 ---
-title: "FasterKV C++ Port"
+title: FasterKV C++ Port
 permalink: /docs/fasterkv-cpp/
-excerpt: "FasterKV C++ Port"
-last_modified_at: 2020-11-07
+excerpt: FasterKV C++ Port
+last_modified_at: 2020-11-07T00:00:00.000Z
 toc: true
 ---
+
+# FasterKV C++ Port
+
+<!-- Use markdown-toc from https://github.com/jonschlinkert to insert the Table of Contents between the toc/tocstop comments; commandline is: markdown-toc -i <this file> -->
+
+<!-- toc -->
+
+- [Building C++ FASTER](#building-c-faster)
+  * [Building on Windows](#building-on-windows)
+  * [Building on Linux](#building-on-linux)
+  * [Other options](#other-options)
+- [Examples](#examples)
+- [Remote Device](#remote-device)
+
+<!-- tocstop -->
 
 ## Building C++ FASTER
 
@@ -108,3 +123,4 @@ for Windows.
 If you run into issues while trying to setup this device, please refer to FASTER's
 [CI](https://github.com/Microsoft/FASTER/tree/master/azure-pipelines.yml); it contains rules that setup and test
 this layer on both, Linux and Windows.
+

--- a/docs/_docs/40-fasterlog-basics.md
+++ b/docs/_docs/40-fasterlog-basics.md
@@ -1,10 +1,31 @@
 ---
-title: "FasterLog Basics"
+title: FasterLog Basics
 permalink: /docs/fasterlog-basics/
-excerpt: "FasterLog Basics"
-last_modified_at: 2020-11-08
+excerpt: FasterLog Basics
+last_modified_at: 2020-11-08T00:00:00.000Z
 toc: true
 ---
+# FasterLog Basics
+
+<!-- Use markdown-toc from https://github.com/jonschlinkert to insert the Table of Contents between the toc/tocstop comments; commandline is: markdown-toc -i <this file> -->
+
+<!-- toc -->
+
+  * [Introduction to FasterLog C#](#introduction-to-fasterlog-c%23)
+  * [Creating the Log](#creating-the-log)
+  * [Operations on FasterLog](#operations-on-fasterlog)
+    + [Enqueue](#enqueue)
+    + [Commit](#commit)
+    + [Wait-for-Commit](#wait-for-commit)
+    + [Helper: enqueue and wait for commit](#helper-enqueue-and-wait-for-commit)
+    + [Iteration](#iteration)
+    + [Iteration for Uncommitted Data (Publish/Subscribe)](#iteration-for-uncommitted-data-publishsubscribe)
+    + [Log Head Truncation](#log-head-truncation)
+    + [Random Read](#random-read)
+- [Configuring FasterLog](#configuring-fasterlog)
+- [Full API Reference](#full-api-reference)
+
+<!-- tocstop -->
 
 ## Introduction to FasterLog C#
 
@@ -342,3 +363,4 @@ async ValueTask<(byte[], int)> ReadAsync(long address, int estimatedLength = 0)
 void RefreshUncommitted(bool spinWait = false)
 
 ```
+

--- a/docs/_docs/43-fasterlog-tuning.md
+++ b/docs/_docs/43-fasterlog-tuning.md
@@ -7,6 +7,8 @@ toc: false
 classes: wide
 ---
 
+# Tuning FasterLog
+
 FasterLog may be configured using the `FasterLogSettings` input to the FasterLog constructor.
 
 ```cs

--- a/docs/_docs/46-fasterlog-samples.md
+++ b/docs/_docs/46-fasterlog-samples.md
@@ -1,15 +1,15 @@
 ---
-title: "FasterLog Samples"
+title: FasterLog Samples
 permalink: /docs/fasterlog-samples/
-excerpt: "FasterLog Samples"
-last_modified_at: 2020-11-08
+excerpt: FasterLog Samples
+last_modified_at: 2020-11-08T00:00:00.000Z
 toc: false
 classes: wide
 ---
-
 * Main FasterLog sample: [FasterLogSample](https://github.com/microsoft/FASTER/tree/master/cs/samples/FasterLogSample)
 * Publish/subscribe using FasterLog: [FasterLogPubSub](https://github.com/microsoft/FASTER/tree/master/cs/samples/FasterLogPubSub)
 * Unit tests for FasterLog:
   * [FasterLogTests](https://github.com/microsoft/FASTER/blob/master/cs/test/FasterLogTests.cs)
   * [DeviceFasterLogTests](https://github.com/microsoft/FASTER/blob/master/cs/test/DeviceFasterLogTests.cs)
   * [FasterLogResumeTests](https://github.com/microsoft/FASTER/blob/master/cs/test/FasterLogResumeTests.cs)
+

--- a/docs/_docs/84-roadmap.md
+++ b/docs/_docs/84-roadmap.md
@@ -1,11 +1,33 @@
 ---
-title: "Roadmap"
+title: Roadmap
 permalink: /docs/roadmap/
-excerpt: "Roadmap"
-last_modified_at: 2020-11-10
+excerpt: Roadmap
+last_modified_at: 2020-11-10T00:00:00.000Z
 toc: false
 classes: wide
 ---
+# Roadmap
+
+<!-- Use markdown-toc from https://github.com/jonschlinkert to insert the Table of Contents between the toc/tocstop comments; commandline is: markdown-toc -i <this file> -->
+
+<!-- toc -->
+
+- [Past and Future Work](#past-and-future-work)
+  * [Past Work](#past-work)
+    + [General](#general)
+    + [Log, Cache, and Storage](#log-cache-and-storage)
+    + [Checkpoint and Recovery](#checkpoint-and-recovery)
+  * [Ongoing and Future Work](#ongoing-and-future-work)
+- [Release Notes](#release-notes)
+    + [FASTER v2019.10.31.1](#faster-v201910311)
+    + [FASTER v2019.8.27.1](#faster-v20198271)
+    + [FASTER v2019.7.23.1](#faster-v20197231)
+    + [FASTER v2019.4.24.4](#faster-v20194244)
+    + [FASTER v2019.4.1.1](#faster-v2019411)
+    + [FASTER v2019.3.16.1 (cumulative feature list)](#faster-v20193161-cumulative-feature-list)
+- [C++ Porting Notes](#c-porting-notes)
+
+<!-- tocstop -->
 
 This is a living document containing the FASTER team's priorities as well as release notes
 for previous releases. Items refer to FASTER C# unless indicated otherwise. For C++ info, 
@@ -161,3 +183,4 @@ FASTER C++ is a fairly direct port of FASTER C# using C++ based coding and style
 * [x] Ability to resize the hash table
 * [x] C++: Added a new `value_size()` method to `RmwContext` for RCU operations: [PR](https://github.com/microsoft/FASTER/pull/145)
 * [x] Azure storage device: [PR](https://github.com/microsoft/FASTER/pull/353)
+

--- a/docs/_docs/95-research-papers.md
+++ b/docs/_docs/95-research-papers.md
@@ -1,11 +1,23 @@
 ---
-title: "Research Papers"
+title: Research Papers
 permalink: /docs/td-research-papers/
-excerpt: "Technical Details - Research Papers"
-last_modified_at: 2020-11-08
+excerpt: Technical Details - Research Papers
+last_modified_at: 2020-11-08T00:00:00.000Z
 toc: false
 classes: wide
 ---
+# Research Papers
+
+<!-- Use markdown-toc from https://github.com/jonschlinkert to insert the Table of Contents between the toc/tocstop comments; commandline is: markdown-toc -i <this file> -->
+
+<!-- toc -->
+
+- [Core FASTER System](#core-faster-system)
+- [Recovery](#recovery)
+- [Scale-Out](#scale-out)
+- [Secondary Indexing](#secondary-indexing)
+
+<!-- tocstop -->
 
 ## Core FASTER System
 
@@ -30,3 +42,4 @@ classes: wide
 [[pdf](https://badrish.net/papers/p1049-chandramouli.pdf)]
 * Dong Xie, Badrish Chandramouli, Yinan Li, Donald Kossmann. FishStore: Faster Ingestion with Subset Hashing. <i>SIGMOD 2019, Amsterdam, Netherlands, June 2019</i>
 [[pdf](https://badrish.net/papers/fishstore-sigmod19.pdf)]
+


### PR DESCRIPTION
Use markdown-toc from https://github.com/jonschlinkert to insert a Table of Contents in some docs/_doc/*.md files