### PR TITLE
Fixed GrowIndex to work correctly

### DIFF
--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -84,6 +84,10 @@ namespace FASTER.benchmark
 
         public FASTER_YcsbBenchmark(int threadCount_, int numaStyle_, string distribution_, int readPercent_, int backupOptions_)
         {
+            // Pin loading thread if it is not used for checkpointing
+            if (kPeriodicCheckpointMilliseconds <= 0)
+                Native32.AffinitizeThreadShardedNuma(0, 2);
+
             threadCount = threadCount_;
             numaStyle = numaStyle_;
             distribution = distribution_;
@@ -230,8 +234,6 @@ namespace FASTER.benchmark
 
         public unsafe void Run()
         {
-            //Native32.AffinitizeThreadShardedNuma(0, 2);
-
             RandomGenerator rng = new RandomGenerator();
 
             LoadData();

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -656,12 +656,43 @@ namespace FASTER.core
         }
 
         /// <summary>
-        /// Grow the hash index
+        /// Grow the hash index by a factor of two. Make sure to take a full checkpoint
+        /// after growth, for persistence.
         /// </summary>
-        /// <returns>Whether the request succeeded</returns>
+        /// <returns>Whether the grow completed</returns>
         public bool GrowIndex()
         {
-            return StartStateMachine(new IndexResizeStateMachine());
+            if (LightEpoch.AnyInstanceProtected())
+                throw new FasterException("Cannot use GrowIndex when using legacy or non-async sessions");
+
+            if (!StartStateMachine(new IndexResizeStateMachine())) return false;
+
+            epoch.Resume();
+
+            try
+            {
+                while (true)
+                {
+                    SystemState _systemState = SystemState.Copy(ref systemState);
+                    if (_systemState.phase == Phase.IN_PROGRESS_GROW)
+                    {
+                        SplitBuckets(0);
+                        epoch.ProtectAndDrain();
+                    }
+                    else
+                    {
+                        SystemState.RemoveIntermediate(ref _systemState);
+                        if (_systemState.phase != Phase.PREPARE_GROW && _systemState.phase != Phase.IN_PROGRESS_GROW)
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                epoch.Suspend();
+            }
         }
 
         /// <summary>

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -59,6 +59,11 @@ namespace FASTER.core
         public long IndexSize => state[resizeInfo.version].size;
 
         /// <summary>
+        /// Number of overflow buckets in use (64 bytes each)
+        /// </summary>
+        public long OverflowBucketCount => overflowBucketsAllocator.GetMaxValidAddress();
+
+        /// <summary>
         /// Comparer used by FASTER
         /// </summary>
         public IFasterEqualityComparer<Key> Comparer => comparer;

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -244,7 +244,8 @@ namespace FASTER.core
         internal long minTableSize = 16;
 
         // Allocator for the hash buckets
-        internal readonly MallocFixedPageSize<HashBucket> overflowBucketsAllocator;
+        internal MallocFixedPageSize<HashBucket> overflowBucketsAllocator;
+        internal MallocFixedPageSize<HashBucket> overflowBucketsAllocatorResize;
 
         // An array of size two, that contains the old and new versions of the hash-table
         internal InternalHashTable[] state = new InternalHashTable[2];

--- a/cs/src/core/Index/Recovery/IndexRecovery.cs
+++ b/cs/src/core/Index/Recovery/IndexRecovery.cs
@@ -39,15 +39,20 @@ namespace FASTER.core
             var token = info.info.token;
             var ht_version = resizeInfo.version;
 
-            if (state[ht_version].size != info.info.table_size)
-                throw new FasterException($"Incompatible hash table size during recovery; allocated {state[ht_version].size} buckets, recovering {info.info.table_size} buckets");
-
             // Create devices to read from using Async API
             info.main_ht_device = checkpointManager.GetIndexDevice(token);
+            var sectorSize = info.main_ht_device.SectorSize;
+
+            if (state[ht_version].size != info.info.table_size)
+            {
+                Free(ht_version);
+                Initialize(info.info.table_size, (int)sectorSize);
+            }
+
 
             BeginMainIndexRecovery(ht_version, info.main_ht_device, info.info.num_ht_bytes, isAsync);
 
-            var sectorSize = info.main_ht_device.SectorSize;
+            
             var alignedIndexSize = (uint)((info.info.num_ht_bytes + (sectorSize - 1)) & ~(sectorSize - 1));
             return alignedIndexSize;
         }

--- a/cs/src/core/Index/Synchronization/IndexResizeStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/IndexResizeStateMachine.cs
@@ -26,7 +26,8 @@ namespace FASTER.core
 
                     faster.numPendingChunksToBeSplit = numChunks;
                     faster.splitStatus = new long[numChunks];
-
+                    faster.overflowBucketsAllocatorResize = faster.overflowBucketsAllocator;
+                    faster.overflowBucketsAllocator = new MallocFixedPageSize<HashBucket>(false);
                     faster.Initialize(1 - faster.resizeInfo.version, faster.state[faster.resizeInfo.version].size * 2, faster.sectorSize);
 
                     faster.resizeInfo.version = 1 - faster.resizeInfo.version;

--- a/cs/test/RecoveryChecks.cs
+++ b/cs/test/RecoveryChecks.cs
@@ -346,10 +346,6 @@ namespace FASTER.test.recovery
                 var status = s1.Read(ref key, ref output);
                 if (status != Status.PENDING)
                     Assert.IsTrue(status == Status.OK && output == key);
-                else
-                {
-
-                }
             }
             s1.CompletePending(true);
 

--- a/cs/test/RecoveryChecks.cs
+++ b/cs/test/RecoveryChecks.cs
@@ -309,5 +309,82 @@ namespace FASTER.test.recovery
                 s2.CompletePending(true);
             }
         }
+
+        [Test]
+        public async ValueTask RecoveryCheck5([Values] CheckpointType checkpointType, [Values] bool isAsync, [Values] bool useReadCache, [Values(128, 1 << 10)] int size)
+        {
+            using var fht1 = new FasterKV<long, long>
+                (size,
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 14, ReadCacheSettings = useReadCache ? new ReadCacheSettings() : null },
+                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                );
+
+            using var s1 = fht1.NewSession(new MyFunctions());
+            for (long key = 0; key < 1000; key++)
+            {
+                s1.Upsert(ref key, ref key);
+            }
+
+            if (useReadCache)
+            {
+                fht1.Log.FlushAndEvict(true);
+                for (long key = 0; key < 1000; key++)
+                {
+                    long output = default;
+                    var status = s1.Read(ref key, ref output);
+                    if (status != Status.PENDING)
+                        Assert.IsTrue(status == Status.OK && output == key);
+                }
+                s1.CompletePending(true);
+            }
+            
+            fht1.GrowIndex();
+
+            for (long key = 0; key < 1000; key++)
+            {
+                long output = default;
+                var status = s1.Read(ref key, ref output);
+                if (status != Status.PENDING)
+                    Assert.IsTrue(status == Status.OK && output == key);
+                else
+                {
+
+                }
+            }
+            s1.CompletePending(true);
+
+            var task = fht1.TakeFullCheckpointAsync(checkpointType);
+
+            using var fht2 = new FasterKV<long, long>
+                (size,
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20, ReadCacheSettings = useReadCache ? new ReadCacheSettings() : null },
+                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                );
+
+            if (isAsync)
+            {
+                await task;
+                await fht2.RecoverAsync();
+            }
+            else
+            {
+                task.GetAwaiter().GetResult();
+                fht2.Recover();
+            }
+
+            Assert.IsTrue(fht1.Log.HeadAddress == fht2.Log.HeadAddress);
+            Assert.IsTrue(fht1.Log.ReadOnlyAddress == fht2.Log.ReadOnlyAddress);
+            Assert.IsTrue(fht1.Log.TailAddress == fht2.Log.TailAddress);
+
+            using var s2 = fht2.NewSession(new MyFunctions());
+            for (long key = 0; key < 1000; key++)
+            {
+                long output = default;
+                var status = s2.Read(ref key, ref output);
+                if (status != Status.PENDING)
+                    Assert.IsTrue(status == Status.OK && output == key);
+            }
+            s2.CompletePending(true);
+        }
     }
 }


### PR DESCRIPTION
Fixed `GrowIndex()` to work correctly, and return only after index size doubling is complete. For examples on using `GrowIndex` with checkpointing, search for GrowIndex in https://github.com/microsoft/FASTER/blob/master/cs/test/RecoveryChecks.cs

Fix https://github.com/microsoft/FASTER/issues/393
