### PR TITLE
make FasterLogScanIterator read behavior consistent in the face of iterator disposal

### DIFF
--- a/cs/src/core/Index/FasterLog/FasterLogIterator.cs
+++ b/cs/src/core/Index/FasterLog/FasterLogIterator.cs
@@ -191,6 +191,15 @@ namespace FASTER.core
         /// <returns></returns>
         public unsafe bool GetNext(out byte[] entry, out int entryLength, out long currentAddress, out long nextAddress)
         {
+            if (disposed)
+            {
+                entry = default;
+                entryLength = default;
+                currentAddress = default;
+                nextAddress = default;
+                return false;
+            }
+
             epoch.Resume();
             if (GetNextInternal(out long physicalAddress, out entryLength, out currentAddress, out nextAddress))
             {
@@ -243,6 +252,15 @@ namespace FASTER.core
         /// <returns></returns>
         public unsafe bool GetNext(MemoryPool<byte> pool, out IMemoryOwner<byte> entry, out int entryLength, out long currentAddress, out long nextAddress)
         {
+            if (disposed)
+            {
+                entry = default;
+                entryLength = default;
+                currentAddress = default;
+                nextAddress = default;
+                return false;
+            }
+
             epoch.Resume();
             if (GetNextInternal(out long physicalAddress, out entryLength, out currentAddress, out nextAddress))
             {


### PR DESCRIPTION
make FasterLogScanIterator read behavior consistent across the following two flows:

1.
    a. caller initiates GetNext
    b. Log gets disposed

2.
    a. Log gets disposed
    b. a GetNext is initiated

In flow 1 today, we get a return-value of false from GetNext, whereas
In flow 2 today, we get an ObjectDisposedException.