### PR TITLE
[C#] Added store.Log.FixedRecordSize API

### DIFF
--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -335,6 +335,12 @@ namespace FASTER.core
         public abstract int GetAverageRecordSize();
 
         /// <summary>
+        /// Get size of fixed (known) part of record on the main log
+        /// </summary>
+        /// <returns></returns>
+        public abstract int GetFixedRecordSize();
+
+        /// <summary>
         /// Get initial record size
         /// </summary>
         /// <param name="key"></param>

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -75,6 +75,8 @@ namespace FASTER.core
             return recordSize;
         }
 
+        public override int GetFixedRecordSize() => recordSize;
+
         public override (int, int) GetInitialRecordSize<Input, FasterSession>(ref Key key, ref Input input, FasterSession fasterSession)
         {
             return (recordSize, recordSize);

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -160,6 +160,8 @@ namespace FASTER.core
             return recordSize;
         }
 
+        public override int GetFixedRecordSize() => recordSize;
+
         public override (int, int) GetInitialRecordSize<Input, FasterSession>(ref Key key, ref Input input, FasterSession fasterSession)
         {
             return (recordSize, recordSize);

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -158,6 +158,13 @@ namespace FASTER.core
                 ((ValueLength.GetInitialLength() + kRecordAlignment - 1) & (~(kRecordAlignment - 1)));
         }
 
+        public override int GetFixedRecordSize()
+        {
+            return RecordInfo.GetLength()
+                + (fixedSizeKey ? KeyLength.GetInitialLength() : 0)
+                + (fixedSizeValue ? ValueLength.GetInitialLength() : 0);
+        }
+
         public override (int, int) GetInitialRecordSize<TInput, FasterSession>(ref Key key, ref TInput input, FasterSession fasterSession)
         {
             var actualSize = RecordInfo.GetLength() +

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -54,6 +54,14 @@ namespace FASTER.core
         public long BeginAddress => allocator.BeginAddress;
 
         /// <summary>
+        /// Get the bytes used on the primary log by every record. Does not include
+        /// the size of variable-length inline data. Note that class objects occupy
+        /// 8 bytes (reference) on the main log (i.e., the heap space occupied by
+        /// class objects is not included in the result of this call).
+        /// </summary>
+        public int FixedRecordSize => allocator.GetFixedRecordSize();
+
+        /// <summary>
         /// Truncate the log until, but not including, untilAddress. Make sure address corresponds to record boundary if snapToPageStart is set to false.
         /// </summary>
         /// <param name="untilAddress">Address to shift begin address until</param>


### PR DESCRIPTION
* Gets the size per record (only the fixed-size part) on the main log
* For C# class objects, only counts the reference size (8 bytes) and not the actual heap object size
* Does not include the size of inline variable-length struct (varlen) objects on the log
* Usage: `var size = store.Log.FixedRecordSize`