### PR TITLE
fix(iterator): null conditional dispose

### DIFF
--- a/cs/src/core/Index/FASTER/FASTERIterator.cs
+++ b/cs/src/core/Index/FASTER/FASTERIterator.cs
@@ -100,11 +100,11 @@ namespace FASTER.core
 
         public void Dispose()
         {
-            iter1.Dispose();
-            iter2.Dispose();
-            fhtSession.Dispose();
-            tempKvSession.Dispose();
-            tempKv.Dispose();
+            iter1?.Dispose();
+            iter2?.Dispose();
+            fhtSession?.Dispose();
+            tempKvSession?.Dispose();
+            tempKv?.Dispose();
         }
 
         public ref Key GetKey()


### PR DESCRIPTION
In some occasions iter2 is null, which leads to not disposing any other members. This check only disposes members when they are not null.