### PR TITLE
[C#] Performance benchmark refactor

### DIFF
--- a/cs/benchmark/ConcurrentDictionaryBenchmark.cs
+++ b/cs/benchmark/ConcurrentDictionaryBenchmark.cs
@@ -229,12 +229,12 @@ namespace FASTER.benchmark
 
             if (YcsbConstants.kPeriodicCheckpointMilliseconds <= 0)
             {
-                Thread.Sleep(TimeSpan.FromSeconds(YcsbConstants.kRunSeconds));
+                Thread.Sleep(TimeSpan.FromSeconds(testLoader.Options.RunSeconds));
             }
             else
             {
                 double runSeconds = 0;
-                while (runSeconds < YcsbConstants.kRunSeconds)
+                while (runSeconds < testLoader.Options.RunSeconds)
                 {
                     Thread.Sleep(TimeSpan.FromMilliseconds(YcsbConstants.kPeriodicCheckpointMilliseconds));
                     runSeconds += YcsbConstants.kPeriodicCheckpointMilliseconds / 1000;

--- a/cs/benchmark/FasterSpanByteYcsbBenchmark.cs
+++ b/cs/benchmark/FasterSpanByteYcsbBenchmark.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-#pragma warning disable 0162
+#pragma warning disable CS0162 // Unreachable code detected -- when switching on YcsbConstants 
 
 // Define below to enable continuous performance report for dashboard
 // #define DASHBOARD
@@ -9,90 +9,46 @@
 using FASTER.core;
 using System;
 using System.Diagnostics;
-using System.IO;
-using System.Net;
-using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace FASTER.benchmark
 {
-    public class FasterSpanByteYcsbBenchmark
+    internal class FasterSpanByteYcsbBenchmark
     {
-        public enum Op : ulong
-        {
-            Upsert = 0,
-            Read = 1,
-            ReadModifyWrite = 2
-        }
-
-#if DEBUG
-        const bool kDumpDistribution = false;
-        const bool kUseSmallData = true;
-        const bool kUseSyntheticData = true;
-        const bool kSmallMemoryLog = false;
-        const bool kAffinitizedSession = true;
-        const int kRunSeconds = 30;
-        const int kPeriodicCheckpointMilliseconds = 0;
-#else
-        const bool kDumpDistribution = false;
-        const bool kUseSmallData = false;
-        const bool kUseSyntheticData = false;
-        const bool kSmallMemoryLog = false;
-        const bool kAffinitizedSession = true;
-        const int kRunSeconds = 30;
-        const int kPeriodicCheckpointMilliseconds = 0;
-#endif
-
-        // *** Use these to backup and recover database for fast benchmark repeat runs
-        // Use BackupMode.Backup to create the backup, unless it was recovered during BackupMode.Recover
-        // Use BackupMode.Restore for fast subsequent runs
-        // Does NOT work when periodic checkpointing is turned on
-        readonly BackupMode backupMode;
-        // ***
-
-        const long kInitCount_ = kUseSmallData ? 2500480 : 250000000;
-        const long kTxnCount_ = kUseSmallData ? 10000000 : 1000000000;
-
         // Ensure sizes are aligned to chunk sizes
-        const long kInitCount = kChunkSize * (kInitCount_ / kChunkSize);
-        const long kTxnCount = kChunkSize * (kTxnCount_ / kChunkSize);
+        const long kInitCount = YcsbConstants.kChunkSize * (YcsbConstants.kInitCount / YcsbConstants.kChunkSize);
+        const long kTxnCount = YcsbConstants.kChunkSize * (YcsbConstants.kTxnCount / YcsbConstants.kChunkSize);
 
-        const int kMaxKey = kUseSmallData ? 1 << 22 : 1 << 28;
+        readonly ManualResetEventSlim waiter = new ManualResetEventSlim();
+        readonly int numaStyle;
+        readonly int readPercent;
+        readonly FunctionsSB functions;
+        readonly Input[] input_;
 
-        public const int kKeySize = 16;
-        public const int kValueSize = 100;
+        readonly KeySpanByte[] init_keys_;
+        readonly KeySpanByte[] txn_keys_;
 
-        const int kFileChunkSize = 4096;
-        const long kChunkSize = 640;
-
-        KeySpanByte[] init_keys_;
-
-        KeySpanByte[] txn_keys_;
-
-        long idx_ = 0;
-
-        Input[] input_;
         readonly IDevice device;
-
         readonly FasterKV<SpanByte, SpanByte> store;
 
+        long idx_ = 0;
         long total_ops_done = 0;
-
-        readonly int threadCount;
-        readonly int numaStyle;
-        readonly string distribution;
-        readonly int readPercent;
-        readonly FunctionsSB functions = new FunctionsSB();
-
         volatile bool done = false;
 
-        public FasterSpanByteYcsbBenchmark(int threadCount_, int numaStyle_, string distribution_, int readPercent_, int backupOptions_)
+        internal const int kKeySize = 16;
+        internal const int kValueSize = 100;
+
+        internal FasterSpanByteYcsbBenchmark(KeySpanByte[] i_keys_, KeySpanByte[] t_keys_, TestLoader testLoader)
         {
-            threadCount = threadCount_;
-            numaStyle = numaStyle_;
-            distribution = distribution_;
-            readPercent = readPercent_;
-            this.backupMode = (BackupMode)backupOptions_;
+            // Pin loading thread if it is not used for checkpointing
+            if (YcsbConstants.kPeriodicCheckpointMilliseconds <= 0)
+                Native32.AffinitizeThreadShardedNuma(0, 2);
+
+            init_keys_ = i_keys_;
+            txn_keys_ = t_keys_;
+            numaStyle = testLoader.Options.NumaStyle;
+            readPercent = testLoader.Options.ReadPercent;
+            functions = new FunctionsSB();
 
 #if DASHBOARD
             statsWritten = new AutoResetEvent[threadCount];
@@ -108,15 +64,26 @@ namespace FASTER.benchmark
             freq = Stopwatch.Frequency;
 #endif
 
-            var path = "D:\\data\\FasterYcsbBenchmark\\";
-            device = Devices.CreateLogDevice(path + "hlog", preallocateFile: true);
+            input_ = new Input[8];
+            for (int i = 0; i < 8; i++)
+                input_[i].value = i;
 
-            if (kSmallMemoryLog)
+            device = Devices.CreateLogDevice(TestLoader.DevicePath, preallocateFile: true);
+
+            if (YcsbConstants.kSmallMemoryLog)
                 store = new FasterKV<SpanByte, SpanByte>
-                    (kMaxKey / 2, new LogSettings { LogDevice = device, PreallocateLog = true, PageSizeBits = 22, SegmentSizeBits = 26, MemorySizeBits = 26 }, new CheckpointSettings { CheckPointType = CheckpointType.FoldOver, CheckpointDir = path });
+                    (YcsbConstants.kMaxKey / 2, new LogSettings { LogDevice = device, PreallocateLog = true, PageSizeBits = 22, SegmentSizeBits = 26, MemorySizeBits = 26 },
+                    new CheckpointSettings { CheckPointType = CheckpointType.FoldOver, CheckpointDir = testLoader.BackupPath });
             else
                 store = new FasterKV<SpanByte, SpanByte>
-                    (kMaxKey / 2, new LogSettings { LogDevice = device, PreallocateLog = true, MemorySizeBits = 35 }, new CheckpointSettings { CheckPointType = CheckpointType.FoldOver, CheckpointDir = path });
+                    (YcsbConstants.kMaxKey / 2, new LogSettings { LogDevice = device, PreallocateLog = true, MemorySizeBits = 35 },
+                    new CheckpointSettings { CheckPointType = CheckpointType.FoldOver, CheckpointDir = testLoader.BackupPath });
+        }
+
+        internal void Dispose()
+        {
+            store.Dispose();
+            device.Dispose();
         }
 
         private void RunYcsb(int thread_idx)
@@ -128,9 +95,10 @@ namespace FASTER.benchmark
             else
                 Native32.AffinitizeThreadShardedNuma((uint)thread_idx, 2); // assuming two NUMA sockets
 
+            waiter.Wait();
+
             Stopwatch sw = new Stopwatch();
             sw.Start();
-
 
             Span<byte> value = stackalloc byte[kValueSize];
             Span<byte> input = stackalloc byte[kValueSize];
@@ -150,19 +118,19 @@ namespace FASTER.benchmark
             int count = 0;
 #endif
 
-            var session = store.For(functions).NewSession<FunctionsSB>(null, kAffinitizedSession);
+            var session = store.For(functions).NewSession<FunctionsSB>(null, YcsbConstants.kAffinitizedSession);
 
             while (!done)
             {
-                long chunk_idx = Interlocked.Add(ref idx_, kChunkSize) - kChunkSize;
+                long chunk_idx = Interlocked.Add(ref idx_, YcsbConstants.kChunkSize) - YcsbConstants.kChunkSize;
                 while (chunk_idx >= kTxnCount)
                 {
                     if (chunk_idx == kTxnCount)
                         idx_ = 0;
-                    chunk_idx = Interlocked.Add(ref idx_, kChunkSize) - kChunkSize;
+                    chunk_idx = Interlocked.Add(ref idx_, YcsbConstants.kChunkSize) - YcsbConstants.kChunkSize;
                 }
 
-                for (long idx = chunk_idx; idx < chunk_idx + kChunkSize && !done; ++idx)
+                for (long idx = chunk_idx; idx < chunk_idx + YcsbConstants.kChunkSize && !done; ++idx)
                 {
                     Op op;
                     int r = (int)rng.Generate(100);
@@ -175,7 +143,7 @@ namespace FASTER.benchmark
 
                     if (idx % 512 == 0)
                     {
-                        if (kAffinitizedSession)
+                        if (YcsbConstants.kAffinitizedSession)
                             session.Refresh();
                         session.CompletePending(false);
                     }
@@ -236,94 +204,70 @@ namespace FASTER.benchmark
             Interlocked.Add(ref total_ops_done, reads_done + writes_done);
         }
 
-        public unsafe void Run()
+        internal unsafe (double, double) Run(TestLoader testLoader)
         {
             //Native32.AffinitizeThreadShardedNuma(0, 2);
-
-            RandomGenerator rng = new RandomGenerator();
-
-            LoadData();
-
-            input_ = new Input[8];
-            for (int i = 0; i < 8; i++)
-                input_[i].value = i;
 
 #if DASHBOARD
             var dash = new Thread(() => DoContinuousMeasurements());
             dash.Start();
 #endif
 
-            Thread[] workers = new Thread[threadCount];
+            Thread[] workers = new Thread[testLoader.Options.ThreadCount];
 
             Console.WriteLine("Executing setup.");
 
-            Stopwatch sw = new Stopwatch();
-            var storeWasRecovered = false;
-            if (this.backupMode.HasFlag(BackupMode.Restore) && kPeriodicCheckpointMilliseconds <= 0)
-            {
-                sw.Start();
-                try
-                {
-                    Console.WriteLine("Recovering FasterKV for fast restart");
-                    store.Recover();
-                    storeWasRecovered = true;
-                } catch (Exception)
-                {
-                    Console.WriteLine("Unable to recover prior store");
-                }
-                sw.Stop();
-            }
+            var storeWasRecovered = testLoader.MaybeRecoverStore(store);
+            long elapsedMs = 0;
             if (!storeWasRecovered)
             {
                 // Setup the store for the YCSB benchmark.
                 Console.WriteLine("Loading FasterKV from data");
-                for (int idx = 0; idx < threadCount; ++idx)
+                for (int idx = 0; idx < testLoader.Options.ThreadCount; ++idx)
                 {
                     int x = idx;
                     workers[idx] = new Thread(() => SetupYcsb(x));
                 }
 
-                sw.Start();
-                // Start threads.
                 foreach (Thread worker in workers)
                 {
                     worker.Start();
                 }
+
+                waiter.Set();
+                var sw = Stopwatch.StartNew();
                 foreach (Thread worker in workers)
                 {
                     worker.Join();
                 }
                 sw.Stop();
-            }
-            Console.WriteLine("Loading time: {0}ms", sw.ElapsedMilliseconds);
+                waiter.Reset();
 
-            long startTailAddress = store.Log.TailAddress;
-            Console.WriteLine("Start tail address = " + startTailAddress);
-
-            if (!storeWasRecovered && this.backupMode.HasFlag(BackupMode.Backukp) && kPeriodicCheckpointMilliseconds <= 0)
-            {
-                Console.WriteLine("Checkpointing FasterKV for fast restart");
-                store.TakeFullCheckpoint(out _);
-                store.CompleteCheckpointAsync().GetAwaiter().GetResult();
-                Console.WriteLine("Completed checkpoint");
+                elapsedMs = sw.ElapsedMilliseconds;
             }
+            double insertsPerSecond = elapsedMs == 0 ? 0 : ((double)kInitCount / elapsedMs) * 1000;
+            Console.WriteLine(TestStats.GetLoadingTimeLine(insertsPerSecond, elapsedMs));
+            Console.WriteLine(TestStats.GetAddressesLine(AddressLineNum.Before, store.Log.BeginAddress, store.Log.HeadAddress, store.Log.ReadOnlyAddress, store.Log.TailAddress));
+
+            if (!storeWasRecovered)
+                testLoader.MaybeCheckpointStore(store);
 
             // Uncomment below to dispose log from memory, use for 100% read workloads only
             // store.Log.DisposeFromMemory();
 
             idx_ = 0;
 
-            if (kDumpDistribution)
+            if (YcsbConstants.kDumpDistribution)
                 Console.WriteLine(store.DumpDistribution());
 
             // Ensure first checkpoint is fast
-            if (kPeriodicCheckpointMilliseconds > 0)
+            if (YcsbConstants.kPeriodicCheckpointMilliseconds > 0)
                 store.Log.ShiftReadOnlyAddress(store.Log.TailAddress, true);
 
             Console.WriteLine("Executing experiment.");
 
             // Run the experiment.
-            for (int idx = 0; idx < threadCount; ++idx)
+            for (int idx = 0; idx < testLoader.Options.ThreadCount; ++idx)
             {
                 int x = idx;
                 workers[idx] = new Thread(() => RunYcsb(x));
@@ -334,19 +278,20 @@ namespace FASTER.benchmark
                 worker.Start();
             }
 
+            waiter.Set();
             Stopwatch swatch = new Stopwatch();
             swatch.Start();
 
-            if (kPeriodicCheckpointMilliseconds <= 0)
+            if (YcsbConstants.kPeriodicCheckpointMilliseconds <= 0)
             {
-                Thread.Sleep(TimeSpan.FromSeconds(kRunSeconds));
+                Thread.Sleep(TimeSpan.FromSeconds(YcsbConstants.kRunSeconds));
             }
             else
             {
                 var checkpointTaken = 0;
-                while (swatch.ElapsedMilliseconds < 1000 * kRunSeconds)
+                while (swatch.ElapsedMilliseconds < 1000 * YcsbConstants.kRunSeconds)
                 {
-                    if (checkpointTaken < swatch.ElapsedMilliseconds / kPeriodicCheckpointMilliseconds)
+                    if (checkpointTaken < swatch.ElapsedMilliseconds / YcsbConstants.kPeriodicCheckpointMilliseconds)
                     {
                         if (store.TakeHybridLogCheckpoint(out _))
                         {
@@ -365,20 +310,19 @@ namespace FASTER.benchmark
             {
                 worker.Join();
             }
+            waiter.Reset();
 
 #if DASHBOARD
             dash.Join();
 #endif
 
             double seconds = swatch.ElapsedMilliseconds / 1000.0;
-            long endTailAddress = store.Log.TailAddress;
-            Console.WriteLine("End tail address = " + endTailAddress);
+            Console.WriteLine(TestStats.GetAddressesLine(AddressLineNum.After, store.Log.BeginAddress, store.Log.HeadAddress, store.Log.ReadOnlyAddress, store.Log.TailAddress));
 
-            Console.WriteLine("Total " + total_ops_done + " ops done " + " in " + seconds + " secs.");
-            Console.WriteLine("##, " + distribution + ", " + numaStyle + ", " + readPercent + ", "
-                + threadCount + ", " + total_ops_done / seconds + ", "
-                + (endTailAddress - startTailAddress));
-            device.Dispose();
+            double opsPerSecond = total_ops_done / seconds;
+            Console.WriteLine(TestStats.GetTotalOpsString(total_ops_done, seconds));
+            Console.WriteLine(TestStats.GetStatsLine(StatsLineNum.Iteration, YcsbConstants.OpsPerSec, opsPerSecond));
+            return (insertsPerSecond, opsPerSecond);
         }
 
         private void SetupYcsb(int thread_idx)
@@ -388,7 +332,9 @@ namespace FASTER.benchmark
             else
                 Native32.AffinitizeThreadShardedNuma((uint)thread_idx, 2); // assuming two NUMA sockets
 
-            var session = store.For(functions).NewSession<FunctionsSB>(null, kAffinitizedSession);
+            waiter.Wait();
+
+            var session = store.For(functions).NewSession<FunctionsSB>(null, YcsbConstants.kAffinitizedSession);
 
 #if DASHBOARD
             var tstart = Stopwatch.GetTimestamp();
@@ -400,11 +346,11 @@ namespace FASTER.benchmark
             Span<byte> value = stackalloc byte[kValueSize];
             ref SpanByte _value = ref SpanByte.Reinterpret(value);
 
-            for (long chunk_idx = Interlocked.Add(ref idx_, kChunkSize) - kChunkSize;
+            for (long chunk_idx = Interlocked.Add(ref idx_, YcsbConstants.kChunkSize) - YcsbConstants.kChunkSize;
                 chunk_idx < kInitCount;
-                chunk_idx = Interlocked.Add(ref idx_, kChunkSize) - kChunkSize)
+                chunk_idx = Interlocked.Add(ref idx_, YcsbConstants.kChunkSize) - YcsbConstants.kChunkSize)
             {
-                for (long idx = chunk_idx; idx < chunk_idx + kChunkSize; ++idx)
+                for (long idx = chunk_idx; idx < chunk_idx + YcsbConstants.kChunkSize; ++idx)
                 {
                     if (idx % 256 == 0)
                     {
@@ -504,154 +450,21 @@ namespace FASTER.benchmark
 
         #region Load Data
 
-        private unsafe void LoadDataFromFile(string filePath)
+        internal static void CreateKeyVectors(out KeySpanByte[] i_keys, out KeySpanByte[] t_keys)
         {
-            string init_filename = filePath + "/load_" + distribution + "_250M_raw.dat";
-            string txn_filename = filePath + "/run_" + distribution + "_250M_1000M_raw.dat";
-
-            long count = 0;
-            using (FileStream stream = File.Open(init_filename, FileMode.Open, FileAccess.Read,
-                FileShare.Read))
-            {
-                Console.WriteLine("loading keys from " + init_filename + " into memory...");
-                init_keys_ = new KeySpanByte[kInitCount];
-
-                byte[] chunk = new byte[kFileChunkSize];
-                GCHandle chunk_handle = GCHandle.Alloc(chunk, GCHandleType.Pinned);
-                byte* chunk_ptr = (byte*)chunk_handle.AddrOfPinnedObject();
-
-                long offset = 0;
-
-                while (true)
-                {
-                    stream.Position = offset;
-                    int size = stream.Read(chunk, 0, kFileChunkSize);
-                    for (int idx = 0; idx < size; idx += 8)
-                    {
-                        init_keys_[count].length = kKeySize - 4;
-                        init_keys_[count].value = *(long*)(chunk_ptr + idx);
-                        ++count;
-                        if (count == kInitCount)
-                            break;
-                    }
-                    if (size == kFileChunkSize)
-                        offset += kFileChunkSize;
-                    else
-                        break;
-
-                    if (count == kInitCount)
-                        break;
-                }
-
-                if (count != kInitCount)
-                {
-                    throw new InvalidDataException("Init file load fail!");
-                }
-            }
-
-            Console.WriteLine("loaded " + kInitCount + " keys.");
-
-
-            using (FileStream stream = File.Open(txn_filename, FileMode.Open, FileAccess.Read, FileShare.Read))
-            {
-                byte[] chunk = new byte[kFileChunkSize];
-                GCHandle chunk_handle = GCHandle.Alloc(chunk, GCHandleType.Pinned);
-                byte* chunk_ptr = (byte*)chunk_handle.AddrOfPinnedObject();
-
-                Console.WriteLine("loading txns from " + txn_filename + " into memory...");
-
-                txn_keys_ = new KeySpanByte[kTxnCount];
-
-                count = 0;
-                long offset = 0;
-
-                while (true)
-                {
-                    stream.Position = offset;
-                    int size = stream.Read(chunk, 0, kFileChunkSize);
-                    for (int idx = 0; idx < size; idx += 8)
-                    {
-                        txn_keys_[count].length = kKeySize - 4;
-                        txn_keys_[count].value = *(long*)(chunk_ptr + idx);
-                        ++count;
-                        if (count == kTxnCount)
-                            break;
-                    }
-                    if (size == kFileChunkSize)
-                        offset += kFileChunkSize;
-                    else
-                        break;
-
-                    if (count == kTxnCount)
-                        break;
-                }
-
-                if (count != kTxnCount)
-                {
-                    throw new InvalidDataException("Txn file load fail!" + count + ":" + kTxnCount);
-                }
-            }
-
-            Console.WriteLine("loaded " + kTxnCount + " txns.");
+            i_keys = new KeySpanByte[kInitCount];
+            t_keys = new KeySpanByte[kTxnCount];
         }
 
-        private void LoadData()
+        internal class KeySetter : IKeySetter<KeySpanByte>
         {
-            if (kUseSyntheticData)
+            public unsafe void Set(KeySpanByte[] vector, long idx, long value)
             {
-                LoadSyntheticData();
-                return;
-            }
-
-            string filePath = "C:\\ycsb_files";
-
-            if (!Directory.Exists(filePath))
-            {
-                filePath = "D:\\ycsb_files";
-            }
-            if (!Directory.Exists(filePath))
-            {
-                filePath = "E:\\ycsb_files";
-            }
-
-            if (Directory.Exists(filePath))
-            {
-                LoadDataFromFile(filePath);
-            }
-            else
-            {
-                Console.WriteLine("WARNING: Could not find YCSB directory, loading synthetic data instead");
-                LoadSyntheticData();
+                vector[idx].length = kKeySize - 4;
+                vector[idx].value = value;
             }
         }
 
-        private void LoadSyntheticData()
-        {
-            Console.WriteLine("Loading synthetic data (uniform distribution)");
-
-            init_keys_ = new KeySpanByte[kInitCount];
-            long val = 0;
-            for (int idx = 0; idx < kInitCount; idx++)
-            {
-                init_keys_[idx] = new KeySpanByte { length = kKeySize - 4, value = val++ };
-            }
-
-            Console.WriteLine("loaded " + kInitCount + " keys.");
-
-            RandomGenerator generator = new RandomGenerator();
-
-            txn_keys_ = new KeySpanByte[kTxnCount];
-
-            for (int idx = 0; idx < kTxnCount; idx++)
-            {
-                txn_keys_[idx] = new KeySpanByte { length = kKeySize - 4, value = (long)generator.Generate64(kInitCount) };
-            }
-
-            Console.WriteLine("loaded " + kTxnCount + " txns.");
-
-        }
         #endregion
-
-
     }
 }

--- a/cs/benchmark/FasterSpanByteYcsbBenchmark.cs
+++ b/cs/benchmark/FasterSpanByteYcsbBenchmark.cs
@@ -284,12 +284,12 @@ namespace FASTER.benchmark
 
             if (YcsbConstants.kPeriodicCheckpointMilliseconds <= 0)
             {
-                Thread.Sleep(TimeSpan.FromSeconds(YcsbConstants.kRunSeconds));
+                Thread.Sleep(TimeSpan.FromSeconds(testLoader.Options.RunSeconds));
             }
             else
             {
                 var checkpointTaken = 0;
-                while (swatch.ElapsedMilliseconds < 1000 * YcsbConstants.kRunSeconds)
+                while (swatch.ElapsedMilliseconds < 1000 * testLoader.Options.RunSeconds)
                 {
                     if (checkpointTaken < swatch.ElapsedMilliseconds / YcsbConstants.kPeriodicCheckpointMilliseconds)
                     {

--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-#pragma warning disable 0162
+#pragma warning disable CS0162 // Unreachable code detected -- when switching on YcsbConstants 
 
 // Define below to enable continuous performance report for dashboard
 // #define DASHBOARD
@@ -9,90 +9,43 @@
 using FASTER.core;
 using System;
 using System.Diagnostics;
-using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace FASTER.benchmark
 {
-    public class FASTER_YcsbBenchmark
+    internal class FASTER_YcsbBenchmark
     {
-        public enum Op : ulong
-        {
-            Upsert = 0,
-            Read = 1,
-            ReadModifyWrite = 2
-        }
-
-#if DEBUG
-        const bool kDumpDistribution = false;
-        const bool kUseSmallData = true;
-        const bool kUseSyntheticData = true;
-        const bool kSmallMemoryLog = false;
-        const bool kAffinitizedSession = true;
-        const int kRunSeconds = 30;
-        const int kPeriodicCheckpointMilliseconds = 0;
-#else
-        const bool kDumpDistribution = false;
-        const bool kUseSmallData = false;
-        const bool kUseSyntheticData = false;
-        const bool kSmallMemoryLog = false;
-        const bool kAffinitizedSession = true;
-        const int kRunSeconds = 30;
-        const int kPeriodicCheckpointMilliseconds = 0;
-#endif
-
-        // *** Use these to backup and recover database for fast benchmark repeat runs
-        // Use BackupMode.Backup to create the backup, unless it was recovered during BackupMode.Recover
-        // Use BackupMode.Restore for fast subsequent runs
-        // Does NOT work when periodic checkpointing is turned on
-        readonly BackupMode backupMode;
-        // ***
-
-        const long kInitCount_ = kUseSmallData ? 2500480 : 250000000;
-        const long kTxnCount_ = kUseSmallData ? 10000000 : 1000000000;
-
         // Ensure sizes are aligned to chunk sizes
-        const long kInitCount = kChunkSize * (kInitCount_ / kChunkSize);
-        const long kTxnCount = kChunkSize * (kTxnCount_ / kChunkSize);
+        const long kInitCount = YcsbConstants.kChunkSize * (YcsbConstants.kInitCount / YcsbConstants.kChunkSize);
+        const long kTxnCount = YcsbConstants.kChunkSize * (YcsbConstants.kTxnCount / YcsbConstants.kChunkSize);
 
-        const int kMaxKey = kUseSmallData ? 1 << 22 : 1 << 28;
+        readonly ManualResetEventSlim waiter = new ManualResetEventSlim();
+        readonly int numaStyle;
+        readonly int readPercent;
+        readonly Functions functions;
+        readonly Input[] input_;
 
-        const int kFileChunkSize = 4096;
-        const long kChunkSize = 640;
+        readonly Key[] init_keys_;
+        readonly Key[] txn_keys_;
 
-        Key[] init_keys_;
-
-        Key[] txn_keys_;
-
-        long idx_ = 0;
-
-        Input[] input_;
         readonly IDevice device;
-
         readonly FasterKV<Key, Value> store;
 
+        long idx_ = 0;
         long total_ops_done = 0;
-
-        readonly int threadCount;
-        readonly int numaStyle;
-        readonly string distribution;
-        readonly int readPercent;
-        readonly Functions functions = new Functions();
-
         volatile bool done = false;
 
-        public FASTER_YcsbBenchmark(int threadCount_, int numaStyle_, string distribution_, int readPercent_, int backupOptions_)
+        internal FASTER_YcsbBenchmark(Key[] i_keys_, Key[] t_keys_, TestLoader testLoader)
         {
             // Pin loading thread if it is not used for checkpointing
-            if (kPeriodicCheckpointMilliseconds <= 0)
+            if (YcsbConstants.kPeriodicCheckpointMilliseconds <= 0)
                 Native32.AffinitizeThreadShardedNuma(0, 2);
 
-            threadCount = threadCount_;
-            numaStyle = numaStyle_;
-            distribution = distribution_;
-            readPercent = readPercent_;
-            this.backupMode = (BackupMode)backupOptions_;
+            init_keys_ = i_keys_;
+            txn_keys_ = t_keys_;
+            numaStyle = testLoader.Options.NumaStyle;
+            readPercent = testLoader.Options.ReadPercent;
+            functions = new Functions();
 
 #if DASHBOARD
             statsWritten = new AutoResetEvent[threadCount];
@@ -108,18 +61,26 @@ namespace FASTER.benchmark
             freq = Stopwatch.Frequency;
 #endif
 
-            var path = "D:\\data\\FasterYcsbBenchmark\\";
-            device = Devices.CreateLogDevice(path + "hlog", preallocateFile: true, useIoCompletionPort: false);
+            input_ = new Input[8];
+            for (int i = 0; i < 8; i++)
+                input_[i].value = i;
 
-            // Increase throttle limit for higher concurrency runs
-            if (threadCount > 8) device.ThrottleLimit *= 2;
+            device = Devices.CreateLogDevice(TestLoader.DevicePath, preallocateFile: true);
 
-            if (kSmallMemoryLog)
+            if (YcsbConstants.kSmallMemoryLog)
                 store = new FasterKV<Key, Value>
-                    (kMaxKey / 2, new LogSettings { LogDevice = device, PreallocateLog = true, PageSizeBits = 22, SegmentSizeBits = 26, MemorySizeBits = 26 }, new CheckpointSettings { CheckPointType = CheckpointType.FoldOver, CheckpointDir = path });
+                    (YcsbConstants.kMaxKey / 2, new LogSettings { LogDevice = device, PreallocateLog = true, PageSizeBits = 22, SegmentSizeBits = 26, MemorySizeBits = 26 },
+                    new CheckpointSettings { CheckPointType = CheckpointType.FoldOver, CheckpointDir = testLoader.BackupPath });
             else
                 store = new FasterKV<Key, Value>
-                    (kMaxKey / 2, new LogSettings { LogDevice = device, PreallocateLog = true }, new CheckpointSettings { CheckPointType = CheckpointType.FoldOver, CheckpointDir = path });
+                    (YcsbConstants.kMaxKey / 2, new LogSettings { LogDevice = device, PreallocateLog = true },
+                    new CheckpointSettings { CheckPointType = CheckpointType.FoldOver, CheckpointDir = testLoader.BackupPath });
+        }
+
+        internal void Dispose()
+        {
+            store.Dispose();
+            device.Dispose();
         }
 
         private void RunYcsb(int thread_idx)
@@ -131,9 +92,10 @@ namespace FASTER.benchmark
             else
                 Native32.AffinitizeThreadShardedNuma((uint)thread_idx, 2); // assuming two NUMA sockets
 
+            waiter.Wait();
+
             Stopwatch sw = new Stopwatch();
             sw.Start();
-
 
             Value value = default;
             Input input = default;
@@ -149,19 +111,19 @@ namespace FASTER.benchmark
             int count = 0;
 #endif
 
-            var session = store.For(functions).NewSession<Functions>(null, kAffinitizedSession);
+            var session = store.For(functions).NewSession<Functions>(null, YcsbConstants.kAffinitizedSession);
 
             while (!done)
             {
-                long chunk_idx = Interlocked.Add(ref idx_, kChunkSize) - kChunkSize;
+                long chunk_idx = Interlocked.Add(ref idx_, YcsbConstants.kChunkSize) - YcsbConstants.kChunkSize;
                 while (chunk_idx >= kTxnCount)
                 {
                     if (chunk_idx == kTxnCount)
                         idx_ = 0;
-                    chunk_idx = Interlocked.Add(ref idx_, kChunkSize) - kChunkSize;
+                    chunk_idx = Interlocked.Add(ref idx_, YcsbConstants.kChunkSize) - YcsbConstants.kChunkSize;
                 }
 
-                for (long idx = chunk_idx; idx < chunk_idx + kChunkSize && !done; ++idx)
+                for (long idx = chunk_idx; idx < chunk_idx + YcsbConstants.kChunkSize && !done; ++idx)
                 {
                     Op op;
                     int r = (int)rng.Generate(100);
@@ -174,7 +136,7 @@ namespace FASTER.benchmark
 
                     if (idx % 512 == 0)
                     {
-                        if (kAffinitizedSession)
+                        if (YcsbConstants.kAffinitizedSession)
                             session.Refresh();
                         session.CompletePending(false);
                     }
@@ -235,97 +197,67 @@ namespace FASTER.benchmark
             Interlocked.Add(ref total_ops_done, reads_done + writes_done);
         }
 
-        public unsafe void Run()
+        internal unsafe (double, double) Run(TestLoader testLoader)
         {
-            RandomGenerator rng = new RandomGenerator();
-
-            LoadData();
-
-            input_ = new Input[8];
-            for (int i = 0; i < 8; i++)
-                input_[i].value = i;
-
 #if DASHBOARD
             var dash = new Thread(() => DoContinuousMeasurements());
             dash.Start();
 #endif
 
-            Thread[] workers = new Thread[threadCount];
+            Thread[] workers = new Thread[testLoader.Options.ThreadCount];
 
             Console.WriteLine("Executing setup.");
 
-            Stopwatch sw = new Stopwatch();
-            var storeWasRecovered = false;
-            if (this.backupMode.HasFlag(BackupMode.Restore) && kPeriodicCheckpointMilliseconds <= 0)
-            {
-                Console.WriteLine("Recovering store for fast restart");
-                sw.Start();
-                try
-                {
-                    Console.WriteLine("Recovering FasterKV for fast restart");
-                    store.Recover();
-                    storeWasRecovered = true;
-                } catch (Exception)
-                {
-                    Console.WriteLine("Unable to recover prior store");
-                }
-                sw.Stop();
-            }
+            var storeWasRecovered = testLoader.MaybeRecoverStore(store);
+            long elapsedMs = 0;
             if (!storeWasRecovered)
             {
                 // Setup the store for the YCSB benchmark.
                 Console.WriteLine("Loading FasterKV from data");
-                for (int idx = 0; idx < threadCount; ++idx)
+                for (int idx = 0; idx < testLoader.Options.ThreadCount; ++idx)
                 {
                     int x = idx;
                     workers[idx] = new Thread(() => SetupYcsb(x));
                 }
 
-                sw.Start();
-                // Start threads.
                 foreach (Thread worker in workers)
                 {
                     worker.Start();
                 }
+
+                waiter.Set();
+                var sw = Stopwatch.StartNew();
                 foreach (Thread worker in workers)
                 {
                     worker.Join();
                 }
                 sw.Stop();
+                elapsedMs = sw.ElapsedMilliseconds;
+                waiter.Reset();
             }
-            Console.WriteLine("Loading time: {0}ms", sw.ElapsedMilliseconds);
+            double insertsPerSecond = elapsedMs == 0 ? 0 : ((double)kInitCount / elapsedMs) * 1000;
+            Console.WriteLine(TestStats.GetLoadingTimeLine(insertsPerSecond, elapsedMs));
+            Console.WriteLine(TestStats.GetAddressesLine(AddressLineNum.Before, store.Log.BeginAddress, store.Log.HeadAddress, store.Log.ReadOnlyAddress, store.Log.TailAddress));
 
-            long startTailAddress = store.Log.TailAddress;
-            Console.WriteLine("Start tail address = " + startTailAddress);
-
-            if (!storeWasRecovered && this.backupMode.HasFlag(BackupMode.Backukp) && kPeriodicCheckpointMilliseconds <= 0)
-            {
-                Console.WriteLine("Checkpointing FasterKV for fast restart");
-                store.TakeFullCheckpoint(out _);
-                store.CompleteCheckpointAsync().GetAwaiter().GetResult();
-                Console.WriteLine("Completed checkpoint");
-            }
-
-            // Flush and evict log from main memory
-            if (kSmallMemoryLog)
-                store.Log.FlushAndEvict(true);
+            if (!storeWasRecovered)
+                testLoader.MaybeCheckpointStore(store);
 
             // Uncomment below to dispose log from memory, use for 100% read workloads only
             // store.Log.DisposeFromMemory();
 
             idx_ = 0;
 
-            if (kDumpDistribution)
+            if (YcsbConstants.kDumpDistribution)
                 Console.WriteLine(store.DumpDistribution());
 
             // Ensure first checkpoint is fast
-            if (kPeriodicCheckpointMilliseconds > 0)
+            if (YcsbConstants.kPeriodicCheckpointMilliseconds > 0)
                 store.Log.ShiftReadOnlyAddress(store.Log.TailAddress, true);
 
             Console.WriteLine("Executing experiment.");
 
             // Run the experiment.
-            for (int idx = 0; idx < threadCount; ++idx)
+            for (int idx = 0; idx < testLoader.Options.ThreadCount; ++idx)
             {
                 int x = idx;
                 workers[idx] = new Thread(() => RunYcsb(x));
@@ -336,19 +268,20 @@ namespace FASTER.benchmark
                 worker.Start();
             }
 
+            waiter.Set();
             Stopwatch swatch = new Stopwatch();
             swatch.Start();
 
-            if (kPeriodicCheckpointMilliseconds <= 0)
+            if (YcsbConstants.kPeriodicCheckpointMilliseconds <= 0)
             {
-                Thread.Sleep(TimeSpan.FromSeconds(kRunSeconds));
+                Thread.Sleep(TimeSpan.FromSeconds(YcsbConstants.kRunSeconds));
             }
             else
             {
                 var checkpointTaken = 0;
-                while (swatch.ElapsedMilliseconds < 1000 * kRunSeconds)
+                while (swatch.ElapsedMilliseconds < 1000 * YcsbConstants.kRunSeconds)
                 {
-                    if (checkpointTaken < swatch.ElapsedMilliseconds / kPeriodicCheckpointMilliseconds)
+                    if (checkpointTaken < swatch.ElapsedMilliseconds / YcsbConstants.kPeriodicCheckpointMilliseconds)
                     {
                         if (store.TakeHybridLogCheckpoint(out _))
                         {
@@ -367,20 +300,19 @@ namespace FASTER.benchmark
             {
                 worker.Join();
             }
+            waiter.Reset();
 
 #if DASHBOARD
             dash.Join();
 #endif
 
             double seconds = swatch.ElapsedMilliseconds / 1000.0;
-            long endTailAddress = store.Log.TailAddress;
-            Console.WriteLine("End tail address = " + endTailAddress);
+            Console.WriteLine(TestStats.GetAddressesLine(AddressLineNum.After, store.Log.BeginAddress, store.Log.HeadAddress, store.Log.ReadOnlyAddress, store.Log.TailAddress));
 
-            Console.WriteLine("Total " + total_ops_done + " ops done " + " in " + seconds + " secs.");
-            Console.WriteLine("##, " + distribution + ", " + numaStyle + ", " + readPercent + ", "
-                + threadCount + ", " + total_ops_done / seconds + ", "
-                + (endTailAddress - startTailAddress));
-            device.Dispose();
+            double opsPerSecond = total_ops_done / seconds;
+            Console.WriteLine(TestStats.GetTotalOpsString(total_ops_done, seconds));
+            Console.WriteLine(TestStats.GetStatsLine(StatsLineNum.Iteration, YcsbConstants.OpsPerSec, opsPerSecond));
+            return (insertsPerSecond, opsPerSecond);
         }
 
         private void SetupYcsb(int thread_idx)
@@ -390,7 +322,9 @@ namespace FASTER.benchmark
             else
                 Native32.AffinitizeThreadShardedNuma((uint)thread_idx, 2); // assuming two NUMA sockets
 
-            var session = store.For(functions).NewSession<Functions>(null, kAffinitizedSession);
+            waiter.Wait();
+
+            var session = store.For(functions).NewSession<Functions>(null, YcsbConstants.kAffinitizedSession);
 
 #if DASHBOARD
             var tstart = Stopwatch.GetTimestamp();
@@ -401,11 +335,11 @@ namespace FASTER.benchmark
 
             Value value = default;
 
-            for (long chunk_idx = Interlocked.Add(ref idx_, kChunkSize) - kChunkSize;
+            for (long chunk_idx = Interlocked.Add(ref idx_, YcsbConstants.kChunkSize) - YcsbConstants.kChunkSize;
                 chunk_idx < kInitCount;
-                chunk_idx = Interlocked.Add(ref idx_, kChunkSize) - kChunkSize)
+                chunk_idx = Interlocked.Add(ref idx_, YcsbConstants.kChunkSize) - YcsbConstants.kChunkSize)
             {
-                for (long idx = chunk_idx; idx < chunk_idx + kChunkSize; ++idx)
+                for (long idx = chunk_idx; idx < chunk_idx + YcsbConstants.kChunkSize; ++idx)
                 {
                     if (idx % 256 == 0)
                     {
@@ -503,154 +437,19 @@ namespace FASTER.benchmark
         }
 #endif
 
-        #region Load Data
+#region Load Data
 
-        private unsafe void LoadDataFromFile(string filePath)
+        internal static void CreateKeyVectors(out Key[] i_keys, out Key[] t_keys)
         {
-            string init_filename = filePath + "/load_" + distribution + "_250M_raw.dat";
-            string txn_filename = filePath + "/run_" + distribution + "_250M_1000M_raw.dat";
-
-            long count = 0;
-            using (FileStream stream = File.Open(init_filename, FileMode.Open, FileAccess.Read,
-                FileShare.Read))
-            {
-                Console.WriteLine("loading keys from " + init_filename + " into memory...");
-                init_keys_ = new Key[kInitCount];
-
-                byte[] chunk = new byte[kFileChunkSize];
-                GCHandle chunk_handle = GCHandle.Alloc(chunk, GCHandleType.Pinned);
-                byte* chunk_ptr = (byte*)chunk_handle.AddrOfPinnedObject();
-
-                long offset = 0;
-
-                while (true)
-                {
-                    stream.Position = offset;
-                    int size = stream.Read(chunk, 0, kFileChunkSize);
-                    for (int idx = 0; idx < size; idx += 8)
-                    {
-                        init_keys_[count].value = *(long*)(chunk_ptr + idx);
-                        ++count;
-                        if (count == kInitCount)
-                            break;
-                    }
-                    if (size == kFileChunkSize)
-                        offset += kFileChunkSize;
-                    else
-                        break;
-
-                    if (count == kInitCount)
-                        break;
-                }
-
-                if (count != kInitCount)
-                {
-                    throw new InvalidDataException("Init file load fail!");
-                }
-            }
-
-            Console.WriteLine("loaded " + kInitCount + " keys.");
-
-
-            using (FileStream stream = File.Open(txn_filename, FileMode.Open, FileAccess.Read, FileShare.Read))
-            {
-                byte[] chunk = new byte[kFileChunkSize];
-                GCHandle chunk_handle = GCHandle.Alloc(chunk, GCHandleType.Pinned);
-                byte* chunk_ptr = (byte*)chunk_handle.AddrOfPinnedObject();
-
-                Console.WriteLine("loading txns from " + txn_filename + " into memory...");
-
-                txn_keys_ = new Key[kTxnCount];
-
-                count = 0;
-                long offset = 0;
-
-                while (true)
-                {
-                    stream.Position = offset;
-                    int size = stream.Read(chunk, 0, kFileChunkSize);
-                    for (int idx = 0; idx < size; idx += 8)
-                    {
-                        txn_keys_[count].value = *(long*)(chunk_ptr + idx);
-                        ++count;
-                        if (count == kTxnCount)
-                            break;
-                    }
-                    if (size == kFileChunkSize)
-                        offset += kFileChunkSize;
-                    else
-                        break;
-
-                    if (count == kTxnCount)
-                        break;
-                }
-
-                if (count != kTxnCount)
-                {
-                    throw new InvalidDataException("Txn file load fail!" + count + ":" + kTxnCount);
-                }
-            }
-
-            Console.WriteLine("loaded " + kTxnCount + " txns.");
+            i_keys = new Key[kInitCount];
+            t_keys = new Key[kTxnCount];
         }
 
-        private void LoadData()
+        internal class KeySetter : IKeySetter<Key>
         {
-            if (kUseSyntheticData)
-            {
-                LoadSyntheticData();
-                return;
-            }
-
-            string filePath = "C:\\ycsb_files";
-
-            if (!Directory.Exists(filePath))
-            {
-                filePath = "D:\\ycsb_files";
-            }
-            if (!Directory.Exists(filePath))
-            {
-                filePath = "E:\\ycsb_files";
-            }
-
-            if (Directory.Exists(filePath))
-            {
-                LoadDataFromFile(filePath);
-            }
-            else
-            {
-                Console.WriteLine("WARNING: Could not find YCSB directory, loading synthetic data instead");
-                LoadSyntheticData();
-            }
+            public void Set(Key[] vector, long idx, long value) => vector[idx].value = value;
         }
 
-        private void LoadSyntheticData()
-        {
-            Console.WriteLine("Loading synthetic data (uniform distribution)");
-
-            init_keys_ = new Key[kInitCount];
-            long val = 0;
-            for (int idx = 0; idx < kInitCount; idx++)
-            {
-                init_keys_[idx] = new Key { value = val++ };
-            }
-
-            Console.WriteLine("loaded " + kInitCount + " keys.");
-
-            RandomGenerator generator = new RandomGenerator();
-
-            txn_keys_ = new Key[kTxnCount];
-
-            for (int idx = 0; idx < kTxnCount; idx++)
-            {
-                txn_keys_[idx] = new Key { value = (long)generator.Generate64(kInitCount) };
-            }
-
-            Console.WriteLine("loaded " + kTxnCount + " txns.");
-
-        }
-        #endregion
-
-
+#endregion
     }
 }

--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -274,12 +274,12 @@ namespace FASTER.benchmark
 
             if (YcsbConstants.kPeriodicCheckpointMilliseconds <= 0)
             {
-                Thread.Sleep(TimeSpan.FromSeconds(YcsbConstants.kRunSeconds));
+                Thread.Sleep(TimeSpan.FromSeconds(testLoader.Options.RunSeconds));
             }
             else
             {
                 var checkpointTaken = 0;
-                while (swatch.ElapsedMilliseconds < 1000 * YcsbConstants.kRunSeconds)
+                while (swatch.ElapsedMilliseconds < 1000 * testLoader.Options.RunSeconds)
                 {
                     if (checkpointTaken < swatch.ElapsedMilliseconds / YcsbConstants.kPeriodicCheckpointMilliseconds)
                     {

--- a/cs/benchmark/Functions.cs
+++ b/cs/benchmark/Functions.cs
@@ -3,11 +3,9 @@
 
 #pragma warning disable 1591
 
-using System;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
 using FASTER.core;
-using System.Collections.Generic;
 
 namespace FASTER.benchmark
 {

--- a/cs/benchmark/Options.cs
+++ b/cs/benchmark/Options.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using CommandLine;
+
+namespace FASTER.benchmark
+{
+    class Options
+    {
+        [Option('b', "benchmark", Required = false, Default = 0,
+        HelpText = "Benchmark to run:" +
+                        "\n    0 = YCSB" +
+                        "\n    1 = YCSB with SpanByte" +
+                        "\n    2 = ConcurrentDictionary")]
+        public int Benchmark { get; set; }
+
+        [Option('t', "threads", Required = false, Default = 8,
+         HelpText = "Number of threads to run the workload on")]
+        public int ThreadCount { get; set; }
+
+        [Option('n', "numa", Required = false, Default = 0,
+             HelpText = "NUMA options:" +
+                        "\n    0 = No sharding across NUMA sockets" +
+                        "\n    1 = Sharding across NUMA sockets")]
+        public int NumaStyle { get; set; }
+
+        [Option('k', "backup", Required = false, Default = false,
+             HelpText = "Enable Backup and Restore of FasterKV for fast test startup." +
+                        "\n    True = Recover FasterKV if a Checkpoint is available, else populate FasterKV from data and Checkpoint it so it can be Restored in a subsequent run" +
+                        "\n    False = Populate FasterKV from data" +
+                        "\n    Checkpoints are stored in directories under " + TestLoader.DataPath + " in directories named by distribution, ycsb vs. synthetic data, and key counts;" +
+                        "\n    to force a new checkpoint, delete the existing folder")]
+        public bool BackupAndRestore { get; set; }
+
+        [Option('i', "iterations", Required = false, Default = 1,
+         HelpText = "Number of iterations of the test to run")]
+        public int IterationCount { get; set; }
+
+        [Option('r', "read_percent", Required = false, Default = 50,
+         HelpText = "Percentage of reads (-1 for 100% read-modify-write")]
+        public int ReadPercent { get; set; }
+
+        [Option('d', "distribution", Required = false, Default = YcsbConstants.UniformDist,
+            HelpText = "Distribution of keys in workload")]
+        public string DistributionName { get; set; }
+
+        [Option('s', "seed", Required = false, Default = 211,
+            HelpText = "Seed for synthetic data distribution")]
+        public int RandomSeed { get; set; }
+
+        [Option((char)0, "sy", Required = false, Default = false,
+            HelpText = "Use synthetic data")]
+        public bool UseSyntheticData { get; set; }
+
+        public string GetOptionsString()
+        {
+            static string boolStr(bool value) => value ? "y" : "n";
+            return $"d: {DistributionName.ToLower()}; n: {NumaStyle}; r: {ReadPercent}; t: {ThreadCount};"
+                        + $" sd: {boolStr(YcsbConstants.kUseSmallData)}; sm: {boolStr(YcsbConstants.kSmallMemoryLog)}; sy: {boolStr(this.UseSyntheticData)}";
+        }
+    }
+}

--- a/cs/benchmark/Options.cs
+++ b/cs/benchmark/Options.cs
@@ -24,12 +24,11 @@ namespace FASTER.benchmark
                         "\n    1 = Sharding across NUMA sockets")]
         public int NumaStyle { get; set; }
 
-        [Option('k', "backup", Required = false, Default = false,
+        [Option('k', "recover", Required = false, Default = false,
              HelpText = "Enable Backup and Restore of FasterKV for fast test startup." +
                         "\n    True = Recover FasterKV if a Checkpoint is available, else populate FasterKV from data and Checkpoint it so it can be Restored in a subsequent run" +
-                        "\n    False = Populate FasterKV from data" +
-                        "\n    Checkpoints are stored in directories under " + TestLoader.DataPath + " in directories named by distribution, ycsb vs. synthetic data, and key counts;" +
-                        "\n    to force a new checkpoint, delete the existing folder")]
+                        "\n    False = Populate FasterKV from data and do not Checkpoint a backup" +
+                        "\n    (Checkpoints are stored in directories under " + TestLoader.DataPath + " in directories named by distribution, ycsb vs. synthetic data, and key counts)")]
         public bool BackupAndRestore { get; set; }
 
         [Option('i', "iterations", Required = false, Default = 1,
@@ -51,6 +50,10 @@ namespace FASTER.benchmark
         [Option((char)0, "sy", Required = false, Default = false,
             HelpText = "Use synthetic data")]
         public bool UseSyntheticData { get; set; }
+
+        [Option((char)0, "runsec", Required = false, Default = YcsbConstants.kRunSeconds,
+            HelpText = "Number of seconds to execute experiment")]
+        public int RunSeconds { get; set; }
 
         public string GetOptionsString()
         {

--- a/cs/benchmark/Options.cs
+++ b/cs/benchmark/Options.cs
@@ -47,11 +47,11 @@ namespace FASTER.benchmark
             HelpText = "Seed for synthetic data distribution")]
         public int RandomSeed { get; set; }
 
-        [Option((char)0, "sy", Required = false, Default = false,
+        [Option("synth", Required = false, Default = false,
             HelpText = "Use synthetic data")]
         public bool UseSyntheticData { get; set; }
 
-        [Option((char)0, "runsec", Required = false, Default = YcsbConstants.kRunSeconds,
+        [Option("runsec", Required = false, Default = YcsbConstants.kRunSeconds,
             HelpText = "Number of seconds to execute experiment")]
         public int RunSeconds { get; set; }
 

--- a/cs/benchmark/Program.cs
+++ b/cs/benchmark/Program.cs
@@ -1,80 +1,68 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using CommandLine;
 using System;
+using System.Threading;
 
 namespace FASTER.benchmark
 {
-    class Options
-    {
-        [Option('b', "benchmark", Required = false, Default = 0,
-        HelpText = "Benchmark to run (0 = YCSB)")]
-        public int Benchmark { get; set; }
-
-        [Option('t', "threads", Required = false, Default = 8,
-         HelpText = "Number of threads to run the workload on")]
-        public int ThreadCount { get; set; }
-
-        [Option('n', "numa", Required = false, Default = 0,
-             HelpText = "0 = No sharding across NUMA sockets, 1 = Sharding across NUMA sockets")]
-        public int NumaStyle { get; set; }
-
-        [Option('k', "backup", Required = false, Default = 0,
-             HelpText = "Enable Backup and Restore of FasterKV for fast test startup:" +
-                        "\n    0 = None; Populate FasterKV from data" +
-                        "\n    1 = Recover FasterKV from Checkpoint; if this fails, populate FasterKV from data" +
-                        "\n    2 = Checkpoint FasterKV (unless it was Recovered by option 1; if option 1 is not specified, this will overwrite an existing Checkpoint)" +
-                        "\n    3 = Both (Recover FasterKV if the Checkpoint is available, else populate FasterKV from data and Checkpoint it so it can be Restored in a subsequent run)")]
-        public int Backup { get; set; }
-
-        [Option('r', "read_percent", Required = false, Default = 50,
-         HelpText = "Percentage of reads (-1 for 100% read-modify-write")]
-        public int ReadPercent { get; set; }
-
-        [Option('d', "distribution", Required = false, Default = "uniform",
-            HelpText = "Distribution of keys in workload")]
-        public string Distribution { get; set; }
-    }
-
-    enum BenchmarkType : int
-    {
-        Ycsb, SpanByte, ConcurrentDictionaryYcsb
-    };
-
-    [Flags] enum BackupMode : int
-    {
-        None, Restore, Backukp, Both
-    };
-
     public class Program
     {
+        const int kTrimResultCount = 3; // Use some high value like int.MaxValue to disable
+
         public static void Main(string[] args)
         {
-            ParserResult<Options> result = Parser.Default.ParseArguments<Options>(args);
-            if (result.Tag == ParserResultType.NotParsed)
-            {
+            var testLoader = new TestLoader();
+            if (!testLoader.Parse(args))
                 return;
+
+            var testStats = new TestStats(testLoader.Options);
+            testLoader.LoadData();
+            var options = testLoader.Options;   // shortcut
+
+            for (var iter = 0; iter < options.IterationCount; ++iter)
+            {
+                Console.WriteLine();
+                if (options.IterationCount > 1)
+                    Console.WriteLine($"Iteration {iter + 1} of {options.IterationCount}");
+
+                switch (testLoader.BenchmarkType)
+                {
+                    case BenchmarkType.Ycsb:
+                        var yTest = new FASTER_YcsbBenchmark(testLoader.init_keys, testLoader.txn_keys, testLoader);
+                        testStats.AddResult(yTest.Run(testLoader));
+                        yTest.Dispose();
+                        break;
+                    case BenchmarkType.SpanByte:
+                        var sTest = new FasterSpanByteYcsbBenchmark(testLoader.init_span_keys, testLoader.txn_span_keys, testLoader);
+                        testStats.AddResult(sTest.Run(testLoader));
+                        sTest.Dispose();
+                        break;
+                    case BenchmarkType.ConcurrentDictionaryYcsb:
+                        var cTest = new ConcurrentDictionary_YcsbBenchmark(testLoader.init_keys, testLoader.txn_keys, testLoader);
+                        testStats.AddResult(cTest.Run(testLoader));
+                        cTest.Dispose();
+                        break;
+                    default:
+                        throw new ApplicationException("Unknown benchmark type");
+                }
+
+                if (options.IterationCount > 1)
+                {
+                    testStats.ShowAllStats(AggregateType.Running);
+                    if (iter < options.IterationCount - 1)
+                    {
+                        GC.Collect();
+                        GC.WaitForFullGCComplete();
+                        Thread.Sleep(1000);
+                    }
+                }
             }
 
-            var options = result.MapResult(o => o, xs => new Options());
-            BenchmarkType b = (BenchmarkType)options.Benchmark;
-
-            if (b == BenchmarkType.Ycsb)
-            {
-                var test = new FASTER_YcsbBenchmark(options.ThreadCount, options.NumaStyle, options.Distribution, options.ReadPercent, options.Backup);
-                test.Run();
-            }
-            else if (b == BenchmarkType.SpanByte)
-            {
-                var test = new FasterSpanByteYcsbBenchmark(options.ThreadCount, options.NumaStyle, options.Distribution, options.ReadPercent, options.Backup);
-                test.Run();
-            }
-            else if (b == BenchmarkType.ConcurrentDictionaryYcsb)
-            {
-                var test = new ConcurrentDictionary_YcsbBenchmark(options.ThreadCount, options.NumaStyle, options.Distribution, options.ReadPercent);
-                test.Run();
-            }
+            Console.WriteLine();
+            testStats.ShowAllStats(AggregateType.FinalFull);
+            if (options.IterationCount >= kTrimResultCount)
+                testStats.ShowTrimmedStats();
         }
     }
 }

--- a/cs/benchmark/TestLoader.cs
+++ b/cs/benchmark/TestLoader.cs
@@ -1,0 +1,355 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using CommandLine;
+using FASTER.core;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+#pragma warning disable CS0162 // Unreachable code detected -- when switching on YcsbConstants 
+
+namespace FASTER.benchmark
+{
+    internal interface IKeySetter<TKey>
+    {
+        void Set(TKey[] vector, long idx, long value);
+    }
+
+    class TestLoader
+    {
+        internal Options Options;
+
+        internal BenchmarkType BenchmarkType;
+        internal string Distribution;
+
+        internal Key[] init_keys = default;
+        internal Key[] txn_keys = default;
+        internal KeySpanByte[] init_span_keys = default;
+        internal KeySpanByte[] txn_span_keys = default;
+
+        internal bool Parse(string[] args)
+        {
+            ParserResult<Options> result = Parser.Default.ParseArguments<Options>(args);
+            if (result.Tag == ParserResultType.NotParsed)
+            {
+                return false;
+            }
+            Options = result.MapResult(o => o, xs => new Options());
+
+            static bool verifyOption(bool isValid, string name)
+            {
+                if (!isValid)
+                    Console.WriteLine($"Invalid {name} argument");
+                return isValid;
+            }
+
+            this.BenchmarkType = (BenchmarkType)Options.Benchmark;
+            if (!verifyOption(Enum.IsDefined(typeof(BenchmarkType), this.BenchmarkType), "Benchmark"))
+                return false;
+
+            if (!verifyOption(Options.NumaStyle >= 0 && Options.NumaStyle <= 1, "NumaStyle"))
+                return false;
+
+            if (!verifyOption(Options.IterationCount > 0, "Iteration Count"))
+                return false;
+
+            if (!verifyOption(Options.ReadPercent >= -1 && Options.ReadPercent <= 100, "Read Percent"))
+                return false;
+
+            this.Distribution = Options.DistributionName.ToLower();
+            if (!verifyOption(this.Distribution == YcsbConstants.UniformDist || this.Distribution == YcsbConstants.ZipfDist, "Distribution"))
+                return false;
+
+            return true;
+        }
+
+        internal void LoadData()
+        {
+            var worker = new Thread(LoadDataThreadProc);
+            worker.Start();
+            worker.Join();
+        }
+
+        private void LoadDataThreadProc()
+        {
+            Native32.AffinitizeThreadShardedNuma(0, 2);
+
+            switch (this.BenchmarkType)
+            {
+                case BenchmarkType.Ycsb:
+                    FASTER_YcsbBenchmark.CreateKeyVectors(out this.init_keys, out this.txn_keys);
+                    LoadData(this, this.init_keys, this.txn_keys, new FASTER_YcsbBenchmark.KeySetter());
+                    break;
+                case BenchmarkType.SpanByte:
+                    FasterSpanByteYcsbBenchmark.CreateKeyVectors(out this.init_span_keys, out this.txn_span_keys);
+                    LoadData(this, this.init_span_keys, this.txn_span_keys, new FasterSpanByteYcsbBenchmark.KeySetter());
+                    break;
+                case BenchmarkType.ConcurrentDictionaryYcsb:
+                    ConcurrentDictionary_YcsbBenchmark.CreateKeyVectors(out this.init_keys, out this.txn_keys);
+                    LoadData(this, this.init_keys, this.txn_keys, new ConcurrentDictionary_YcsbBenchmark.KeySetter());
+                    break;
+                default:
+                    throw new ApplicationException("Unknown benchmark type");
+            }
+        }
+
+        private static void LoadData<TKey, TKeySetter>(TestLoader testLoader, TKey[] init_keys, TKey[] txn_keys, TKeySetter keySetter)
+            where TKeySetter : IKeySetter<TKey>
+        {
+            if (testLoader.Options.UseSyntheticData)
+            {
+                LoadSyntheticData(testLoader.Distribution, (uint)testLoader.Options.RandomSeed, init_keys, txn_keys, keySetter);
+                return;
+            }
+
+            string filePath = "C:/ycsb_files";
+
+            if (!Directory.Exists(filePath))
+            {
+                filePath = "D:/ycsb_files";
+            }
+            if (!Directory.Exists(filePath))
+            {
+                filePath = "E:/ycsb_files";
+            }
+
+            if (Directory.Exists(filePath))
+            {
+                LoadDataFromFile(filePath, testLoader.Distribution, init_keys, txn_keys, keySetter);
+            }
+            else
+            {
+                Console.WriteLine("WARNING: Could not find YCSB directory, loading synthetic data instead");
+                LoadSyntheticData(testLoader.Distribution, (uint)testLoader.Options.RandomSeed, init_keys, txn_keys, keySetter);
+            }
+        }
+
+        private static unsafe void LoadDataFromFile<TKey, TKeySetter>(string filePath, string distribution, TKey[] init_keys, TKey[] txn_keys, TKeySetter keySetter)
+            where TKeySetter : IKeySetter<TKey>
+        {
+            string init_filename = filePath + "/load_" + distribution + "_250M_raw.dat";
+            string txn_filename = filePath + "/run_" + distribution + "_250M_1000M_raw.dat";
+
+            Console.WriteLine($"loading all keys from {init_filename} into memory...");
+            var sw = Stopwatch.StartNew();
+
+            if (YcsbConstants.kUseSmallData)
+            {
+                Console.WriteLine($"loading subset of keys and txns from {txn_filename} into memory...");
+                using FileStream stream = File.Open(txn_filename, FileMode.Open, FileAccess.Read, FileShare.Read);
+                byte[] chunk = new byte[YcsbConstants.kFileChunkSize];
+                GCHandle chunk_handle = GCHandle.Alloc(chunk, GCHandleType.Pinned);
+                byte* chunk_ptr = (byte*)chunk_handle.AddrOfPinnedObject();
+
+                var initValueSet = new HashSet<long>();
+
+                long init_count = 0;
+                long txn_count = 0;
+
+                long offset = 0;
+
+                while (true)
+                {
+                    stream.Position = offset;
+                    int size = stream.Read(chunk, 0, YcsbConstants.kFileChunkSize);
+                    for (int idx = 0; idx < size && txn_count < txn_keys.Length; idx += 8)
+                    {
+                        var value = *(long*)(chunk_ptr + idx);
+                        if (!initValueSet.Contains(value))
+                        {
+                            if (init_count >= init_keys.Length)
+                                continue;
+
+                            initValueSet.Add(value);
+                            keySetter.Set(init_keys, init_count, value);
+                            ++init_count;
+                        }
+                        keySetter.Set(txn_keys, txn_count, value);
+                        ++txn_count;
+                    }
+                    if (size == YcsbConstants.kFileChunkSize)
+                        offset += YcsbConstants.kFileChunkSize;
+                    else
+                        break;
+
+                    if (txn_count == txn_keys.Length)
+                        break;
+                }
+
+                sw.Stop();
+                chunk_handle.Free();
+
+                if (init_count != init_keys.Length)
+                    throw new InvalidDataException($"Init file subset load fail! Expected {init_keys.Length} keys; found {init_count}");
+                if (txn_count != txn_keys.Length)
+                    throw new InvalidDataException($"Txn file subset load fail! Expected {txn_keys.Length} keys; found {txn_count}");
+
+                Console.WriteLine($"loaded {init_keys.Length:N0} keys and {txn_keys.Length:N0} txns in {(double)sw.ElapsedMilliseconds / 1000:N3} seconds");
+                return;
+            }
+
+            long count = 0;
+
+            using (FileStream stream = File.Open(init_filename, FileMode.Open, FileAccess.Read,
+                FileShare.Read))
+            {
+                byte[] chunk = new byte[YcsbConstants.kFileChunkSize];
+                GCHandle chunk_handle = GCHandle.Alloc(chunk, GCHandleType.Pinned);
+                byte* chunk_ptr = (byte*)chunk_handle.AddrOfPinnedObject();
+
+                long offset = 0;
+
+                while (true)
+                {
+                    stream.Position = offset;
+                    int size = stream.Read(chunk, 0, YcsbConstants.kFileChunkSize);
+                    for (int idx = 0; idx < size; idx += 8)
+                    {
+                        keySetter.Set(init_keys, count, *(long*)(chunk_ptr + idx));
+                        ++count;
+                        if (count == init_keys.Length)
+                            break;
+                    }
+                    if (size == YcsbConstants.kFileChunkSize)
+                        offset += YcsbConstants.kFileChunkSize;
+                    else
+                        break;
+
+                    if (count == init_keys.Length)
+                        break;
+                }
+
+                chunk_handle.Free();
+
+                if (count != init_keys.Length)
+                    throw new InvalidDataException($"Init file load fail! Expected {init_keys.Length} keys; found {count}");
+            }
+
+            sw.Stop();
+            Console.WriteLine($"loaded {init_keys.Length:N0} keys in {(double)sw.ElapsedMilliseconds / 1000:N3} seconds");
+
+            Console.WriteLine($"loading all txns from {txn_filename} into memory...");
+            sw.Restart();
+
+            using (FileStream stream = File.Open(txn_filename, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                byte[] chunk = new byte[YcsbConstants.kFileChunkSize];
+                GCHandle chunk_handle = GCHandle.Alloc(chunk, GCHandleType.Pinned);
+                byte* chunk_ptr = (byte*)chunk_handle.AddrOfPinnedObject();
+
+                count = 0;
+                long offset = 0;
+
+                while (true)
+                {
+                    stream.Position = offset;
+                    int size = stream.Read(chunk, 0, YcsbConstants.kFileChunkSize);
+                    for (int idx = 0; idx < size; idx += 8)
+                    {
+                        keySetter.Set(txn_keys, count, *(long*)(chunk_ptr + idx));
+                        ++count;
+                        if (count == txn_keys.Length)
+                            break;
+                    }
+                    if (size == YcsbConstants.kFileChunkSize)
+                        offset += YcsbConstants.kFileChunkSize;
+                    else
+                        break;
+
+                    if (count == txn_keys.Length)
+                        break;
+                }
+
+                chunk_handle.Free();
+
+                if (count != txn_keys.Length)
+                    throw new InvalidDataException($"Txn file load fail! Expected {txn_keys.Length} keys; found {count}");
+            }
+
+            sw.Stop();
+            Console.WriteLine($"loaded {txn_keys.Length:N0} txns in {(double)sw.ElapsedMilliseconds / 1000:N3} seconds");
+        }
+
+        private static void LoadSyntheticData<TKey, TKeySetter>(string distribution, uint seed, TKey[] init_keys, TKey[] txn_keys, TKeySetter keySetter)
+            where TKeySetter : IKeySetter<TKey>
+        {
+            Console.WriteLine($"Loading synthetic data ({distribution} distribution), seed = {seed}");
+            var sw = Stopwatch.StartNew();
+
+            long val = 0;
+            for (int idx = 0; idx < init_keys.Length; idx++)
+            {
+                keySetter.Set(init_keys, idx, val++);
+            }
+
+            sw.Stop();
+            Console.WriteLine($"loaded {init_keys.Length:N0} keys in {(double)sw.ElapsedMilliseconds / 1000:N3} seconds");
+
+            RandomGenerator generator = new RandomGenerator(seed);
+            var zipf = new ZipfGenerator(generator, (int)init_keys.Length, theta: 0.99);
+
+            sw.Restart();
+            for (int idx = 0; idx < txn_keys.Length; idx++)
+            {
+                var rand = distribution == YcsbConstants.UniformDist ? (long)generator.Generate64((ulong)init_keys.Length) : zipf.Next();
+                keySetter.Set(txn_keys, idx, rand);
+            }
+
+            sw.Stop();
+            Console.WriteLine($"loaded {txn_keys.Length:N0} txns in {(double)sw.ElapsedMilliseconds / 1000:N3} seconds");
+        }
+
+        internal const string DataPath = "D:/data/FasterYcsbBenchmark";
+        
+        internal static string DevicePath => $"{DataPath}/hlog";
+
+        internal string BackupPath => $"{DataPath}/{this.Distribution}_{(this.Options.UseSyntheticData ? "synthetic" : "ycsb")}_{(YcsbConstants.kUseSmallData ? "2.5M_10M" : "250M_1000M")}";
+
+        internal bool MaybeRecoverStore<K, V>(FasterKV<K, V> store)
+        {
+            // Recover database for fast benchmark repeat runs.
+            if (this.Options.BackupAndRestore && YcsbConstants.kPeriodicCheckpointMilliseconds <= 0)
+            {
+                if (YcsbConstants.kUseSmallData)
+                {
+                    Console.WriteLine("Skipping Recover() for kSmallData");
+                    return false;
+                }
+
+                Console.WriteLine($"Recovering FasterKV from {this.BackupPath} for fast restart");
+                try
+                {
+                    var sw = Stopwatch.StartNew();
+                    store.Recover();
+                    sw.Stop();
+                    Console.WriteLine($"  Completed recovery in {(double)sw.ElapsedMilliseconds / 1000:N3} seconds");
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    var suffix = Directory.Exists(this.BackupPath) ? "" : " (directory does not exist)";
+                    Console.WriteLine($"Unable to recover prior store: {ex.Message}{suffix}");
+                }
+            }
+            return false;
+        }
+
+        internal void MaybeCheckpointStore<K, V>(FasterKV<K, V> store)
+        {
+            // Checkpoint database for fast benchmark repeat runs.
+            if (this.Options.BackupAndRestore && YcsbConstants.kPeriodicCheckpointMilliseconds <= 0)
+            {
+                Console.WriteLine($"Checkpointing FasterKV to {this.BackupPath} for fast restart");
+                Stopwatch sw = Stopwatch.StartNew();
+                store.TakeFullCheckpoint(out _);
+                store.CompleteCheckpointAsync().GetAwaiter().GetResult();
+                sw.Stop();
+                Console.WriteLine($"  Completed checkpoint in {(double)sw.ElapsedMilliseconds / 1000:N3} seconds");
+            }
+        }
+    }
+}

--- a/cs/benchmark/TestStats.cs
+++ b/cs/benchmark/TestStats.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static FASTER.benchmark.YcsbConstants;
+
+namespace FASTER.benchmark
+{
+    class TestStats 
+    {
+        private readonly List<double> initsPerRun = new List<double>();
+        private readonly List<double> opsPerRun = new List<double>();
+
+        private Options options;
+        internal static string OptionsString;
+
+        internal TestStats(Options options)
+        {
+            this.options = options;
+            OptionsString = options.GetOptionsString();
+        }
+
+        internal void AddResult((double ips, double ops) result)
+        {
+            initsPerRun.Add(result.ips);
+            opsPerRun.Add(result.ops);
+        }
+
+        internal void ShowAllStats(AggregateType aggregateType, string discardMessage = "")
+        {
+            var aggTypeString = aggregateType == AggregateType.Running ? "Running" : "Final";
+            Console.WriteLine($"{aggTypeString} averages per second over {initsPerRun.Count} iteration(s){discardMessage}:");
+            var statsLineNum = aggregateType switch
+            {
+                AggregateType.Running => StatsLineNum.RunningIns,
+                AggregateType.FinalFull => StatsLineNum.FinalFullIns,
+                AggregateType.FinalTrimmed => StatsLineNum.FinalTrimmedIns,
+                _ => throw new InvalidOperationException("Unknown AggregateType")
+            };
+            ShowStats(statsLineNum, "ins/sec", initsPerRun);
+            statsLineNum = aggregateType switch
+            {
+                AggregateType.Running => StatsLineNum.RunningOps,
+                AggregateType.FinalFull => StatsLineNum.FinalFullOps,
+                AggregateType.FinalTrimmed => StatsLineNum.FinalTrimmedOps,
+                _ => throw new InvalidOperationException("Unknown AggregateType")
+            };
+            ShowStats(statsLineNum, "ops/sec", opsPerRun);
+        }
+
+        private void ShowStats(StatsLineNum lineNum, string tag, List<double> vec)
+        {
+            var mean = vec.Sum() / vec.Count;
+            var stddev = Math.Sqrt(vec.Sum(n => Math.Pow(n - mean, 2)) / vec.Count);
+            var stddevpct = mean == 0 ? 0 : (stddev / mean) * 100;
+            Console.WriteLine(GetStatsLine(lineNum, tag, mean, stddev, stddevpct));
+        }
+
+        internal void ShowTrimmedStats()
+        {
+            static void discardHiLo(List<double> vec)
+            {
+                vec.Sort();
+#pragma warning disable IDE0056 // Use index operator (^ is not supported on .NET Framework or NETCORE pre-3.0)
+                vec[0] = vec[vec.Count - 2];        // overwrite lowest with second-highest
+#pragma warning restore IDE0056 // Use index operator
+                vec.RemoveRange(vec.Count - 2, 2);  // remove highest and (now-duplicated) second-highest
+            }
+            discardHiLo(initsPerRun);
+            discardHiLo(opsPerRun);
+
+            Console.WriteLine();
+            ShowAllStats(AggregateType.FinalTrimmed, $" ({this.options.IterationCount} iterations specified, with high and low discarded)");
+        }
+
+        internal static string GetTotalOpsString(long totalOps, double seconds) => $"Total {totalOps:N0} ops done in {seconds:N3} seconds";
+
+        internal static string GetLoadingTimeLine(double insertsPerSec, long elapsedMs)
+            => $"##00; {InsPerSec}: {insertsPerSec:N2}; sec: {(double)elapsedMs / 1000:N3}";
+
+        internal static string GetAddressesLine(AddressLineNum lineNum, long begin, long head, long rdonly, long tail)
+            => $"##{(int)lineNum:00}; begin: {begin}; head: {head}; readonly: {rdonly}; tail: {tail}";
+
+        internal static string GetStatsLine(StatsLineNum lineNum, string opsPerSecTag, double opsPerSec)
+            => $"##{(int)lineNum:00}; {opsPerSecTag}: {opsPerSec:N2}; {OptionsString}";
+
+        internal static string GetStatsLine(StatsLineNum lineNum, string meanTag, double mean, double stdev, double stdevpct)
+            => $"##{(int)lineNum:00}; {meanTag}: {mean:N2}; stdev: {stdev:N1}; stdev%: {stdevpct:N1}; {OptionsString}";
+    }
+}

--- a/cs/benchmark/YcsbConstants.cs
+++ b/cs/benchmark/YcsbConstants.cs
@@ -12,15 +12,6 @@ namespace FASTER.benchmark
         ConcurrentDictionaryYcsb
     };
 
-    [Flags]
-    enum BackupMode : int
-    {
-        None = 0,
-        Restore = 1,
-        Backup = 2,
-        Both = 3
-    };
-
     enum AddressLineNum : int
     {
         Before = 1,

--- a/cs/benchmark/YcsbConstants.cs
+++ b/cs/benchmark/YcsbConstants.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+
+namespace FASTER.benchmark
+{
+    enum BenchmarkType : int
+    {
+        Ycsb,
+        SpanByte,
+        ConcurrentDictionaryYcsb
+    };
+
+    [Flags]
+    enum BackupMode : int
+    {
+        None = 0,
+        Restore = 1,
+        Backup = 2,
+        Both = 3
+    };
+
+    enum AddressLineNum : int
+    {
+        Before = 1,
+        After = 2
+    }
+
+    enum AggregateType
+    {
+        Running = 0,
+        FinalFull = 1,
+        FinalTrimmed = 2
+    }
+
+    enum StatsLineNum : int
+    {
+        Iteration = 3,
+        RunningIns = 4,
+        RunningOps = 5,
+        FinalFullIns = 10,
+        FinalFullOps = 11,
+        FinalTrimmedIns = 20,
+        FinalTrimmedOps = 21
+    }
+
+    public enum Op : ulong
+    {
+        Upsert = 0,
+        Read = 1,
+        ReadModifyWrite = 2
+    }
+
+    public static class YcsbConstants
+    {
+        internal const string UniformDist = "uniform";    // Uniformly random distribution of keys
+        internal const string ZipfDist = "zipf";          // Smooth zipf curve (most localized keys)
+
+        internal const string SyntheticData = "synthetic";
+        internal const string YcsbData = "ycsb";
+
+        internal const string InsPerSec = "ins/sec";
+        internal const string OpsPerSec = "ops/sec";
+
+#if DEBUG
+        internal const bool kUseSmallData = true;
+        internal const bool kSmallMemoryLog = false;
+        internal const int kRunSeconds = 30;
+        internal const bool kDumpDistribution = false;
+        internal const bool kAffinitizedSession = true;
+        internal const int kPeriodicCheckpointMilliseconds = 0;
+#else
+        internal const bool kUseSmallData = false;
+        internal const bool kSmallMemoryLog = false;
+        internal const int kRunSeconds = 30;
+        internal const bool kDumpDistribution = false;
+        internal const bool kAffinitizedSession = true;
+        internal const int kPeriodicCheckpointMilliseconds = 0;
+#endif
+
+        internal const long kInitCount = kUseSmallData ? 2500480 : 250000000;
+        internal const long kTxnCount = kUseSmallData ? 10000000 : 1000000000;
+        internal const int kMaxKey = kUseSmallData ? 1 << 22 : 1 << 28;
+
+        internal const int kFileChunkSize = 4096;
+        internal const long kChunkSize = 640;
+    }
+}

--- a/cs/benchmark/ZipfGenerator.cs
+++ b/cs/benchmark/ZipfGenerator.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+
+namespace FASTER.benchmark
+{
+    public class ZipfGenerator
+    {
+        // Based on "Quickly Generating Billion-Record Synthetic Databases", Jim Gray et al., SIGMOD 1994.
+        readonly RandomGenerator rng;
+        readonly private int size;
+        readonly double theta;
+        readonly double zetaN, alpha, cutoff2, eta;
+
+        public ZipfGenerator(RandomGenerator rng, int size, double theta = 0.99)
+        {
+            this.rng = rng;
+            this.size = size;
+            this.theta = theta;
+
+            zetaN = Zeta(size, this.theta);
+            alpha = 1.0 / (1.0 - this.theta);
+            cutoff2 = Math.Pow(0.5, this.theta);
+            var zeta2 = Zeta(2, this.theta);
+            eta = (1.0 - Math.Pow(2.0 / size, 1.0 - this.theta)) / (1.0 - zeta2 / zetaN);
+        }
+
+        private static double Zeta(int count, double theta)
+        {
+            double zetaN = 0.0;
+            for (var ii = 1; ii <= count; ++ii)
+                zetaN += 1.0 / Math.Pow(ii, theta);
+            return zetaN;
+        }
+
+        public int Next()
+        {
+            double u = (double)rng.Generate64(int.MaxValue) / int.MaxValue;
+            double uz = u * zetaN;
+            if (uz < 1)
+                return 0;
+            if (uz < 1 + cutoff2)
+                return 1;
+            return (int)(size * Math.Pow(eta * u - eta + 1, alpha));
+        }
+    }
+}


### PR DESCRIPTION
Refactor YCSB benchmark:
- Move constants and code out of program.cs into Options.cs, YcsbConstants.cs
- Move constants from the test classes to YcsbConstants.cs
- Add ZipfGenerator.cs to generate synthetic data in Zipf distribution
- Move LoadData logic from test classes to TestLoader.cs and hold the keys to be shared across iterations (see new -i param)
- Move backup/recover logic from test classes to TestLoader.cs
- Added commandline-arg verification to TestLoader.cs
- Add TestStats.cs to report summary stats across iterations (see new -i param): mean ins/sec (load) or ops/sec (experiment), stdev, stdev as % of mean
- Formatted output for improved parsability, to include all relevant commandline args (for charting etc)
- Update commandline options:
    - Modify -k (and change the full param from --backup to --recover) to checkpoint to and restore from d:\data\FasterYcsbBenchmark directories named for the distribution, data source (ycsb vs. synthetic), and init/txn key counts
    - Add -i (--iterations) parameter to call Run() multiple times, reusing the keys from LoadData for each iteration
    - Add --runsec parameter to override kRunSeconds
    - Add --sy to use synthetic data (replacing kUseSyntheticData)
    - Add -s --seed for synthetic data RNG
