### PR TITLE
[C#] Support IOCP-based operations in LocalStorageDevice

### DIFF
--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -109,7 +109,7 @@ namespace FASTER.benchmark
 #endif
 
             var path = "D:\\data\\FasterYcsbBenchmark\\";
-            device = Devices.CreateLogDevice(path + "hlog", preallocateFile: true);
+            device = Devices.CreateLogDevice(path + "hlog", preallocateFile: true, useIoCompletionPort: true);
 
             if (kSmallMemoryLog)
                 store = new FasterKV<Key, Value>

--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -109,7 +109,7 @@ namespace FASTER.benchmark
 #endif
 
             var path = "D:\\data\\FasterYcsbBenchmark\\";
-            device = Devices.CreateLogDevice(path + "hlog", preallocateFile: true, useIoCompletionPort: true);
+            device = Devices.CreateLogDevice(path + "hlog", preallocateFile: true, useIoCompletionPort: false);
 
             if (kSmallMemoryLog)
                 store = new FasterKV<Key, Value>

--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -108,11 +108,11 @@ namespace FASTER.benchmark
             freq = Stopwatch.Frequency;
 #endif
 
-            // Increase throttle limit for higher concurrency runs
-            if (threadCount > 8) LocalStorageDevice.ThrottleLimit *= 2;
-
             var path = "D:\\data\\FasterYcsbBenchmark\\";
             device = Devices.CreateLogDevice(path + "hlog", preallocateFile: true, useIoCompletionPort: false);
+
+            // Increase throttle limit for higher concurrency runs
+            if (threadCount > 8) device.ThrottleLimit *= 2;
 
             if (kSmallMemoryLog)
                 store = new FasterKV<Key, Value>

--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -108,6 +108,9 @@ namespace FASTER.benchmark
             freq = Stopwatch.Frequency;
 #endif
 
+            // Increase throttle limit for higher concurrency runs
+            if (threadCount > 8) LocalStorageDevice.ThrottleLimit *= 2;
+
             var path = "D:\\data\\FasterYcsbBenchmark\\";
             device = Devices.CreateLogDevice(path + "hlog", preallocateFile: true, useIoCompletionPort: false);
 
@@ -302,6 +305,10 @@ namespace FASTER.benchmark
                 store.CompleteCheckpointAsync().GetAwaiter().GetResult();
                 Console.WriteLine("Completed checkpoint");
             }
+
+            // Flush and evict log from main memory
+            if (kSmallMemoryLog)
+                store.Log.FlushAndEvict(true);
 
             // Uncomment below to dispose log from memory, use for 100% read workloads only
             // store.Log.DisposeFromMemory();

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -915,6 +915,11 @@ namespace FASTER.core
             device.TruncateUntilAddress(toAddress);
         }
 
+        internal virtual bool TryComplete()
+        {
+            return device.TryComplete();
+        }
+
         /// <summary>
         /// Seal: make sure there are no longer any threads writing to the page
         /// Flush: send page to secondary store
@@ -1514,6 +1519,7 @@ namespace FASTER.core
             {
                 while (device.Throttle())
                 {
+                    device.TryComplete();
                     Thread.Yield();
                     epoch.ProtectAndDrain();
                 }

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -172,6 +172,13 @@ namespace FASTER.core
             return (recordSize, recordSize);
         }
 
+        internal override bool TryComplete()
+        {
+            var b1 = objectLogDevice.TryComplete();
+            var b2 = base.TryComplete();
+            return b1 || b2;
+        }
+
         /// <summary>
         /// Dispose memory allocator
         /// </summary>

--- a/cs/src/core/Device/Devices.cs
+++ b/cs/src/core/Device/Devices.cs
@@ -23,8 +23,9 @@ namespace FASTER.core
         /// <param name="deleteOnClose">Delete files on close</param>
         /// <param name="capacity">The maximal number of bytes this storage device can accommondate, or CAPACITY_UNSPECIFIED if there is no such limit</param>
         /// <param name="recoverDevice">Whether to recover device metadata from existing files</param>
+        /// <param name="useIoCompletionPort">Whether we use IO completion port with polling</param>
         /// <returns>Device instance</returns>
-        public static IDevice CreateLogDevice(string logPath, bool preallocateFile = false, bool deleteOnClose = false, long capacity = CAPACITY_UNSPECIFIED, bool recoverDevice = false)
+        public static IDevice CreateLogDevice(string logPath, bool preallocateFile = false, bool deleteOnClose = false, long capacity = CAPACITY_UNSPECIFIED, bool recoverDevice = false, bool useIoCompletionPort = false)
         {
             IDevice logDevice;
 
@@ -36,7 +37,7 @@ namespace FASTER.core
             else
 #endif
             {
-                logDevice = new LocalStorageDevice(logPath, preallocateFile, deleteOnClose, true, capacity, recoverDevice);
+                logDevice = new LocalStorageDevice(logPath, preallocateFile, deleteOnClose, true, capacity, recoverDevice, useIoCompletionPort);
             }
             return logDevice;
         }

--- a/cs/src/core/Device/IDevice.cs
+++ b/cs/src/core/Device/IDevice.cs
@@ -66,6 +66,12 @@ namespace FASTER.core
         void Initialize(long segmentSize, LightEpoch epoch = null);
 
         /// <summary>
+        /// Try complete async IO completions
+        /// </summary>
+        /// <returns></returns>
+        bool TryComplete();
+
+        /// <summary>
         /// Whether device should be throttled
         /// </summary>
         /// <returns></returns>

--- a/cs/src/core/Device/IDevice.cs
+++ b/cs/src/core/Device/IDevice.cs
@@ -53,6 +53,12 @@ namespace FASTER.core
         int EndSegment { get; }
 
         /// <summary>
+        /// Throttle limit (max number of pending I/Os) for this device instance. Device needs
+        /// to implement Throttle() in order to use this limit.
+        /// </summary>
+        int ThrottleLimit { get; set; }
+
+        /// <summary>
         /// Initialize device. This function is used to pass optional information that may only be known after
         /// FASTER initialization (whose constructor takes in IDevice upfront). Implementation are free to ignore
         /// information if it does not need the supplied information. Segment size of -1 is used for object log.
@@ -72,7 +78,7 @@ namespace FASTER.core
         bool TryComplete();
 
         /// <summary>
-        /// Whether device should be throttled
+        /// Whether device should be throttled at this instant (i.e., caller should stop issuing new I/Os)
         /// </summary>
         /// <returns></returns>
         bool Throttle();

--- a/cs/src/core/Device/LocalStorageDevice.cs
+++ b/cs/src/core/Device/LocalStorageDevice.cs
@@ -23,17 +23,12 @@ namespace FASTER.core
         /// are concurrently created.
         /// </summary>
         public static bool UsePrivileges = true;
-        
+
         /// <summary>
         /// Number of IO completion threads dedicated to this instance. Used only
         /// if useIoCompletionPort is set to true.
         /// </summary>
         public static int NumCompletionThreads = 1;
-
-        /// <summary>
-        /// Throttle I/O when this limit is reached
-        /// </summary>
-        public static int ThrottleLimit = 120;
 
         private readonly bool preallocateFile;
         private readonly bool deleteOnClose;
@@ -108,7 +103,7 @@ namespace FASTER.core
                 throw new FasterException("Cannot use LocalStorageDevice from non-Windows OS platform, use ManagedLocalStorageDevice instead.");
             }
 #endif
-
+            ThrottleLimit = 120;
             this.useIoCompletionPort = useIoCompletionPort;
             if (useIoCompletionPort)
             {

--- a/cs/src/core/Device/ManagedLocalStorageDevice.cs
+++ b/cs/src/core/Device/ManagedLocalStorageDevice.cs
@@ -38,6 +38,7 @@ namespace FASTER.core
             : base(filename, GetSectorSize(filename), capacity)
         {
             pool = new SectorAlignedBufferPool(1, 1);
+            ThrottleLimit = 120;
 
             string path = new FileInfo(filename).Directory.FullName;
             if (!Directory.Exists(path))
@@ -51,7 +52,7 @@ namespace FASTER.core
         }
 
         /// <inheritdoc />
-        public override bool Throttle() => numPending > 120;
+        public override bool Throttle() => numPending > ThrottleLimit;
 
         private void RecoverFiles()
         {

--- a/cs/src/core/Device/StorageDeviceBase.cs
+++ b/cs/src/core/Device/StorageDeviceBase.cs
@@ -52,6 +52,11 @@ namespace FASTER.core
         private ulong segmentSizeMask;
 
         /// <summary>
+        /// Throttle limit (max number of pending I/Os) for this device instance
+        /// </summary>
+        public int ThrottleLimit { get; set; } = int.MaxValue;
+
+        /// <summary>
         /// Instance of the epoch protection framework in the current system.
         /// A device may have internal in-memory data structure that requires epoch protection under concurrent access.
         /// </summary>

--- a/cs/src/core/Device/StorageDeviceBase.cs
+++ b/cs/src/core/Device/StorageDeviceBase.cs
@@ -283,5 +283,11 @@ namespace FASTER.core
                 TruncateUntilSegmentAsync(newStartSegment, r => { }, null);
             }
         }
+
+        /// <inheritdoc/>
+        public virtual bool TryComplete()
+        {
+            return true;
+        }
     }
 }

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -1707,6 +1707,7 @@ namespace FASTER.core
         {
             while ((logicalAddress = hlog.TryAllocate(recordSize)) == 0)
             {
+                hlog.TryComplete();
                 InternalRefresh(ctx, fasterSession);
                 Thread.Yield();
             }

--- a/cs/src/core/Index/FASTER/FASTERIterator.cs
+++ b/cs/src/core/Index/FASTER/FASTERIterator.cs
@@ -100,11 +100,11 @@ namespace FASTER.core
 
         public void Dispose()
         {
-            iter1.Dispose();
-            iter2.Dispose();
-            fhtSession.Dispose();
-            tempKvSession.Dispose();
-            tempKv.Dispose();
+            iter1?.Dispose();
+            iter2?.Dispose();
+            fhtSession?.Dispose();
+            tempKvSession?.Dispose();
+            tempKv?.Dispose();
         }
 
         public ref Key GetKey()

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -283,6 +283,8 @@ namespace FASTER.core
             FasterSession fasterSession)
             where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
         {
+            hlog.TryComplete();
+
             if (opCtx.readyResponses.Count == 0) return;
 
             while (opCtx.readyResponses.TryDequeue(out AsyncIOContext<Key, Value> request))

--- a/cs/src/core/Utilities/Native32.cs
+++ b/cs/src/core/Utilities/Native32.cs
@@ -124,6 +124,21 @@ namespace FASTER.core
             [Out] out UInt32 lpNumberOfBytesWritten,
             [In] NativeOverlapped* lpOverlapped);
 
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern IntPtr CreateIoCompletionPort(
+            [In] SafeFileHandle hFile,
+            IntPtr ExistingCompletionPort,
+            UIntPtr CompletionKey,
+            uint NumberOfConcurrentThreads);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern unsafe bool GetQueuedCompletionStatus(
+            [In] IntPtr hCompletionPort,
+            [Out] out UInt32 lpNumberOfBytesWritten,
+            [Out] out IntPtr lpCompletionKey,
+            [Out] out NativeOverlapped* lpOverlapped,
+            [In] int dwMilliseconds);
 
         internal enum EMoveMethod : uint
         {

--- a/cs/src/core/Utilities/Native32.cs
+++ b/cs/src/core/Utilities/Native32.cs
@@ -132,13 +132,12 @@ namespace FASTER.core
             uint NumberOfConcurrentThreads);
 
         [DllImport("kernel32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern unsafe bool GetQueuedCompletionStatus(
+        internal static extern bool GetQueuedCompletionStatus(
             [In] IntPtr hCompletionPort,
             [Out] out UInt32 lpNumberOfBytesWritten,
             [Out] out IntPtr lpCompletionKey,
             [Out] out NativeOverlapped* lpOverlapped,
-            [In] int dwMilliseconds);
+            [In] UInt32 dwMilliseconds);
 
         internal enum EMoveMethod : uint
         {

--- a/cs/test/SharedDirectoryTests.cs
+++ b/cs/test/SharedDirectoryTests.cs
@@ -132,7 +132,7 @@ namespace FASTER.test.recovery.sumstore
                     for (int i = 0; i < segmentIds.Count; i++)
                     {
                         var segmentId = segmentIds[i];
-                        var handle = LocalStorageDevice.CreateHandle(segmentId, disableFileBuffering: false, deleteOnClose: true, preallocateFile: false, segmentSize: -1, fileName: deviceFileName);
+                        var handle = LocalStorageDevice.CreateHandle(segmentId, disableFileBuffering: false, deleteOnClose: true, preallocateFile: false, segmentSize: -1, fileName: deviceFileName, IntPtr.Zero);
                         initialHandles[i] = new KeyValuePair<int, SafeFileHandle>(segmentId, handle);
                     }
                 }


### PR DESCRIPTION
The C# ThreadPool binding based disk I/O (`ThreadPool.Bind(handle)`) in FASTER was found to not scale well beyond around 500K ops/sec, so we have added our own implementation of I/O Completion Port based I/O handling. This is only for `LocalStorageDevice` on Windows systems. This gives excellent scalability for disk-bound use cases.

### Performance Test

*Setup*: YCSB benchmark with 250 million tuples (8 byte keys and values), database pre-loaded, 100% read workload, uniform random keys, all data served from disk (no memory used by log).

*Disk*: Dell Express Flash NVMe PM1725 3.2TB AIC

*Results*:

![image](https://user-images.githubusercontent.com/18355833/107706971-0b82e300-6c76-11eb-9846-6e6e3f07cfcf.png)
