### PR TITLE
[C#] Add locking methods to Functions

### DIFF
--- a/cs/benchmark/FasterSpanByteYcsbBenchmark.cs
+++ b/cs/benchmark/FasterSpanByteYcsbBenchmark.cs
@@ -48,7 +48,8 @@ namespace FASTER.benchmark
             txn_keys_ = t_keys_;
             numaStyle = testLoader.Options.NumaStyle;
             readPercent = testLoader.Options.ReadPercent;
-            functions = new FunctionsSB();
+            var lockImpl = testLoader.LockImpl;
+            functions = new FunctionsSB(lockImpl != LockImpl.None);
 
 #if DASHBOARD
             statsWritten = new AutoResetEvent[threadCount];

--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -45,7 +45,8 @@ namespace FASTER.benchmark
             txn_keys_ = t_keys_;
             numaStyle = testLoader.Options.NumaStyle;
             readPercent = testLoader.Options.ReadPercent;
-            functions = new Functions();
+            var lockImpl = testLoader.LockImpl;
+            functions = new Functions(lockImpl != LockImpl.None);
 
 #if DASHBOARD
             statsWritten = new AutoResetEvent[threadCount];

--- a/cs/benchmark/Functions.cs
+++ b/cs/benchmark/Functions.cs
@@ -85,12 +85,12 @@ namespace FASTER.benchmark
 
         public bool SupportsLocking => locking;
 
-        public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long context)
+        public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long lockContext)
         {
             if (locking) recordInfo.SpinLock();
         }
 
-        public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long context)
+        public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long lockContext)
         {
             if (locking) recordInfo.Unlock();
             return true;

--- a/cs/benchmark/Functions.cs
+++ b/cs/benchmark/Functions.cs
@@ -87,12 +87,12 @@ namespace FASTER.benchmark
 
         public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long lockContext)
         {
-            if (locking) recordInfo.SpinLock();
+            recordInfo.SpinLock();
         }
 
         public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long lockContext)
         {
-            if (locking) recordInfo.Unlock();
+            recordInfo.Unlock();
             return true;
         }
     }

--- a/cs/benchmark/Functions.cs
+++ b/cs/benchmark/Functions.cs
@@ -11,6 +11,10 @@ namespace FASTER.benchmark
 {
     public struct Functions : IFunctions<Key, Value, Input, Output, Empty>
     {
+        readonly bool locking;
+
+        public Functions(bool locking) => this.locking = locking;
+
         public void RMWCompletionCallback(ref Key key, ref Input input, Empty ctx, Status status)
         {
         }
@@ -77,6 +81,19 @@ namespace FASTER.benchmark
         public void CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue)
         {
             newValue.value = input.value + oldValue.value;
+        }
+
+        public bool SupportsLocking => locking;
+
+        public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long context)
+        {
+            if (locking) recordInfo.SpinLock();
+        }
+
+        public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long context)
+        {
+            if (locking) recordInfo.Unlock();
+            return true;
         }
     }
 }

--- a/cs/benchmark/FunctionsSB.cs
+++ b/cs/benchmark/FunctionsSB.cs
@@ -7,5 +7,6 @@ namespace FASTER.benchmark
 {
     public sealed class FunctionsSB : SpanByteFunctions<Empty>
     {
+        public FunctionsSB(bool locking) : base(locking: locking) { }
     }
 }

--- a/cs/benchmark/Options.cs
+++ b/cs/benchmark/Options.cs
@@ -31,6 +31,12 @@ namespace FASTER.benchmark
                         "\n    (Checkpoints are stored in directories under " + TestLoader.DataPath + " in directories named by distribution, ycsb vs. synthetic data, and key counts)")]
         public bool BackupAndRestore { get; set; }
 
+        [Option('z', "locking", Required = false, Default = 0,
+             HelpText = "Locking Implementation:" +
+                        "\n    0 = None (default)" +
+                        "\n    1 = RecordInfo.SpinLock()")]
+        public int LockImpl { get; set; }
+
         [Option('i', "iterations", Required = false, Default = 1,
          HelpText = "Number of iterations of the test to run")]
         public int IterationCount { get; set; }
@@ -58,7 +64,7 @@ namespace FASTER.benchmark
         public string GetOptionsString()
         {
             static string boolStr(bool value) => value ? "y" : "n";
-            return $"d: {DistributionName.ToLower()}; n: {NumaStyle}; r: {ReadPercent}; t: {ThreadCount};"
+            return $"d: {DistributionName.ToLower()}; n: {NumaStyle}; r: {ReadPercent}; t: {ThreadCount}; z: {LockImpl}; i: {IterationCount};"
                         + $" sd: {boolStr(YcsbConstants.kUseSmallData)}; sm: {boolStr(YcsbConstants.kSmallMemoryLog)}; sy: {boolStr(this.UseSyntheticData)}";
         }
     }

--- a/cs/benchmark/TestLoader.cs
+++ b/cs/benchmark/TestLoader.cs
@@ -24,6 +24,7 @@ namespace FASTER.benchmark
         internal Options Options;
 
         internal BenchmarkType BenchmarkType;
+        internal LockImpl LockImpl;
         internal string Distribution;
 
         internal Key[] init_keys = default;
@@ -54,6 +55,10 @@ namespace FASTER.benchmark
             if (!verifyOption(Options.NumaStyle >= 0 && Options.NumaStyle <= 1, "NumaStyle"))
                 return false;
 
+            this.LockImpl = (LockImpl)Options.LockImpl;
+            if (!verifyOption(Enum.IsDefined(typeof(LockImpl), this.LockImpl), "Lock Implementation"))
+                return false;
+
             if (!verifyOption(Options.IterationCount > 0, "Iteration Count"))
                 return false;
 
@@ -62,6 +67,9 @@ namespace FASTER.benchmark
 
             this.Distribution = Options.DistributionName.ToLower();
             if (!verifyOption(this.Distribution == YcsbConstants.UniformDist || this.Distribution == YcsbConstants.ZipfDist, "Distribution"))
+                return false;
+
+            if (!verifyOption(this.Options.RunSeconds >= 0, "RunSeconds"))
                 return false;
 
             return true;

--- a/cs/benchmark/YcsbConstants.cs
+++ b/cs/benchmark/YcsbConstants.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using System;
-
 namespace FASTER.benchmark
 {
     enum BenchmarkType : int
@@ -10,6 +8,12 @@ namespace FASTER.benchmark
         Ycsb,
         SpanByte,
         ConcurrentDictionaryYcsb
+    };
+
+    enum LockImpl : int
+    {
+        None,
+        RecordInfo
     };
 
     enum AddressLineNum : int

--- a/cs/samples/ReadAddress/Types.cs
+++ b/cs/samples/ReadAddress/Types.cs
@@ -43,9 +43,9 @@ namespace ReadAddress
     public class Functions : AdvancedSimpleFunctions<Key, Value, Context>
     {
         // Return false to force a chain of values.
-        public override bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst, long address) => false;
+        public override bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst, ref RecordInfo recordInfo, long address) => false;
 
-        public override bool InPlaceUpdater(ref Key key, ref Value input, ref Value value, long address) => false;
+        public override bool InPlaceUpdater(ref Key key, ref Value input, ref Value value, ref RecordInfo recordInfo, long address) => false;
 
         // Track the recordInfo for its PreviousAddress.
         public override void ReadCompletionCallback(ref Key key, ref Value input, ref Value output, Context ctx, Status status, RecordInfo recordInfo)

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -47,21 +47,17 @@ namespace FASTER.core
                 throw new FasterException("LogSettings.ObjectLogDevice needs to be specified (e.g., use Devices.CreateLogDevice, AzureStorageDevice, or NullDevice)");
             }
 
-            SerializerSettings = serializerSettings;
+            SerializerSettings = serializerSettings ?? new SerializerSettings<Key, Value>();
 
             if ((!keyBlittable) && (settings.LogDevice as NullDevice == null) && ((SerializerSettings == null) || (SerializerSettings.keySerializer == null)))
             {
                 Debug.WriteLine("Key is not blittable, but no serializer specified via SerializerSettings. Using (slow) DataContractSerializer as default.");
-                if (SerializerSettings == null)
-                    SerializerSettings = new SerializerSettings<Key, Value>();
                 SerializerSettings.keySerializer = ObjectSerializer.Get<Key>();
             }
 
             if ((!valueBlittable) && (settings.LogDevice as NullDevice == null) && ((SerializerSettings == null) || (SerializerSettings.valueSerializer == null)))
             {
                 Debug.WriteLine("Value is not blittable, but no serializer specified via SerializerSettings. Using (slow) DataContractSerializer as default.");
-                if (SerializerSettings == null)
-                    SerializerSettings = new SerializerSettings<Key, Value>();
                 SerializerSettings.valueSerializer = ObjectSerializer.Get<Value>();
             }
 

--- a/cs/src/core/ClientSession/AdvancedClientSession.cs
+++ b/cs/src/core/ClientSession/AdvancedClientSession.cs
@@ -906,9 +906,9 @@ namespace FASTER.core
 
             public bool SupportsLocking => _clientSession.functions.SupportsLocking;
 
-            public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long context) => _clientSession.functions.Lock(ref recordInfo, ref key, ref value, lockType, ref context);
+            public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long lockContext) => _clientSession.functions.Lock(ref recordInfo, ref key, ref value, lockType, ref lockContext);
 
-            public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long context) => _clientSession.functions.Unlock(ref recordInfo, ref key, ref value, lockType, context);
+            public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long lockContext) => _clientSession.functions.Unlock(ref recordInfo, ref key, ref value, lockType, lockContext);
 
             public IHeapContainer<Input> GetHeapContainer(ref Input input)
             {

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -35,7 +35,7 @@ namespace FASTER.core
         internal readonly IVariableLengthStruct<Value, Input> variableLengthStruct;
         internal readonly IVariableLengthStruct<Input> inputVariableLengthStruct;
 
-        internal readonly AsyncFasterSession FasterSession;
+        internal readonly InternalFasterSession FasterSession;
 
         internal const string NotAsyncSessionErr = "Session does not support async operations";
 
@@ -51,7 +51,7 @@ namespace FASTER.core
             this.functions = functions;
             SupportAsync = supportAsync;
             LatestCommitPoint = new CommitPoint { UntilSerialNo = -1, ExcludedSerialNos = null };
-            FasterSession = new AsyncFasterSession(this);
+            FasterSession = new InternalFasterSession(this);
 
             this.variableLengthStruct = sessionVariableLengthStructSettings?.valueLength;
             if (this.variableLengthStruct == default)
@@ -730,11 +730,11 @@ namespace FASTER.core
         }
 
         // This is a struct to allow JIT to inline calls (and bypass default interface call mechanism)
-        internal struct AsyncFasterSession : IFasterSession<Key, Value, Input, Output, Context>
+        internal readonly struct InternalFasterSession : IFasterSession<Key, Value, Input, Output, Context>
         {
             private readonly ClientSession<Key, Value, Input, Output, Context, Functions> _clientSession;
 
-            public AsyncFasterSession(ClientSession<Key, Value, Input, Output, Context, Functions> clientSession)
+            public InternalFasterSession(ClientSession<Key, Value, Input, Output, Context, Functions> clientSession)
             {
                 _clientSession = clientSession;
             }
@@ -745,20 +745,89 @@ namespace FASTER.core
                 _clientSession.LatestCommitPoint = commitPoint;
             }
 
-            public void ConcurrentReader(ref Key key, ref Input input, ref Value value, ref Output dst, long address)
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void ConcurrentReader(ref Key key, ref Input input, ref Value value, ref Output dst, ref RecordInfo recordInfo, long address)
             {
-                _clientSession.functions.ConcurrentReader(ref key, ref input, ref value, ref dst);
+                if (!this.SupportsLocking)
+                    _clientSession.functions.ConcurrentReader(ref key, ref input, ref value, ref dst);
+                else
+                    ConcurrentReaderLock(ref key, ref input, ref value, ref dst, ref recordInfo);
             }
 
-            public bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst, long address)
+            public void ConcurrentReaderLock(ref Key key, ref Input input, ref Value value, ref Output dst, ref RecordInfo recordInfo)
             {
-                return _clientSession.functions.ConcurrentWriter(ref key, ref src, ref dst);
+                for (bool retry = true; retry; /* updated in loop */)
+                {
+                    long context = 0;
+                    this.Lock(ref recordInfo, ref key, ref value, LockType.Shared, ref context);
+                    try
+                    {
+                        _clientSession.functions.ConcurrentReader(ref key, ref input, ref value, ref dst);
+                    }
+                    finally
+                    {
+                        retry = !this.Unlock(ref recordInfo, ref key, ref value, LockType.Shared, context);
+                    }
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst, ref RecordInfo recordInfo, long address)
+                => !this.SupportsLocking
+                    ? ConcurrentWriterNoLock(ref key, ref src, ref dst, address)
+                    : ConcurrentWriterLock(ref key, ref src, ref dst, ref recordInfo, address);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private bool ConcurrentWriterNoLock(ref Key key, ref Value src, ref Value dst, long address)
+                => _clientSession.functions.ConcurrentWriter(ref key, ref src, ref dst);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private bool ConcurrentWriterLock(ref Key key, ref Value src, ref Value dst, ref RecordInfo recordInfo, long address)
+            {
+                long context = 0;
+                this.Lock(ref recordInfo, ref key, ref dst, LockType.Exclusive, ref context);
+                try
+                {
+                    return !recordInfo.Tombstone && ConcurrentWriterNoLock(ref key, ref src, ref dst, address);
+                }
+                finally
+                {
+                    this.Unlock(ref recordInfo, ref key, ref dst, LockType.Exclusive, context);
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool ConcurrentDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, long address)
+                => !this.SupportsLocking
+                    ? ConcurrentDeleterNoLock(ref key, ref value, ref recordInfo, address)
+                    : ConcurrentDeleterLock(ref key, ref value, ref recordInfo, address);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private bool ConcurrentDeleterNoLock(ref Key key, ref Value value, ref RecordInfo recordInfo, long address)
+            {
+                // Non-Advanced IFunctions has no ConcurrentDeleter
+                _clientSession.fht.SetRecordDeleted(ref value, ref recordInfo);
+                return true;
+            }
+
+            private bool ConcurrentDeleterLock(ref Key key, ref Value value, ref RecordInfo recordInfo, long address)
+            {
+                long context = 0;
+                this.Lock(ref recordInfo, ref key, ref value, LockType.Exclusive, ref context);
+                try
+                {
+                    return ConcurrentDeleterNoLock(ref key, ref value, ref recordInfo, address);
+                }
+                finally
+                {
+                    this.Unlock(ref recordInfo, ref key, ref value, LockType.Exclusive, context);
+                }
             }
 
             public bool NeedCopyUpdate(ref Key key, ref Input input, ref Value oldValue)
                 => _clientSession.functions.NeedCopyUpdate(ref key, ref input, ref oldValue);
 
-            public void CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue, long oldAddress, long newAddress)
+            public void CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue)
             {
                 _clientSession.functions.CopyUpdater(ref key, ref input, ref oldValue, ref newValue);
             }
@@ -778,14 +847,33 @@ namespace FASTER.core
                 return _clientSession.variableLengthStruct.GetLength(ref t, ref input);
             }
 
-            public void InitialUpdater(ref Key key, ref Input input, ref Value value, long address)
+            public void InitialUpdater(ref Key key, ref Input input, ref Value value)
             {
                 _clientSession.functions.InitialUpdater(ref key, ref input, ref value);
             }
 
-            public bool InPlaceUpdater(ref Key key, ref Input input, ref Value value, long address)
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool InPlaceUpdater(ref Key key, ref Input input, ref Value value, ref RecordInfo recordInfo, long address)
+                => !this.SupportsLocking
+                    ? InPlaceUpdaterNoLock(ref key, ref input, ref value, address)
+                    : InPlaceUpdaterLock(ref key, ref input, ref value, ref recordInfo, address);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private bool InPlaceUpdaterNoLock(ref Key key, ref Input input, ref Value value, long address)
+                => _clientSession.functions.InPlaceUpdater(ref key, ref input, ref value);
+
+            private bool InPlaceUpdaterLock(ref Key key, ref Input input, ref Value value, ref RecordInfo recordInfo, long address)
             {
-                return _clientSession.functions.InPlaceUpdater(ref key, ref input, ref value);
+                long context = 0;
+                this.Lock(ref recordInfo, ref key, ref value, LockType.Exclusive, ref context);
+                try
+                {
+                    return !recordInfo.Tombstone && InPlaceUpdaterNoLock(ref key, ref input, ref value, address);
+                }
+                finally
+                {
+                    this.Unlock(ref recordInfo, ref key, ref value, LockType.Exclusive, context);
+                }
             }
 
             public void ReadCompletionCallback(ref Key key, ref Input input, ref Output output, Context ctx, Status status, RecordInfo recordInfo)
@@ -803,7 +891,7 @@ namespace FASTER.core
                 _clientSession.functions.SingleReader(ref key, ref input, ref value, ref dst);
             }
 
-            public void SingleWriter(ref Key key, ref Value src, ref Value dst, long address)
+            public void SingleWriter(ref Key key, ref Value src, ref Value dst)
             {
                 _clientSession.functions.SingleWriter(ref key, ref src, ref dst);
             }
@@ -822,6 +910,12 @@ namespace FASTER.core
             {
                 _clientSession.functions.UpsertCompletionCallback(ref key, ref value, ctx);
             }
+
+            public bool SupportsLocking => _clientSession.functions.SupportsLocking;
+
+            public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long context) => _clientSession.functions.Lock(ref recordInfo, ref key, ref value, lockType, ref context);
+
+            public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long context) => _clientSession.functions.Unlock(ref recordInfo, ref key, ref value, lockType, context);
 
             public IHeapContainer<Input> GetHeapContainer(ref Input input)
             {

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -797,31 +797,9 @@ namespace FASTER.core
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public bool ConcurrentDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, long address)
-                => !this.SupportsLocking
-                    ? ConcurrentDeleterNoLock(ref key, ref value, ref recordInfo, address)
-                    : ConcurrentDeleterLock(ref key, ref value, ref recordInfo, address);
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private bool ConcurrentDeleterNoLock(ref Key key, ref Value value, ref RecordInfo recordInfo, long address)
+            public void ConcurrentDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, long address)
             {
                 // Non-Advanced IFunctions has no ConcurrentDeleter
-                _clientSession.fht.SetRecordDeleted(ref value, ref recordInfo);
-                return true;
-            }
-
-            private bool ConcurrentDeleterLock(ref Key key, ref Value value, ref RecordInfo recordInfo, long address)
-            {
-                long context = 0;
-                this.Lock(ref recordInfo, ref key, ref value, LockType.Exclusive, ref context);
-                try
-                {
-                    return ConcurrentDeleterNoLock(ref key, ref value, ref recordInfo, address);
-                }
-                finally
-                {
-                    this.Unlock(ref recordInfo, ref key, ref value, LockType.Exclusive, context);
-                }
             }
 
             public bool NeedCopyUpdate(ref Key key, ref Input input, ref Value oldValue)

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -913,9 +913,9 @@ namespace FASTER.core
 
             public bool SupportsLocking => _clientSession.functions.SupportsLocking;
 
-            public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long context) => _clientSession.functions.Lock(ref recordInfo, ref key, ref value, lockType, ref context);
+            public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long lockContext) => _clientSession.functions.Lock(ref recordInfo, ref key, ref value, lockType, ref lockContext);
 
-            public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long context) => _clientSession.functions.Unlock(ref recordInfo, ref key, ref value, lockType, context);
+            public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long lockContext) => _clientSession.functions.Unlock(ref recordInfo, ref key, ref value, lockType, lockContext);
 
             public IHeapContainer<Input> GetHeapContainer(ref Input input)
             {

--- a/cs/src/core/Index/Common/RecordInfo.cs
+++ b/cs/src/core/Index/Common/RecordInfo.cs
@@ -148,6 +148,7 @@ namespace FASTER.core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SpinLock()
         {
+            // Note: Any improvements here should be done in IntExclusiveLocker.SpinLock() as well.
             while (true)
             {
                 long expected_word = word;

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -37,6 +37,7 @@ namespace FASTER.core
         private readonly CopyReadsToTail CopyReadsToTail;
         private readonly bool FoldOverSnapshot;
         internal readonly int sectorSize;
+        private readonly bool WriteDefaultOnDelete;
         internal bool RelaxedCPR;
 
         /// <summary>
@@ -154,6 +155,8 @@ namespace FASTER.core
             if ((!Utility.IsBlittable<Key>() && variableLengthStructSettings?.keyLength == null) ||
                 (!Utility.IsBlittable<Value>() && variableLengthStructSettings?.valueLength == null))
             {
+                WriteDefaultOnDelete = true;
+
                 hlog = new GenericAllocator<Key, Value>(logSettings, serializerSettings, this.comparer, null, epoch);
                 Log = new LogAccessor<Key, Value>(this, hlog);
                 if (UseReadCache)

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -37,7 +37,6 @@ namespace FASTER.core
         private readonly CopyReadsToTail CopyReadsToTail;
         private readonly bool FoldOverSnapshot;
         internal readonly int sectorSize;
-        private readonly bool WriteDefaultOnDelete;
         internal bool RelaxedCPR;
 
         /// <summary>
@@ -78,11 +77,6 @@ namespace FASTER.core
         /// </summary>
         public LogAccessor<Key, Value> ReadCache { get; }
 
-        /// <summary>
-        /// An accessor to the record at a given logical address, for use in IFunctions callbacks.
-        /// </summary>
-        public RecordAccessor<Key, Value> RecordAccessor { get; }
-
         internal ConcurrentDictionary<string, CommitPoint> _recoveredSessions;
 
         /// <summary>
@@ -119,8 +113,6 @@ namespace FASTER.core
                     this.comparer = FasterEqualityComparer.Get<Key>();
                 }
             }
-
-            this.RecordAccessor = new RecordAccessor<Key, Value>(this);
 
             if (checkpointSettings == null)
                 checkpointSettings = new CheckpointSettings();
@@ -162,8 +154,6 @@ namespace FASTER.core
             if ((!Utility.IsBlittable<Key>() && variableLengthStructSettings?.keyLength == null) ||
                 (!Utility.IsBlittable<Value>() && variableLengthStructSettings?.valueLength == null))
             {
-                WriteDefaultOnDelete = true;
-
                 hlog = new GenericAllocator<Key, Value>(logSettings, serializerSettings, this.comparer, null, epoch);
                 Log = new LogAccessor<Key, Value>(this, hlog);
                 if (UseReadCache)

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -162,30 +162,32 @@ namespace FASTER.core
             // Mutable region (even fuzzy region is included here)
             if (logicalAddress >= hlog.SafeReadOnlyAddress)
             {
-                pendingContext.recordInfo = hlog.GetInfo(physicalAddress);
-                if (pendingContext.recordInfo.Tombstone)
-                    return OperationStatus.NOTFOUND;
-
-                fasterSession.ConcurrentReader(ref key, ref input, ref hlog.GetValue(physicalAddress), ref output, logicalAddress);
-                return OperationStatus.SUCCESS;
+                ref RecordInfo recordInfo = ref hlog.GetInfo(physicalAddress);
+                pendingContext.recordInfo = recordInfo;
+                if (!pendingContext.recordInfo.Tombstone)
+                {
+                    fasterSession.ConcurrentReader(ref key, ref input, ref hlog.GetValue(physicalAddress), ref output, ref recordInfo, logicalAddress);
+                    return OperationStatus.SUCCESS;
+                }
+                return OperationStatus.NOTFOUND;
             }
 
             // Immutable region
             else if (logicalAddress >= hlog.HeadAddress)
             {
                 pendingContext.recordInfo = hlog.GetInfo(physicalAddress);
-                if (pendingContext.recordInfo.Tombstone)
-                    return OperationStatus.NOTFOUND;
-
-                fasterSession.SingleReader(ref key, ref input, ref hlog.GetValue(physicalAddress), ref output, logicalAddress);
-
-                if (CopyReadsToTail == CopyReadsToTail.FromReadOnly)
+                if (!pendingContext.recordInfo.Tombstone)
                 {
-                    var container = hlog.GetValueContainer(ref hlog.GetValue(physicalAddress));
-                    InternalUpsert(ref key, ref container.Get(), ref userContext, ref pendingContext, fasterSession, sessionCtx, lsn);
-                    container.Dispose();
+                    fasterSession.SingleReader(ref key, ref input, ref hlog.GetValue(physicalAddress), ref output, logicalAddress);
+                    if (CopyReadsToTail == CopyReadsToTail.FromReadOnly)
+                    {
+                        var container = hlog.GetValueContainer(ref hlog.GetValue(physicalAddress));
+                        InternalUpsert(ref key, ref container.Get(), ref userContext, ref pendingContext, fasterSession, sessionCtx, lsn);
+                        container.Dispose();
+                    }
+                    return OperationStatus.SUCCESS;
                 }
-                return OperationStatus.SUCCESS;
+                return OperationStatus.NOTFOUND;
             }
 
             // On-Disk Region
@@ -254,9 +256,16 @@ namespace FASTER.core
 
             return status;
         }
-#endregion
+        #endregion
 
-#region Upsert Operation
+        #region Upsert Operation
+
+        private enum LatchDestination
+        {
+            CreateNewRecord,
+            CreatePendingContext,
+            NormalProcessing
+        }
 
         /// <summary>
         /// Upsert operation. Replaces the value corresponding to 'key' with provided 'value', if one exists 
@@ -299,12 +308,11 @@ namespace FASTER.core
                             long lsn)
             where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
         {
-            var status = default(OperationStatus);
             var bucket = default(HashBucket*);
             var slot = default(int);
-            var logicalAddress = Constants.kInvalidAddress;
-            var physicalAddress = default(long);
-            var latchOperation = default(LatchOperation);
+            var status = default(OperationStatus);
+            var latchOperation = LatchOperation.None;
+            var latchDestination = LatchDestination.NormalProcessing;
 
             var hash = comparer.GetHashCode64(ref key);
             var tag = (ushort)((ulong)hash >> Constants.kHashTagShift);
@@ -315,7 +323,8 @@ namespace FASTER.core
 #region Trace back for record in in-memory HybridLog
             var entry = default(HashBucketEntry);
             FindOrCreateTag(hash, tag, ref bucket, ref slot, ref entry, hlog.BeginAddress);
-            logicalAddress = entry.Address;
+            var logicalAddress = entry.Address;
+            var physicalAddress = default(long);
 
             if (UseReadCache)
                 SkipAndInvalidateReadCache(ref logicalAddress, ref key);
@@ -334,101 +343,41 @@ namespace FASTER.core
                                         out physicalAddress);
                 }
             }
-#endregion
+            #endregion
 
-            // Optimization for most common case
-            if (sessionCtx.phase == Phase.REST && logicalAddress >= hlog.ReadOnlyAddress && !hlog.GetInfo(physicalAddress).Tombstone)
+            // Optimization for the most common case
+            if (sessionCtx.phase == Phase.REST && logicalAddress >= hlog.ReadOnlyAddress)
             {
-                if (fasterSession.ConcurrentWriter(ref key, ref value, ref hlog.GetValue(physicalAddress), logicalAddress))
-                {
+                ref RecordInfo recordInfo = ref hlog.GetInfo(physicalAddress);
+                if (!recordInfo.Tombstone
+                    && fasterSession.ConcurrentWriter(ref key, ref value, ref hlog.GetValue(physicalAddress), ref recordInfo, logicalAddress))
                     return OperationStatus.SUCCESS;
-                }
                 goto CreateNewRecord;
             }
 
 #region Entry latch operation
             if (sessionCtx.phase != Phase.REST)
             {
-                switch (sessionCtx.phase)
-                {
-                    case Phase.PREPARE:
-                        {
-                            if (HashBucket.TryAcquireSharedLatch(bucket))
-                            {
-                                // Set to release shared latch (default)
-                                latchOperation = LatchOperation.Shared;
-                                if (GetLatestRecordVersion(ref entry, sessionCtx.version) > sessionCtx.version)
-                                {
-                                    status = OperationStatus.CPR_SHIFT_DETECTED;
-                                    goto CreatePendingContext; // Pivot Thread
-                                }
-                                break; // Normal Processing
-                            }
-                            else
-                            {
-                                status = OperationStatus.CPR_SHIFT_DETECTED;
-                                goto CreatePendingContext; // Pivot Thread
-                            }
-                        }
-                    case Phase.IN_PROGRESS:
-                        {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
-                            {
-                                if (HashBucket.TryAcquireExclusiveLatch(bucket))
-                                {
-                                    // Set to release exclusive latch (default)
-                                    latchOperation = LatchOperation.Exclusive;
-                                    goto CreateNewRecord; // Create a (v+1) record
-                                }
-                                else
-                                {
-                                    status = OperationStatus.RETRY_LATER;
-                                    goto CreatePendingContext; // Go Pending
-                                }
-                            }
-                            break; // Normal Processing
-                        }
-                    case Phase.WAIT_PENDING:
-                        {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
-                            {
-                                if (HashBucket.NoSharedLatches(bucket))
-                                {
-                                    goto CreateNewRecord; // Create a (v+1) record
-                                }
-                                else
-                                {
-                                    status = OperationStatus.RETRY_LATER;
-                                    goto CreatePendingContext; // Go Pending
-                                }
-                            }
-                            break; // Normal Processing
-                        }
-                    case Phase.WAIT_FLUSH:
-                        {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
-                            {
-                                goto CreateNewRecord; // Create a (v+1) record
-                            }
-                            break; // Normal Processing
-                        }
-                    default:
-                        break;
-                }
+                latchDestination = AcquireLatchUpsert(sessionCtx, bucket, ref status, ref latchOperation, ref entry);
             }
-#endregion
+            #endregion
 
             Debug.Assert(GetLatestRecordVersion(ref entry, sessionCtx.version) <= sessionCtx.version);
 
-#region Normal processing
+            #region Normal processing
 
             // Mutable Region: Update the record in-place
-            if (logicalAddress >= hlog.ReadOnlyAddress && !hlog.GetInfo(physicalAddress).Tombstone)
+            if (latchDestination == LatchDestination.NormalProcessing)
             {
-                if (fasterSession.ConcurrentWriter(ref key, ref value, ref hlog.GetValue(physicalAddress), logicalAddress))
+                if (logicalAddress >= hlog.ReadOnlyAddress)
                 {
-                    status = OperationStatus.SUCCESS;
-                    goto LatchRelease; // Release shared latch (if acquired)
+                    ref RecordInfo recordInfo = ref hlog.GetInfo(physicalAddress);
+                    if (!recordInfo.Tombstone
+                        && fasterSession.ConcurrentWriter(ref key, ref value, ref hlog.GetValue(physicalAddress), ref recordInfo, logicalAddress))
+                    {
+                        status = OperationStatus.SUCCESS;
+                        goto LatchRelease; // Release shared latch (if acquired)
+                    }
                 }
             }
 
@@ -437,46 +386,16 @@ namespace FASTER.core
 
 #region Create new record in the mutable region
         CreateNewRecord:
+            if (latchDestination != LatchDestination.CreatePendingContext)
             {
                 // Immutable region or new record
-                var (actualSize, allocateSize) = hlog.GetRecordSize(ref key, ref value);
-                BlockAllocate(allocateSize, out long newLogicalAddress, sessionCtx, fasterSession);
-                var newPhysicalAddress = hlog.GetPhysicalAddress(newLogicalAddress);
-                RecordInfo.WriteInfo(ref hlog.GetInfo(newPhysicalAddress),
-                               sessionCtx.version,
-                               tombstone:false, invalidBit:false,
-                               latestLogicalAddress);
-                hlog.Serialize(ref key, newPhysicalAddress);
-                fasterSession.SingleWriter(ref key, ref value,
-                                       ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize), newLogicalAddress);
-
-                var updatedEntry = default(HashBucketEntry);
-                updatedEntry.Tag = tag;
-                updatedEntry.Address = newLogicalAddress & Constants.kAddressMask;
-                updatedEntry.Pending = entry.Pending;
-                updatedEntry.Tentative = false;
-
-                var foundEntry = default(HashBucketEntry);
-                foundEntry.word = Interlocked.CompareExchange(
-                                        ref bucket->bucket_entries[slot],
-                                        updatedEntry.word, entry.word);
-
-                if (foundEntry.word == entry.word)
-                {
-                    status = OperationStatus.SUCCESS;
-                    goto LatchRelease;
-                }
-                else
-                {
-                    hlog.GetInfo(newPhysicalAddress).Invalid = true;
-                    status = OperationStatus.RETRY_NOW;
-                    goto LatchRelease;
-                }
+                status = CreateNewRecordUpsert(ref key, ref value, ref pendingContext, fasterSession, sessionCtx, bucket, slot, tag, entry, latestLogicalAddress);
+                goto LatchRelease;
             }
-#endregion
+            #endregion
 
-#region Create pending context
-        CreatePendingContext:
+            #region Create pending context
+            Debug.Assert(latchDestination == LatchDestination.CreatePendingContext, $"Upsert CreatePendingContext encountered latchDest == {latchDestination}");
             {
                 pendingContext.type = OperationType.UPSERT;
                 pendingContext.key = hlog.GetKeyContainer(ref key);
@@ -507,6 +426,110 @@ namespace FASTER.core
 #endregion
 
             return status;
+        }
+
+        private LatchDestination AcquireLatchUpsert<Input, Output, Context>(FasterExecutionContext<Input, Output, Context> sessionCtx, HashBucket* bucket, ref OperationStatus status, ref LatchOperation latchOperation, ref HashBucketEntry entry)
+        {
+            switch (sessionCtx.phase)
+            {
+                case Phase.PREPARE:
+                    {
+                        if (HashBucket.TryAcquireSharedLatch(bucket))
+                        {
+                            // Set to release shared latch (default)
+                            latchOperation = LatchOperation.Shared;
+                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) > sessionCtx.version)
+                            {
+                                status = OperationStatus.CPR_SHIFT_DETECTED;
+                                return LatchDestination.CreatePendingContext; // Pivot Thread
+                            }
+                            break; // Normal Processing
+                        }
+                        else
+                        {
+                            status = OperationStatus.CPR_SHIFT_DETECTED;
+                            return LatchDestination.CreatePendingContext; // Pivot Thread
+                        }
+                    }
+                case Phase.IN_PROGRESS:
+                    {
+                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        {
+                            if (HashBucket.TryAcquireExclusiveLatch(bucket))
+                            {
+                                // Set to release exclusive latch (default)
+                                latchOperation = LatchOperation.Exclusive;
+                                return LatchDestination.CreateNewRecord; // Create a (v+1) record
+                            }
+                            else
+                            {
+                                status = OperationStatus.RETRY_LATER;
+                                return LatchDestination.CreatePendingContext; // Go Pending
+                            }
+                        }
+                        break; // Normal Processing
+                    }
+                case Phase.WAIT_PENDING:
+                    {
+                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        {
+                            if (HashBucket.NoSharedLatches(bucket))
+                            {
+                                return LatchDestination.CreateNewRecord; // Create a (v+1) record
+                            }
+                            else
+                            {
+                                status = OperationStatus.RETRY_LATER;
+                                return LatchDestination.CreatePendingContext; // Go Pending
+                            }
+                        }
+                        break; // Normal Processing
+                    }
+                case Phase.WAIT_FLUSH:
+                    {
+                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        {
+                            return LatchDestination.CreateNewRecord; // Create a (v+1) record
+                        }
+                        break; // Normal Processing
+                    }
+                default:
+                    break;
+            }
+            return LatchDestination.NormalProcessing;
+        }
+
+        private OperationStatus CreateNewRecordUpsert<Input, Output, Context, FasterSession>(ref Key key, ref Value value, ref PendingContext<Input, Output, Context> pendingContext, FasterSession fasterSession, FasterExecutionContext<Input, Output, Context> sessionCtx, HashBucket* bucket, int slot, ushort tag, HashBucketEntry entry, long latestLogicalAddress) where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
+        {
+            var (actualSize, allocateSize) = hlog.GetRecordSize(ref key, ref value);
+            BlockAllocate(allocateSize, out long newLogicalAddress, sessionCtx, fasterSession);
+            var newPhysicalAddress = hlog.GetPhysicalAddress(newLogicalAddress);
+            RecordInfo.WriteInfo(ref hlog.GetInfo(newPhysicalAddress),
+                           sessionCtx.version,
+                           tombstone: false, invalidBit: false,
+                           latestLogicalAddress);
+            hlog.Serialize(ref key, newPhysicalAddress);
+            fasterSession.SingleWriter(ref key, ref value,
+                                   ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize));
+
+            var updatedEntry = default(HashBucketEntry);
+            updatedEntry.Tag = tag;
+            updatedEntry.Address = newLogicalAddress & Constants.kAddressMask;
+            updatedEntry.Pending = entry.Pending;
+            updatedEntry.Tentative = false;
+
+            var foundEntry = default(HashBucketEntry);
+            foundEntry.word = Interlocked.CompareExchange(ref bucket->bucket_entries[slot], updatedEntry.word, entry.word);
+
+            if (foundEntry.word == entry.word)
+            {
+                pendingContext.logicalAddress = newLogicalAddress;
+                return OperationStatus.SUCCESS;
+            }
+
+            // CAS failed
+            hlog.GetInfo(newPhysicalAddress).Invalid = true;
+            return OperationStatus.RETRY_NOW;
         }
 
 #endregion
@@ -561,11 +584,11 @@ namespace FASTER.core
         {
             var bucket = default(HashBucket*);
             var slot = default(int);
-            var logicalAddress = Constants.kInvalidAddress;
             var physicalAddress = default(long);
             var status = default(OperationStatus);
             var latchOperation = LatchOperation.None;
             var heldOperation = LatchOperation.None;
+            var latchDestination = LatchDestination.NormalProcessing;
 
             var hash = comparer.GetHashCode64(ref key);
             var tag = (ushort)((ulong)hash >> Constants.kHashTagShift);
@@ -576,7 +599,7 @@ namespace FASTER.core
 #region Trace back for record in in-memory HybridLog
             var entry = default(HashBucketEntry);
             FindOrCreateTag(hash, tag, ref bucket, ref slot, ref entry, hlog.BeginAddress);
-            logicalAddress = entry.Address;
+            var logicalAddress = entry.Address;
 
             // For simplicity, we don't let RMW operations use read cache
             if (UseReadCache)
@@ -590,245 +613,117 @@ namespace FASTER.core
                 if (!comparer.Equals(ref key, ref hlog.GetKey(physicalAddress)))
                 {
                     logicalAddress = hlog.GetInfo(physicalAddress).PreviousAddress;
-                    TraceBackForKeyMatch(ref key, logicalAddress,
-                                            hlog.HeadAddress,
-                                            out logicalAddress,
-                                            out physicalAddress);
+                    TraceBackForKeyMatch(ref key,
+                                        logicalAddress,
+                                        hlog.HeadAddress,
+                                        out logicalAddress,
+                                        out physicalAddress);
                 }
             }
 #endregion
 
             // Optimization for the most common case
-            if (sessionCtx.phase == Phase.REST && logicalAddress >= hlog.ReadOnlyAddress && !hlog.GetInfo(physicalAddress).Tombstone)
+            if (sessionCtx.phase == Phase.REST && logicalAddress >= hlog.ReadOnlyAddress)
             {
-                if (fasterSession.InPlaceUpdater(ref key, ref input, ref hlog.GetValue(physicalAddress), logicalAddress))
-                {
+                ref RecordInfo recordInfo = ref hlog.GetInfo(physicalAddress);
+                if (!recordInfo.Tombstone
+                    && fasterSession.InPlaceUpdater(ref key, ref input, ref hlog.GetValue(physicalAddress), ref recordInfo, logicalAddress))
                     return OperationStatus.SUCCESS;
-                }
                 goto CreateNewRecord;
             }
 
 #region Entry latch operation
             if (sessionCtx.phase != Phase.REST)
             {
-                switch (sessionCtx.phase)
-                {
-                    case Phase.PREPARE:
-                        {
-                            Debug.Assert(pendingContext.heldLatch != LatchOperation.Exclusive);
-                            if (pendingContext.heldLatch == LatchOperation.Shared || HashBucket.TryAcquireSharedLatch(bucket))
-                            {
-                                // Set to release shared latch (default)
-                                latchOperation = LatchOperation.Shared;
-                                if (GetLatestRecordVersion(ref entry, sessionCtx.version) > sessionCtx.version)
-                                {
-                                    status = OperationStatus.CPR_SHIFT_DETECTED;
-                                    goto CreateFailureContext; // Pivot Thread
-                                }
-                                break; // Normal Processing
-                            }
-                            else
-                            {
-                                status = OperationStatus.CPR_SHIFT_DETECTED;
-                                goto CreateFailureContext; // Pivot Thread
-                            }
-                        }
-                    case Phase.IN_PROGRESS:
-                        {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
-                            {
-                                Debug.Assert(pendingContext.heldLatch != LatchOperation.Shared);
-                                if (pendingContext.heldLatch == LatchOperation.Exclusive || HashBucket.TryAcquireExclusiveLatch(bucket))
-                                {
-                                    // Set to release exclusive latch (default)
-                                    latchOperation = LatchOperation.Exclusive;
-                                    if (logicalAddress >= hlog.HeadAddress)
-                                        goto CreateNewRecord; // Create a (v+1) record
-                                }
-                                else
-                                {
-                                    status = OperationStatus.RETRY_LATER;
-                                    goto CreateFailureContext; // Go Pending
-                                }
-                            }
-                            break; // Normal Processing
-                        }
-                    case Phase.WAIT_PENDING:
-                        {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
-                            {
-                                if (HashBucket.NoSharedLatches(bucket))
-                                {
-                                    if (logicalAddress >= hlog.HeadAddress)
-                                        goto CreateNewRecord; // Create a (v+1) record
-                                }
-                                else
-                                {
-                                    status = OperationStatus.RETRY_LATER;
-                                    goto CreateFailureContext; // Go Pending
-                                }
-                            }
-                            break; // Normal Processing
-                        }
-                    case Phase.WAIT_FLUSH:
-                        {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
-                            {
-                                if (logicalAddress >= hlog.HeadAddress)
-                                    goto CreateNewRecord; // Create a (v+1) record
-                            }
-                            break; // Normal Processing
-                        }
-                    default:
-                        break;
-                }
+                latchDestination = AcquireLatchRMW(pendingContext, sessionCtx, bucket, ref status, ref latchOperation, ref entry, logicalAddress);
             }
-#endregion
+            #endregion
 
             Debug.Assert(GetLatestRecordVersion(ref entry, sessionCtx.version) <= sessionCtx.version);
 
-#region Normal processing
+            #region Normal processing
 
             // Mutable Region: Update the record in-place
-            if (logicalAddress >= hlog.ReadOnlyAddress && !hlog.GetInfo(physicalAddress).Tombstone)
+            if (latchDestination == LatchDestination.NormalProcessing)
             {
-                if (FoldOverSnapshot)
+                if (logicalAddress >= hlog.ReadOnlyAddress)
                 {
-                    Debug.Assert(hlog.GetInfo(physicalAddress).Version == sessionCtx.version);
-                }
+                    ref RecordInfo recordInfo = ref hlog.GetInfo(physicalAddress);
+                    if (!recordInfo.Tombstone)
+                    { 
+                        if (FoldOverSnapshot)
+                        {
+                            Debug.Assert(recordInfo.Version == sessionCtx.version);
+                        }
 
-                if (fasterSession.InPlaceUpdater(ref key, ref input, ref hlog.GetValue(physicalAddress), logicalAddress))
-                {
-                    status = OperationStatus.SUCCESS;
-                    goto LatchRelease; // Release shared latch (if acquired)
-                }
-            }
-
-            // Fuzzy Region: Must go pending due to lost-update anomaly
-            else if (logicalAddress >= hlog.SafeReadOnlyAddress && !hlog.GetInfo(physicalAddress).Tombstone)
-            {
-                status = OperationStatus.RETRY_LATER;
-                // Do not retain latch for pendings ops in relaxed CPR
-                if (!RelaxedCPR)
-                {
-                    // Retain the shared latch (if acquired)
-                    if (latchOperation == LatchOperation.Shared)
-                    {
-                        heldOperation = latchOperation;
-                        latchOperation = LatchOperation.None;
+                        if (fasterSession.InPlaceUpdater(ref key, ref input, ref hlog.GetValue(physicalAddress), ref recordInfo, logicalAddress))
+                        {
+                            status = OperationStatus.SUCCESS;
+                            goto LatchRelease; // Release shared latch (if acquired)
+                        }
                     }
                 }
-                goto CreateFailureContext; // Go pending
-            }
 
-            // Safe Read-Only Region: Create a record in the mutable region
-            else if (logicalAddress >= hlog.HeadAddress)
-            {
-                goto CreateNewRecord;
-            }
-
-            // Disk Region: Need to issue async io requests
-            else if (logicalAddress >= hlog.BeginAddress)
-            {
-                status = OperationStatus.RECORD_ON_DISK;
-                // Do not retain latch for pendings ops in relaxed CPR
-                if (!RelaxedCPR)
+                // Fuzzy Region: Must go pending due to lost-update anomaly
+                else if (logicalAddress >= hlog.SafeReadOnlyAddress && !hlog.GetInfo(physicalAddress).Tombstone)
                 {
-                    // Retain the shared latch (if acquired)
-                    if (latchOperation == LatchOperation.Shared)
+                    status = OperationStatus.RETRY_LATER;
+                    // Do not retain latch for pendings ops in relaxed CPR
+                    if (!RelaxedCPR)
                     {
-                        heldOperation = latchOperation;
-                        latchOperation = LatchOperation.None;
+                        // Retain the shared latch (if acquired)
+                        if (latchOperation == LatchOperation.Shared)
+                        {
+                            heldOperation = latchOperation;
+                            latchOperation = LatchOperation.None;
+                        }
                     }
+                    latchDestination = LatchDestination.CreatePendingContext; // Go pending
                 }
-                goto CreateFailureContext; // Go pending
-            }
 
-            // No record exists - create new
-            else
-            {
-                goto CreateNewRecord;
+                // Safe Read-Only Region: Create a record in the mutable region
+                else if (logicalAddress >= hlog.HeadAddress)
+                {
+                    goto CreateNewRecord;
+                }
+
+                // Disk Region: Need to issue async io requests
+                else if (logicalAddress >= hlog.BeginAddress)
+                {
+                    status = OperationStatus.RECORD_ON_DISK;
+                    // Do not retain latch for pendings ops in relaxed CPR
+                    if (!RelaxedCPR)
+                    {
+                        // Retain the shared latch (if acquired)
+                        if (latchOperation == LatchOperation.Shared)
+                        {
+                            heldOperation = latchOperation;
+                            latchOperation = LatchOperation.None;
+                        }
+                    }
+                    latchDestination = LatchDestination.CreatePendingContext; // Go pending
+                }
+
+                // No record exists - create new
+                else
+                {
+                    goto CreateNewRecord;
+                }
             }
 
 #endregion
 
 #region Create new record
         CreateNewRecord:
+            if (latchDestination != LatchDestination.CreatePendingContext)
             {
-                if (logicalAddress >= hlog.HeadAddress && !hlog.GetInfo(physicalAddress).Tombstone)
-                {
-                    if (!fasterSession.NeedCopyUpdate(ref key, ref input, ref hlog.GetValue(physicalAddress)))
-                    {
-                        status = OperationStatus.SUCCESS;
-                        goto LatchRelease;
-                    }
-                }
-
-                var (actualSize, allocatedSize) = (logicalAddress < hlog.BeginAddress) ?
-                                hlog.GetInitialRecordSize(ref key, ref input, fasterSession) :
-                                hlog.GetRecordSize(physicalAddress, ref input, fasterSession);
-                BlockAllocate(allocatedSize, out long newLogicalAddress, sessionCtx, fasterSession);
-                var newPhysicalAddress = hlog.GetPhysicalAddress(newLogicalAddress);
-                RecordInfo.WriteInfo(ref hlog.GetInfo(newPhysicalAddress), sessionCtx.version,
-                                tombstone:false, invalidBit:false,
-                                latestLogicalAddress);
-                hlog.Serialize(ref key, newPhysicalAddress);
-
-                if (logicalAddress < hlog.BeginAddress)
-                {
-                    fasterSession.InitialUpdater(ref key, ref input, ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize), newLogicalAddress);
-                    status = OperationStatus.NOTFOUND;
-                }
-                else if (logicalAddress >= hlog.HeadAddress)
-                {
-                    if (hlog.GetInfo(physicalAddress).Tombstone)
-                    {
-                        fasterSession.InitialUpdater(ref key, ref input, ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize), newLogicalAddress);
-                        status = OperationStatus.NOTFOUND;
-                    }
-                    else
-                    {
-                        fasterSession.CopyUpdater(ref key, ref input,
-                                                ref hlog.GetValue(physicalAddress),
-                                                ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize), logicalAddress, newLogicalAddress);
-                        status = OperationStatus.SUCCESS;
-                    }
-                }
-                else
-                {
-                    // ah, old record slipped onto disk
-                    hlog.GetInfo(newPhysicalAddress).Invalid = true;
-                    status = OperationStatus.RETRY_NOW;
-                    goto LatchRelease;
-                }
-
-                var updatedEntry = default(HashBucketEntry);
-                updatedEntry.Tag = tag;
-                updatedEntry.Address = newLogicalAddress & Constants.kAddressMask;
-                updatedEntry.Pending = entry.Pending;
-                updatedEntry.Tentative = false;
-
-                var foundEntry = default(HashBucketEntry);
-                foundEntry.word = Interlocked.CompareExchange(
-                                        ref bucket->bucket_entries[slot],
-                                        updatedEntry.word, entry.word);
-
-                if (foundEntry.word == entry.word)
-                {
-                    goto LatchRelease;
-                }
-                else
-                {
-                    // CAS failed
-                    hlog.GetInfo(newPhysicalAddress).Invalid = true;
-                    status = OperationStatus.RETRY_NOW;
-                    goto LatchRelease;
-                }
+                status = CreateNewRecordRMW(ref key, ref input, ref pendingContext, fasterSession, sessionCtx, bucket, slot, logicalAddress, physicalAddress, tag, entry, latestLogicalAddress);
+                goto LatchRelease;
             }
-#endregion
+        #endregion
 
-#region Create failure context
-        CreateFailureContext:
+        #region Create failure context
+            Debug.Assert(latchDestination == LatchDestination.CreatePendingContext, $"RMW CreatePendingContext encountered latchDest == {latchDestination}");
             {
                 pendingContext.type = OperationType.RMW;
                 pendingContext.key = hlog.GetKeyContainer(ref key);
@@ -858,6 +753,151 @@ namespace FASTER.core
                 }
             }
 #endregion
+
+            return status;
+        }
+
+        private LatchDestination AcquireLatchRMW<Input, Output, Context>(PendingContext<Input, Output, Context> pendingContext, FasterExecutionContext<Input, Output, Context> sessionCtx,
+                                                                         HashBucket* bucket, ref OperationStatus status, ref LatchOperation latchOperation, ref HashBucketEntry entry, long logicalAddress)
+        {
+            switch (sessionCtx.phase)
+            {
+                case Phase.PREPARE:
+                    {
+                        Debug.Assert(pendingContext.heldLatch != LatchOperation.Exclusive);
+                        if (pendingContext.heldLatch == LatchOperation.Shared || HashBucket.TryAcquireSharedLatch(bucket))
+                        {
+                            // Set to release shared latch (default)
+                            latchOperation = LatchOperation.Shared;
+                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) > sessionCtx.version)
+                            {
+                                status = OperationStatus.CPR_SHIFT_DETECTED;
+                                return LatchDestination.CreatePendingContext; // Pivot Thread
+                            }
+                            break; // Normal Processing
+                        }
+                        else
+                        {
+                            status = OperationStatus.CPR_SHIFT_DETECTED;
+                            return LatchDestination.CreatePendingContext; // Pivot Thread
+                        }
+                    }
+                case Phase.IN_PROGRESS:
+                    {
+                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        {
+                            Debug.Assert(pendingContext.heldLatch != LatchOperation.Shared);
+                            if (pendingContext.heldLatch == LatchOperation.Exclusive || HashBucket.TryAcquireExclusiveLatch(bucket))
+                            {
+                                // Set to release exclusive latch (default)
+                                latchOperation = LatchOperation.Exclusive;
+                                if (logicalAddress >= hlog.HeadAddress)
+                                    return LatchDestination.CreateNewRecord; // Create a (v+1) record
+                            }
+                            else
+                            {
+                                status = OperationStatus.RETRY_LATER;
+                                return LatchDestination.CreatePendingContext; // Go Pending
+                            }
+                        }
+                        break; // Normal Processing
+                    }
+                case Phase.WAIT_PENDING:
+                    {
+                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        {
+                            if (HashBucket.NoSharedLatches(bucket))
+                            {
+                                if (logicalAddress >= hlog.HeadAddress)
+                                    return LatchDestination.CreateNewRecord; // Create a (v+1) record
+                            }
+                            else
+                            {
+                                status = OperationStatus.RETRY_LATER;
+                                return LatchDestination.CreatePendingContext; // Go Pending
+                            }
+                        }
+                        break; // Normal Processing
+                    }
+                case Phase.WAIT_FLUSH:
+                    {
+                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        {
+                            if (logicalAddress >= hlog.HeadAddress)
+                                return LatchDestination.CreateNewRecord; // Create a (v+1) record
+                        }
+                        break; // Normal Processing
+                    }
+                default:
+                    break;
+            }
+            return LatchDestination.NormalProcessing;
+        }
+
+        private OperationStatus CreateNewRecordRMW<Input, Output, Context, FasterSession>(ref Key key, ref Input input, ref PendingContext<Input, Output, Context> pendingContext, FasterSession fasterSession, FasterExecutionContext<Input, Output, Context> sessionCtx, HashBucket* bucket, int slot, long logicalAddress, long physicalAddress, ushort tag, HashBucketEntry entry, long latestLogicalAddress) where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
+        {
+            if (logicalAddress >= hlog.HeadAddress && !hlog.GetInfo(physicalAddress).Tombstone)
+            {
+                if (!fasterSession.NeedCopyUpdate(ref key, ref input, ref hlog.GetValue(physicalAddress)))
+                    return OperationStatus.SUCCESS;
+            }
+
+            var (actualSize, allocatedSize) = (logicalAddress < hlog.BeginAddress) ?
+                            hlog.GetInitialRecordSize(ref key, ref input, fasterSession) :
+                            hlog.GetRecordSize(physicalAddress, ref input, fasterSession);
+            BlockAllocate(allocatedSize, out long newLogicalAddress, sessionCtx, fasterSession);
+            var newPhysicalAddress = hlog.GetPhysicalAddress(newLogicalAddress);
+            RecordInfo.WriteInfo(ref hlog.GetInfo(newPhysicalAddress), sessionCtx.version,
+                            tombstone: false, invalidBit: false,
+                            latestLogicalAddress);
+            hlog.Serialize(ref key, newPhysicalAddress);
+
+            OperationStatus status;
+            if (logicalAddress < hlog.BeginAddress)
+            {
+                fasterSession.InitialUpdater(ref key, ref input, ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize));
+                status = OperationStatus.NOTFOUND;
+            }
+            else if (logicalAddress >= hlog.HeadAddress)
+            {
+                if (hlog.GetInfo(physicalAddress).Tombstone)
+                {
+                    fasterSession.InitialUpdater(ref key, ref input, ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize));
+                    status = OperationStatus.NOTFOUND;
+                }
+                else
+                {
+                    fasterSession.CopyUpdater(ref key, ref input,
+                                            ref hlog.GetValue(physicalAddress),
+                                            ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize));
+                    status = OperationStatus.SUCCESS;
+                }
+            }
+            else
+            {
+                // ah, old record slipped onto disk
+                hlog.GetInfo(newPhysicalAddress).Invalid = true;
+                return OperationStatus.RETRY_NOW;
+            }
+
+            var updatedEntry = default(HashBucketEntry);
+            updatedEntry.Tag = tag;
+            updatedEntry.Address = newLogicalAddress & Constants.kAddressMask;
+            updatedEntry.Pending = entry.Pending;
+            updatedEntry.Tentative = false;
+
+            var foundEntry = default(HashBucketEntry);
+            foundEntry.word = Interlocked.CompareExchange(ref bucket->bucket_entries[slot], updatedEntry.word, entry.word);
+            if (foundEntry.word == entry.word)
+            {
+                pendingContext.logicalAddress = newLogicalAddress;
+            }
+            else
+            {
+                // CAS failed
+                hlog.GetInfo(newPhysicalAddress).Invalid = true;
+                status = OperationStatus.RETRY_NOW;
+            }
 
             return status;
         }
@@ -1025,29 +1065,25 @@ namespace FASTER.core
             // Mutable Region: Update the record in-place
             if (logicalAddress >= hlog.ReadOnlyAddress)
             {
-                // Apply tombstone bit to the record
-                hlog.GetInfo(physicalAddress).Tombstone = true;
+                ref RecordInfo recordInfo = ref hlog.GetInfo(physicalAddress);
 
-                if (WriteDefaultOnDelete)
-                {
-                    // Write default value. Ignore return value; the record is already marked
-                    Value v = default;
-                    fasterSession.ConcurrentWriter(ref hlog.GetKey(physicalAddress), ref v, ref hlog.GetValue(physicalAddress), logicalAddress);
-                }
+                // Ignore return value of ConcurrentDeleter; the InternalFasterSession wrappers handle the false return.
+                fasterSession.ConcurrentDeleter(ref hlog.GetKey(physicalAddress), ref hlog.GetValue(physicalAddress), ref recordInfo, logicalAddress);
 
                 // Try to update hash chain and completely elide record only if previous address points to invalid address
-                if (entry.Address == logicalAddress && hlog.GetInfo(physicalAddress).PreviousAddress < hlog.BeginAddress)
+                if (entry.Address == logicalAddress && recordInfo.PreviousAddress < hlog.BeginAddress)
                 {
                     var updatedEntry = default(HashBucketEntry);
                     updatedEntry.Tag = 0;
-                    if (hlog.GetInfo(physicalAddress).PreviousAddress == Constants.kTempInvalidAddress)
+                    if (recordInfo.PreviousAddress == Constants.kTempInvalidAddress)
                         updatedEntry.Address = Constants.kInvalidAddress;
                     else
-                        updatedEntry.Address = hlog.GetInfo(physicalAddress).PreviousAddress;
+                        updatedEntry.Address = recordInfo.PreviousAddress;
                     updatedEntry.Pending = entry.Pending;
                     updatedEntry.Tentative = false;
 
-                    // Ignore return value; this is a performance optimization to keep the hash table clean if we can
+                    // Ignore return value; this is a performance optimization to keep the hash table clean if we can, so if we fail it just means
+                    // the hashtable entry has already been updated by someone else.
                     Interlocked.CompareExchange(ref bucket->bucket_entries[slot], updatedEntry.word, entry.word);
                 }
 
@@ -1085,6 +1121,7 @@ namespace FASTER.core
 
                 if (foundEntry.word == entry.word)
                 {
+                    pendingContext.logicalAddress = newLogicalAddress;
                     status = OperationStatus.SUCCESS;
                     goto LatchRelease;
                 }
@@ -1128,6 +1165,14 @@ namespace FASTER.core
 #endregion
 
             return status;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void SetRecordDeleted(ref Value value, ref RecordInfo recordInfo)
+        {
+            recordInfo.Tombstone = true;
+            if (hlog.ValueHasObjects())
+                value = default;
         }
 
 #endregion
@@ -1332,8 +1377,7 @@ namespace FASTER.core
                 readcache.Serialize(ref key, newPhysicalAddress);
                 fasterSession.SingleWriter(ref key,
                                        ref hlog.GetContextRecordValue(ref request),
-                                       ref readcache.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize),
-                                       Constants.kInvalidAddress);  // ReadCache addresses are not valid for indexing etc.
+                                       ref readcache.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize));
             }
             else
             {
@@ -1345,8 +1389,7 @@ namespace FASTER.core
                 hlog.Serialize(ref key, newPhysicalAddress);
                 fasterSession.SingleWriter(ref key,
                                        ref hlog.GetContextRecordValue(ref request),
-                                       ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize),
-                                       newLogicalAddress);
+                                       ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize));
             }
 
 
@@ -1479,7 +1522,7 @@ namespace FASTER.core
                 {
                     fasterSession.InitialUpdater(ref key,
                                              ref pendingContext.input.Get(),
-                                             ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize), newLogicalAddress);
+                                             ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize));
                     status = OperationStatus.NOTFOUND;
                 }
                 else
@@ -1487,7 +1530,7 @@ namespace FASTER.core
                     fasterSession.CopyUpdater(ref key,
                                           ref pendingContext.input.Get(),
                                           ref hlog.GetContextRecordValue(ref request),
-                                          ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize), request.logicalAddress, newLogicalAddress);
+                                          ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize));
                     status = OperationStatus.SUCCESS;
                 }
 

--- a/cs/src/core/Index/FASTER/FASTERLegacy.cs
+++ b/cs/src/core/Index/FASTER/FASTERLegacy.cs
@@ -321,20 +321,25 @@ namespace FASTER.core
                 _fasterKV._functions.CheckpointCompletionCallback(guid, commitPoint);
             }
 
-            public void ConcurrentReader(ref Key key, ref Input input, ref Value value, ref Output dst, long address)
+            public void ConcurrentReader(ref Key key, ref Input input, ref Value value, ref Output dst, ref RecordInfo recordInfo, long address)
             {
                 _fasterKV._functions.ConcurrentReader(ref key, ref input, ref value, ref dst);
             }
 
-            public bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst, long address)
+            public bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst, ref RecordInfo recordInfo, long address)
             {
                 return _fasterKV._functions.ConcurrentWriter(ref key, ref src, ref dst);
+            }
+
+            public bool ConcurrentDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, long address)
+            {
+                return false;
             }
 
             public bool NeedCopyUpdate(ref Key key, ref Input input, ref Value oldValue)
                 => _fasterKV._functions.NeedCopyUpdate(ref key, ref input, ref oldValue);
 
-            public void CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue, long oldAddress, long newAddress)
+            public void CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue)
             {
                 _fasterKV._functions.CopyUpdater(ref key, ref input, ref oldValue, ref newValue);
             }
@@ -354,12 +359,12 @@ namespace FASTER.core
                 return _fasterKV._variableLengthStructForInput.GetLength(ref t, ref input);
             }
 
-            public void InitialUpdater(ref Key key, ref Input input, ref Value value, long address)
+            public void InitialUpdater(ref Key key, ref Input input, ref Value value)
             {
                 _fasterKV._functions.InitialUpdater(ref key, ref input, ref value);
             }
 
-            public bool InPlaceUpdater(ref Key key, ref Input input, ref Value value, long address)
+            public bool InPlaceUpdater(ref Key key, ref Input input, ref Value value, ref RecordInfo recordInfo, long address)
             {
                 return _fasterKV._functions.InPlaceUpdater(ref key, ref input, ref value);
             }
@@ -379,7 +384,7 @@ namespace FASTER.core
                 _fasterKV._functions.SingleReader(ref key, ref input, ref value, ref dst);
             }
 
-            public void SingleWriter(ref Key key, ref Value src, ref Value dst, long address)
+            public void SingleWriter(ref Key key, ref Value src, ref Value dst)
             {
                 _fasterKV._functions.SingleWriter(ref key, ref src, ref dst);
             }
@@ -396,6 +401,12 @@ namespace FASTER.core
             {
                 _fasterKV._functions.UpsertCompletionCallback(ref key, ref value, ctx);
             }
+
+            public bool SupportsLocking => false;
+
+            public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long context) { }
+
+            public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long context) => true;
 
             public IHeapContainer<Input> GetHeapContainer(ref Input input)
             {

--- a/cs/src/core/Index/FASTER/FASTERLegacy.cs
+++ b/cs/src/core/Index/FASTER/FASTERLegacy.cs
@@ -331,10 +331,7 @@ namespace FASTER.core
                 return _fasterKV._functions.ConcurrentWriter(ref key, ref src, ref dst);
             }
 
-            public bool ConcurrentDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, long address)
-            {
-                return false;
-            }
+            public void ConcurrentDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, long address) { }
 
             public bool NeedCopyUpdate(ref Key key, ref Input input, ref Value oldValue)
                 => _fasterKV._functions.NeedCopyUpdate(ref key, ref input, ref oldValue);

--- a/cs/src/core/Index/FASTER/FASTERLegacy.cs
+++ b/cs/src/core/Index/FASTER/FASTERLegacy.cs
@@ -404,9 +404,9 @@ namespace FASTER.core
 
             public bool SupportsLocking => false;
 
-            public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long context) { }
+            public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long lockContext) { }
 
-            public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long context) => true;
+            public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long lockContext) => true;
 
             public IHeapContainer<Input> GetHeapContainer(ref Input input)
             {

--- a/cs/src/core/Index/FASTER/LogCompactionFunctions.cs
+++ b/cs/src/core/Index/FASTER/LogCompactionFunctions.cs
@@ -55,7 +55,7 @@ namespace FASTER.core
         public void UpsertCompletionCallback(ref Key key, ref Value value, Context ctx) { }
 
         public bool SupportsLocking => false;
-        public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long context) { }
-        public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long context) => true;
+        public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long lockContext) { }
+        public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long lockContext) => true;
     }
 }

--- a/cs/src/core/Index/FASTER/LogCompactionFunctions.cs
+++ b/cs/src/core/Index/FASTER/LogCompactionFunctions.cs
@@ -53,5 +53,9 @@ namespace FASTER.core
         public void SingleWriter(ref Key key, ref Value src, ref Value dst) => _functions.SingleWriter(ref key, ref src, ref dst);
 
         public void UpsertCompletionCallback(ref Key key, ref Value value, Context ctx) { }
+
+        public bool SupportsLocking => false;
+        public void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long context) { }
+        public bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long context) => true;
     }
 }

--- a/cs/src/core/Index/Interfaces/FunctionsBase.cs
+++ b/cs/src/core/Index/Interfaces/FunctionsBase.cs
@@ -151,7 +151,7 @@ namespace FASTER.core
         public virtual bool InPlaceUpdater(ref Key key, ref Input input, ref Value value, ref RecordInfo recordInfo, long address) => true;
 
         /// <inheritdoc/>
-        public virtual bool ConcurrentDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, long address) { return false; }
+        public virtual void ConcurrentDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, long address) { }
 
         /// <inheritdoc/>
         public virtual void ReadCompletionCallback(ref Key key, ref Input input, ref Output output, Context ctx, Status status, RecordInfo recordInfo) { }

--- a/cs/src/core/Index/Interfaces/FunctionsBase.cs
+++ b/cs/src/core/Index/Interfaces/FunctionsBase.cs
@@ -21,35 +21,49 @@ namespace FASTER.core
 
         protected FunctionsBase(bool locking = false) => this.locking = locking;
 
+        /// <inheritdoc/>
         public virtual void ConcurrentReader(ref Key key, ref Input input, ref Value value, ref Output dst) { }
+        /// <inheritdoc/>
         public virtual void SingleReader(ref Key key, ref Input input, ref Value value, ref Output dst) { }
 
+        /// <inheritdoc/>
         public virtual bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst) { dst = src; return true; }
+        /// <inheritdoc/>
         public virtual void SingleWriter(ref Key key, ref Value src, ref Value dst) => dst = src;
 
+        /// <inheritdoc/>
         public virtual void InitialUpdater(ref Key key, ref Input input, ref Value value) { }
+        /// <inheritdoc/>
         public virtual bool NeedCopyUpdate(ref Key key, ref Input input, ref Value oldValue) => true;
+        /// <inheritdoc/>
         public virtual void CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue) { }
+        /// <inheritdoc/>
         public virtual bool InPlaceUpdater(ref Key key, ref Input input, ref Value value) => true;
 
+        /// <inheritdoc/>
         public virtual void ReadCompletionCallback(ref Key key, ref Input input, ref Output output, Context ctx, Status status) { }
+        /// <inheritdoc/>
         public virtual void RMWCompletionCallback(ref Key key, ref Input input, Context ctx, Status status) { }
+        /// <inheritdoc/>
         public virtual void UpsertCompletionCallback(ref Key key, ref Value value, Context ctx) { }
+        /// <inheritdoc/>
         public virtual void DeleteCompletionCallback(ref Key key, Context ctx) { }
+        /// <inheritdoc/>
         public virtual void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint) { }
 
+        /// <inheritdoc/>
         public virtual bool SupportsLocking => locking;
 
+        /// <inheritdoc/>
         public virtual void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long lockContext)
         {
-            if (locking)
-                recordInfo.SpinLock();
+            recordInfo.SpinLock();
         }
 
+        /// <inheritdoc/>
         public virtual bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long lockContext)
         {
-            if (locking)
-                recordInfo.Unlock();
+            recordInfo.Unlock();
             return true;
         }
     }
@@ -68,20 +82,32 @@ namespace FASTER.core
         public SimpleFunctions() => merger = (l, r) => l;
         public SimpleFunctions(Func<Value, Value, Value> merger) => this.merger = merger;
 
+        /// <inheritdoc/>
         public override void ConcurrentReader(ref Key key, ref Value input, ref Value value, ref Value dst) => dst = value;
+        /// <inheritdoc/>
         public override void SingleReader(ref Key key, ref Value input, ref Value value, ref Value dst) => dst = value;
 
+        /// <inheritdoc/>
         public override bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst) { dst = src; return true; }
+        /// <inheritdoc/>
         public override void SingleWriter(ref Key key, ref Value src, ref Value dst) => dst = src;
 
+        /// <inheritdoc/>
         public override void InitialUpdater(ref Key key, ref Value input, ref Value value) => value = input;
+        /// <inheritdoc/>
         public override void CopyUpdater(ref Key key, ref Value input, ref Value oldValue, ref Value newValue) => newValue = merger(input, oldValue);
+        /// <inheritdoc/>
         public override bool InPlaceUpdater(ref Key key, ref Value input, ref Value value) { value = merger(input, value); return true; }
 
+        /// <inheritdoc/>
         public override void ReadCompletionCallback(ref Key key, ref Value input, ref Value output, Context ctx, Status status) { }
+        /// <inheritdoc/>
         public override void RMWCompletionCallback(ref Key key, ref Value input, Context ctx, Status status) { }
+        /// <inheritdoc/>
         public override void UpsertCompletionCallback(ref Key key, ref Value value, Context ctx) { }
+        /// <inheritdoc/>
         public override void DeleteCompletionCallback(ref Key key, Context ctx) { }
+        /// <inheritdoc/>
         public override void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint) { }
     }
 
@@ -105,37 +131,52 @@ namespace FASTER.core
 
         protected AdvancedFunctionsBase(bool locking = false) => this.locking = locking;
 
+        /// <inheritdoc/>
         public virtual void ConcurrentReader(ref Key key, ref Input input, ref Value value, ref Output dst, ref RecordInfo recordInfo, long address) { }
+        /// <inheritdoc/>
         public virtual void SingleReader(ref Key key, ref Input input, ref Value value, ref Output dst, long address) { }
 
+        /// <inheritdoc/>
         public virtual bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst, ref RecordInfo recordInfo, long address) { dst = src; return true; }
+        /// <inheritdoc/>
         public virtual void SingleWriter(ref Key key, ref Value src, ref Value dst) => dst = src;
 
+        /// <inheritdoc/>
         public virtual void InitialUpdater(ref Key key, ref Input input, ref Value value) { }
+        /// <inheritdoc/>
         public virtual bool NeedCopyUpdate(ref Key key, ref Input input, ref Value oldValue) => true;
+        /// <inheritdoc/>
         public virtual void CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue) { }
+        /// <inheritdoc/>
         public virtual bool InPlaceUpdater(ref Key key, ref Input input, ref Value value, ref RecordInfo recordInfo, long address) => true;
 
+        /// <inheritdoc/>
         public virtual bool ConcurrentDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, long address) { return false; }
 
+        /// <inheritdoc/>
         public virtual void ReadCompletionCallback(ref Key key, ref Input input, ref Output output, Context ctx, Status status, RecordInfo recordInfo) { }
+        /// <inheritdoc/>
         public virtual void RMWCompletionCallback(ref Key key, ref Input input, Context ctx, Status status) { }
+        /// <inheritdoc/>
         public virtual void UpsertCompletionCallback(ref Key key, ref Value value, Context ctx) { }
+        /// <inheritdoc/>
         public virtual void DeleteCompletionCallback(ref Key key, Context ctx) { }
+        /// <inheritdoc/>
         public virtual void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint) { }
 
+        /// <inheritdoc/>
         public virtual bool SupportsLocking => locking;
 
+        /// <inheritdoc/>
         public virtual void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long lockContext)
         {
-            if (locking)
-                recordInfo.SpinLock();
+            recordInfo.SpinLock();
         }
 
+        /// <inheritdoc/>
         public virtual bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long lockContext)
         {
-            if (locking)
-                recordInfo.Unlock();
+            recordInfo.Unlock();
             return true;
         }
     }
@@ -154,20 +195,32 @@ namespace FASTER.core
         public AdvancedSimpleFunctions() => merger = (l, r) => l;
         public AdvancedSimpleFunctions(Func<Value, Value, Value> merger) => this.merger = merger;
 
+        /// <inheritdoc/>
         public override void ConcurrentReader(ref Key key, ref Value input, ref Value value, ref Value dst, ref RecordInfo recordInfo, long address) => dst = value;
+        /// <inheritdoc/>
         public override void SingleReader(ref Key key, ref Value input, ref Value value, ref Value dst, long address) => dst = value;
 
+        /// <inheritdoc/>
         public override bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst, ref RecordInfo recordInfo, long address) { dst = src; return true; }
+        /// <inheritdoc/>
         public override void SingleWriter(ref Key key, ref Value src, ref Value dst) => dst = src;
 
+        /// <inheritdoc/>
         public override void InitialUpdater(ref Key key, ref Value input, ref Value value) => value = input;
+        /// <inheritdoc/>
         public override void CopyUpdater(ref Key key, ref Value input, ref Value oldValue, ref Value newValue) => newValue = merger(input, oldValue);
+        /// <inheritdoc/>
         public override bool InPlaceUpdater(ref Key key, ref Value input, ref Value value, ref RecordInfo recordInfo, long address) { value = merger(input, value); return true; }
 
+        /// <inheritdoc/>
         public override void ReadCompletionCallback(ref Key key, ref Value input, ref Value output, Context ctx, Status status, RecordInfo recordInfo) { }
+        /// <inheritdoc/>
         public override void RMWCompletionCallback(ref Key key, ref Value input, Context ctx, Status status) { }
+        /// <inheritdoc/>
         public override void UpsertCompletionCallback(ref Key key, ref Value value, Context ctx) { }
+        /// <inheritdoc/>
         public override void DeleteCompletionCallback(ref Key key, Context ctx) { }
+        /// <inheritdoc/>
         public override void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint) { }
     }
 

--- a/cs/src/core/Index/Interfaces/FunctionsBase.cs
+++ b/cs/src/core/Index/Interfaces/FunctionsBase.cs
@@ -40,13 +40,13 @@ namespace FASTER.core
 
         public virtual bool SupportsLocking => locking;
 
-        public virtual void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long context)
+        public virtual void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long lockContext)
         {
             if (locking)
                 recordInfo.SpinLock();
         }
 
-        public virtual bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long context)
+        public virtual bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long lockContext)
         {
             if (locking)
                 recordInfo.Unlock();
@@ -126,13 +126,13 @@ namespace FASTER.core
 
         public virtual bool SupportsLocking => locking;
 
-        public virtual void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long context)
+        public virtual void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long lockContext)
         {
             if (locking)
                 recordInfo.SpinLock();
         }
 
-        public virtual bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long context)
+        public virtual bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long lockContext)
         {
             if (locking)
                 recordInfo.Unlock();

--- a/cs/src/core/Index/Interfaces/IAdvancedFunctions.cs
+++ b/cs/src/core/Index/Interfaces/IAdvancedFunctions.cs
@@ -172,7 +172,7 @@ namespace FASTER.core
         /// <param name="key">The key for the current record</param>
         /// <param name="value">The value for the current record</param>
         /// <param name="lockType">The type of lock being released, as passed to <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/></param>
-        /// <param name="context">The context returned from <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/></param>
+        /// <param name="lockContext">The context returned from <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/></param>
         /// <remarks>
         /// This is called only for records guaranteed to be in the mutable range.
         /// </remarks>
@@ -180,7 +180,7 @@ namespace FASTER.core
         /// True if no inconsistencies detected. Otherwise, the lock and user's callback are reissued.
         /// Currently this is handled only for <see cref="ConcurrentReader(ref Key, ref Input, ref Value, ref Output, ref RecordInfo, long)"/>.
         /// </returns>
-        bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long context);
+        bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long lockContext);
     }
 
     /// <summary>

--- a/cs/src/core/Index/Interfaces/IAdvancedFunctions.cs
+++ b/cs/src/core/Index/Interfaces/IAdvancedFunctions.cs
@@ -141,8 +141,8 @@ namespace FASTER.core
         /// <param name="value">The value for the record being deleted; because this method is called only for in-place updates, there is a previous value there. Usually this is ignored or assigned 'default'.</param>
         /// <param name="recordInfo">A reference to the header of the record; may be used by <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/></param>
         /// <param name="address">The logical address of the record being copied to; used as a RecordId by indexing</param>
-        /// <returns>True if handled by the Functions implementation, else false</returns>
-        public bool ConcurrentDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, long address);
+        /// <remarks>For Object Value types, Dispose() can be called here.</remarks>
+        public void ConcurrentDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, long address);
 
         /// <summary>
         /// Whether this Functions instance supports locking. Iff so, FASTER will call <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/> 

--- a/cs/src/core/Index/Interfaces/IAdvancedFunctions.cs
+++ b/cs/src/core/Index/Interfaces/IAdvancedFunctions.cs
@@ -145,8 +145,8 @@ namespace FASTER.core
         public bool ConcurrentDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, long address);
 
         /// <summary>
-        /// Whether this Functions implementation actually locks in <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/> 
-        /// and <see cref="Unlock(ref RecordInfo, ref Key, ref Value, LockType, long)"/>
+        /// Whether this Functions instance supports locking. Iff so, FASTER will call <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/> 
+        /// and <see cref="Unlock(ref RecordInfo, ref Key, ref Value, LockType, long)"/>.
         /// </summary>
         bool SupportsLocking { get; }
 

--- a/cs/src/core/Index/Interfaces/IAdvancedFunctions.cs
+++ b/cs/src/core/Index/Interfaces/IAdvancedFunctions.cs
@@ -158,11 +158,11 @@ namespace FASTER.core
         /// <param name="key">The key for the current record</param>
         /// <param name="value">The value for the current record</param>
         /// <param name="lockType">The type of lock being taken</param>
-        /// <param name="context">Context-specific information; will be passed to <see cref="Unlock(ref RecordInfo, ref Key, ref Value, LockType, long)"/></param>
+        /// <param name="lockContext">Context-specific information; will be passed to <see cref="Unlock(ref RecordInfo, ref Key, ref Value, LockType, long)"/></param>
         /// <remarks>
         /// This is called only for records guaranteed to be in the mutable range.
         /// </remarks>
-        void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long context);
+        void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long lockContext);
 
         /// <summary>
         /// User-provided unlock call, defaulting to no-op. A default exclusive implementation is available via <see cref="RecordInfo.Unlock()"/>.

--- a/cs/src/core/Index/Interfaces/IFunctions.cs
+++ b/cs/src/core/Index/Interfaces/IFunctions.cs
@@ -125,6 +125,44 @@ namespace FASTER.core
         /// <param name="src">The value to be copied to <paramref name="dst"/></param>
         /// <param name="dst">The location where <paramref name="src"/> is to be copied; because this method is called only for in-place updates, there is a previous value there.</param>
         bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst);
+
+        /// <summary>
+        /// Whether this Functions implementation actually locks in <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/> 
+        /// and <see cref="Unlock(ref RecordInfo, ref Key, ref Value, LockType, long)"/>
+        /// </summary>
+        bool SupportsLocking { get; }
+
+        /// <summary>
+        /// User-provided lock call, defaulting to no-op. A default exclusive implementation is available via <see cref="RecordInfo.SpinLock()"/>.
+        /// See also <see cref="IntExclusiveLocker"/> to use two bits of an existing int value.
+        /// </summary>
+        /// <param name="recordInfo">The header for the current record</param>
+        /// <param name="key">The key for the current record</param>
+        /// <param name="value">The value for the current record</param>
+        /// <param name="lockType">The type of lock being taken</param>
+        /// <param name="context">Context-specific information; will be passed to <see cref="Unlock(ref RecordInfo, ref Key, ref Value, LockType, long)"/></param>
+        /// <remarks>
+        /// This is called only for records guaranteed to be in the mutable range.
+        /// </remarks>
+        void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long context);
+
+        /// <summary>
+        /// User-provided unlock call, defaulting to no-op. A default exclusive implementation is available via <see cref="RecordInfo.Unlock()"/>.
+        /// See also <see cref="IntExclusiveLocker"/> to use two bits of an existing int value.
+        /// </summary>
+        /// <param name="recordInfo">The header for the current record</param>
+        /// <param name="key">The key for the current record</param>
+        /// <param name="value">The value for the current record</param>
+        /// <param name="lockType">The type of lock being released, as passed to <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/></param>
+        /// <param name="context">The context returned from <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/></param>
+        /// <remarks>
+        /// This is called only for records guaranteed to be in the mutable range.
+        /// </remarks>
+        /// <returns>
+        /// True if no inconsistencies detected. Otherwise, the lock and user's callback are reissued.
+        /// Currently this is handled only for <see cref="ConcurrentReader(ref Key, ref Input, ref Value, ref Output)"/>.
+        /// </returns>
+        bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long context);
     }
 
     /// <summary>

--- a/cs/src/core/Index/Interfaces/IFunctions.cs
+++ b/cs/src/core/Index/Interfaces/IFunctions.cs
@@ -154,7 +154,7 @@ namespace FASTER.core
         /// <param name="key">The key for the current record</param>
         /// <param name="value">The value for the current record</param>
         /// <param name="lockType">The type of lock being released, as passed to <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/></param>
-        /// <param name="context">The context returned from <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/></param>
+        /// <param name="lockContext">The context returned from <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/></param>
         /// <remarks>
         /// This is called only for records guaranteed to be in the mutable range.
         /// </remarks>
@@ -162,7 +162,7 @@ namespace FASTER.core
         /// True if no inconsistencies detected. Otherwise, the lock and user's callback are reissued.
         /// Currently this is handled only for <see cref="ConcurrentReader(ref Key, ref Input, ref Value, ref Output)"/>.
         /// </returns>
-        bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long context);
+        bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long lockContext);
     }
 
     /// <summary>

--- a/cs/src/core/Index/Interfaces/IFunctions.cs
+++ b/cs/src/core/Index/Interfaces/IFunctions.cs
@@ -140,11 +140,11 @@ namespace FASTER.core
         /// <param name="key">The key for the current record</param>
         /// <param name="value">The value for the current record</param>
         /// <param name="lockType">The type of lock being taken</param>
-        /// <param name="context">Context-specific information; will be passed to <see cref="Unlock(ref RecordInfo, ref Key, ref Value, LockType, long)"/></param>
+        /// <param name="lockContext">Context-specific information; will be passed to <see cref="Unlock(ref RecordInfo, ref Key, ref Value, LockType, long)"/></param>
         /// <remarks>
         /// This is called only for records guaranteed to be in the mutable range.
         /// </remarks>
-        void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long context);
+        void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long lockContext);
 
         /// <summary>
         /// User-provided unlock call, defaulting to no-op. A default exclusive implementation is available via <see cref="RecordInfo.Unlock()"/>.

--- a/cs/src/core/Index/Interfaces/IFunctions.cs
+++ b/cs/src/core/Index/Interfaces/IFunctions.cs
@@ -127,8 +127,8 @@ namespace FASTER.core
         bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst);
 
         /// <summary>
-        /// Whether this Functions implementation actually locks in <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/> 
-        /// and <see cref="Unlock(ref RecordInfo, ref Key, ref Value, LockType, long)"/>
+        /// Whether this Functions instance supports locking. Iff so, FASTER will call <see cref="Lock(ref RecordInfo, ref Key, ref Value, LockType, ref long)"/> 
+        /// and <see cref="Unlock(ref RecordInfo, ref Key, ref Value, LockType, long)"/>.
         /// </summary>
         bool SupportsLocking { get; }
 

--- a/cs/src/core/Utilities/IntExclusiveLocker.cs
+++ b/cs/src/core/Utilities/IntExclusiveLocker.cs
@@ -15,6 +15,7 @@ namespace FASTER.core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void SpinLock(ref int value)
         {
+            // Note: Any improvements here should be done in RecordInfo.SpinLock() as well.
             while (true)
             {
                 int expected_word = value;

--- a/cs/src/core/Utilities/LockType.cs
+++ b/cs/src/core/Utilities/LockType.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace FASTER.core
+{
+    /// <summary>
+    /// Type of lock taken by FASTER on Read, Upsert, RMW, or Delete operations, either directly or within concurrent callback operations
+    /// </summary>
+    public enum LockType
+    {
+        /// <summary>
+        /// Shared lock, taken on Read
+        /// </summary>
+        Shared,
+
+        /// <summary>
+        /// Exclusive lock, taken on Upsert, RMW, or Delete
+        /// </summary>
+        Exclusive
+    }
+}

--- a/cs/src/core/VarLen/MemoryFunctions.cs
+++ b/cs/src/core/VarLen/MemoryFunctions.cs
@@ -31,14 +31,11 @@ namespace FASTER.core
         /// <inheritdoc/>
         public override bool ConcurrentWriter(ref Key key, ref Memory<T> src, ref Memory<T> dst)
         {
-            if (locking) dst.SpinLock();
-
             // We can write the source (src) data to the existing destination (dst) in-place, 
             // only if there is sufficient space
             if (dst.Length < src.Length || dst.IsMarkedReadOnly())
             {
                 dst.MarkReadOnly();
-                if (locking) dst.Unlock();
                 return false;
             }
 
@@ -49,8 +46,6 @@ namespace FASTER.core
             // We can adjust the length header on the serialized log, if we wish to.
             // This method will also zero out the extra space to retain log scan correctness.
             dst.ShrinkSerializedLength(src.Length);
-
-            if (locking) dst.Unlock();
             return true;
         }
 
@@ -65,11 +60,9 @@ namespace FASTER.core
         /// <inheritdoc/>
         public override void ConcurrentReader(ref Key key, ref Memory<T> input, ref Memory<T> value, ref (IMemoryOwner<T>, int) dst)
         {
-            if (locking) value.SpinLock();
             dst.Item1 = memoryPool.Rent(value.Length);
             dst.Item2 = value.Length;
             value.CopyTo(dst.Item1.Memory);
-            if (locking) value.Unlock();
         }
 
         /// <inheritdoc/>
@@ -89,6 +82,22 @@ namespace FASTER.core
         {
             // The default implementation of IPU simply writes input to destination, if there is space
             return ConcurrentWriter(ref key, ref input, ref value);
+        }
+
+        /// <inheritdoc />
+        public override bool SupportsLocking => locking;
+
+        /// <inheritdoc />
+        public override void Lock(ref RecordInfo recordInfo, ref Key key, ref Memory<T> value, LockType lockType, ref long lockContext)
+        {
+            if (locking) value.SpinLock();
+        }
+
+        /// <inheritdoc />
+        public override bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Memory<T> value, LockType lockType, long lockContext)
+        {
+            if (locking) value.Unlock();
+            return true;
         }
     }
 }

--- a/cs/src/core/VarLen/MemoryFunctions.cs
+++ b/cs/src/core/VarLen/MemoryFunctions.cs
@@ -11,17 +11,15 @@ namespace FASTER.core
         where T : unmanaged
     {
         readonly MemoryPool<T> memoryPool;
-        readonly bool locking;
 
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="memoryPool"></param>
         /// <param name="locking">Whether we lock values before concurrent operations (implemented using a spin lock on length header bit)</param>
-        public MemoryFunctions(MemoryPool<T> memoryPool = default, bool locking = false)
+        public MemoryFunctions(MemoryPool<T> memoryPool = default, bool locking = false) : base(locking)
         {
             this.memoryPool = memoryPool ?? MemoryPool<T>.Shared;
-            this.locking = locking;
         }
 
         /// <inheritdoc/>

--- a/cs/src/core/VarLen/MemoryFunctions.cs
+++ b/cs/src/core/VarLen/MemoryFunctions.cs
@@ -90,13 +90,13 @@ namespace FASTER.core
         /// <inheritdoc />
         public override void Lock(ref RecordInfo recordInfo, ref Key key, ref Memory<T> value, LockType lockType, ref long lockContext)
         {
-            if (locking) value.SpinLock();
+            value.SpinLock();
         }
 
         /// <inheritdoc />
         public override bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Memory<T> value, LockType lockType, long lockContext)
         {
-            if (locking) value.Unlock();
+            value.Unlock();
             return true;
         }
     }

--- a/cs/src/core/VarLen/SpanByteFunctions.cs
+++ b/cs/src/core/VarLen/SpanByteFunctions.cs
@@ -14,9 +14,7 @@ namespace FASTER.core
         /// Constructor
         /// </summary>
         /// <param name="locking"></param>
-        public SpanByteFunctions(bool locking = false) : base(locking)
-        {
-        }
+        public SpanByteFunctions(bool locking = false) : base(locking) { }
 
         /// <inheritdoc />
         public override void SingleWriter(ref Key key, ref SpanByte src, ref SpanByte dst)
@@ -96,9 +94,23 @@ namespace FASTER.core
         /// <inheritdoc />
         public unsafe override void ConcurrentReader(ref SpanByte key, ref SpanByte input, ref SpanByte value, ref SpanByteAndMemory dst)
         {
-            if (locking) value.SpinLock();
             value.CopyTo(ref dst, memoryPool);
+        }
+
+        /// <inheritdoc />
+        public override bool SupportsLocking => locking;
+
+        /// <inheritdoc />
+        public override void Lock(ref RecordInfo recordInfo, ref SpanByte key, ref SpanByte value, LockType lockType, ref long lockContext)
+        {
+            if (locking) value.SpinLock();
+        }
+
+        /// <inheritdoc />
+        public override bool Unlock(ref RecordInfo recordInfo, ref SpanByte key, ref SpanByte value, LockType lockType, long lockContext)
+        {
             if (locking) value.Unlock();
+            return true;
         }
     }
 
@@ -122,9 +134,23 @@ namespace FASTER.core
         /// <inheritdoc />
         public override void ConcurrentReader(ref SpanByte key, ref SpanByte input, ref SpanByte value, ref byte[] dst)
         {
-            value.SpinLock();
             dst = value.ToByteArray();
-            value.Unlock();
+        }
+
+        /// <inheritdoc />
+        public override bool SupportsLocking => locking;
+
+        /// <inheritdoc />
+        public override void Lock(ref RecordInfo recordInfo, ref SpanByte key, ref SpanByte value, LockType lockType, ref long lockContext)
+        {
+            if (locking) value.SpinLock();
+        }
+
+        /// <inheritdoc />
+        public override bool Unlock(ref RecordInfo recordInfo, ref SpanByte key, ref SpanByte value, LockType lockType, long lockContext)
+        {
+            if (locking) value.Unlock();
+            return true;
         }
     }
 }

--- a/cs/src/core/VarLen/SpanByteFunctions.cs
+++ b/cs/src/core/VarLen/SpanByteFunctions.cs
@@ -11,17 +11,11 @@ namespace FASTER.core
     public class SpanByteFunctions<Key, Output, Context> : FunctionsBase<Key, SpanByte, SpanByte, Output, Context>
     {
         /// <summary>
-        /// Whether we lock values before concurrent operations
-        /// </summary>
-        protected readonly bool locking;
-
-        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="locking"></param>
-        public SpanByteFunctions(bool locking = false)
+        public SpanByteFunctions(bool locking = false) : base(locking)
         {
-            this.locking = locking;
         }
 
         /// <inheritdoc />

--- a/cs/src/core/VarLen/SpanByteFunctions.cs
+++ b/cs/src/core/VarLen/SpanByteFunctions.cs
@@ -109,7 +109,7 @@ namespace FASTER.core
         /// <inheritdoc />
         public override bool Unlock(ref RecordInfo recordInfo, ref SpanByte key, ref SpanByte value, LockType lockType, long lockContext)
         {
-            if (locking) value.Unlock();
+            value.Unlock();
             return true;
         }
     }

--- a/cs/src/core/VarLen/SpanByteFunctions.cs
+++ b/cs/src/core/VarLen/SpanByteFunctions.cs
@@ -103,7 +103,7 @@ namespace FASTER.core
         /// <inheritdoc />
         public override void Lock(ref RecordInfo recordInfo, ref SpanByte key, ref SpanByte value, LockType lockType, ref long lockContext)
         {
-            if (locking) value.SpinLock();
+            value.SpinLock();
         }
 
         /// <inheritdoc />
@@ -143,13 +143,13 @@ namespace FASTER.core
         /// <inheritdoc />
         public override void Lock(ref RecordInfo recordInfo, ref SpanByte key, ref SpanByte value, LockType lockType, ref long lockContext)
         {
-            if (locking) value.SpinLock();
+            value.SpinLock();
         }
 
         /// <inheritdoc />
         public override bool Unlock(ref RecordInfo recordInfo, ref SpanByte key, ref SpanByte value, LockType lockType, long lockContext)
         {
-            if (locking) value.Unlock();
+            value.Unlock();
             return true;
         }
     }

--- a/cs/test/AsyncTests.cs
+++ b/cs/test/AsyncTests.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Linq;
 using FASTER.core;
 using System.IO;
 using NUnit.Framework;
@@ -20,7 +17,7 @@ namespace FASTER.test.async
     {
         private FasterKV<AdId, NumClicks> fht1;
         private FasterKV<AdId, NumClicks> fht2;
-        private readonly SimpleFunctions functions = new SimpleFunctions();
+        private readonly AdSimpleFunctions functions = new AdSimpleFunctions();
         private IDevice log;
 
 
@@ -56,9 +53,9 @@ namespace FASTER.test.async
             AdInput inputArg = default;
             Output output = default;
 
-            var s0 = fht1.For(functions).NewSession<SimpleFunctions>();
-            var s1 = fht1.For(functions).NewSession<SimpleFunctions>();
-            var s2 = fht1.For(functions).NewSession<SimpleFunctions>();
+            var s0 = fht1.For(functions).NewSession<AdSimpleFunctions>();
+            var s1 = fht1.For(functions).NewSession<AdSimpleFunctions>();
+            var s2 = fht1.For(functions).NewSession<AdSimpleFunctions>();
 
             for (int key = 0; key < numOps; key++)
             {
@@ -89,7 +86,7 @@ namespace FASTER.test.async
             fht2.Recover(token); // sync, does not require session
 
             var guid = s1.ID;
-            using (var s3 = fht2.For(functions).ResumeSession<SimpleFunctions>(guid, out CommitPoint lsn))
+            using (var s3 = fht2.For(functions).ResumeSession<AdSimpleFunctions>(guid, out CommitPoint lsn))
             {
                 Assert.IsTrue(lsn.UntilSerialNo == numOps - 1);
 
@@ -112,71 +109,31 @@ namespace FASTER.test.async
         }
     }
 
-
-
-
-public class SimpleFunctions : IFunctions<AdId, NumClicks, AdInput, Output, Empty>
+    public class AdSimpleFunctions : FunctionsBase<AdId, NumClicks, AdInput, Output, Empty>
     {
-        public void RMWCompletionCallback(ref AdId key, ref AdInput input, Empty ctx, Status status)
-        {
-        }
-
-        public void ReadCompletionCallback(ref AdId key, ref AdInput input, ref Output output, Empty ctx, Status status)
+        public override void ReadCompletionCallback(ref AdId key, ref AdInput input, ref Output output, Empty ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
             Assert.IsTrue(output.value.numClicks == key.adId);
         }
 
-        public void UpsertCompletionCallback(ref AdId key, ref NumClicks input, Empty ctx)
-        {
-        }
-
-        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
-        {
-        }
-
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-        }
-
         // Read functions
-        public void SingleReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst)
-        {
-            dst.value = value;
-        }
+        public override void SingleReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst) => dst.value = value;
 
-        public void ConcurrentReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst)
-        {
-            dst.value = value;
-        }
-
-        // Upsert functions
-        public void SingleWriter(ref AdId key, ref NumClicks src, ref NumClicks dst)
-        {
-            dst = src;
-        }
-
-        public bool ConcurrentWriter(ref AdId key, ref NumClicks src, ref NumClicks dst)
-        {
-            dst = src;
-            return true;
-        }
+        public override void ConcurrentReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst) => dst.value = value;
 
         // RMW functions
-        public void InitialUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
-        {
-            value = input.numClicks;
-        }
+        public override void InitialUpdater(ref AdId key, ref AdInput input, ref NumClicks value) => value = input.numClicks;
 
-        public bool InPlaceUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
+        public override bool InPlaceUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
         {
             Interlocked.Add(ref value.numClicks, input.numClicks.numClicks);
             return true;
         }
 
-        public bool NeedCopyUpdate(ref AdId key, ref AdInput input, ref NumClicks oldValue) => true;
+        public override bool NeedCopyUpdate(ref AdId key, ref AdInput input, ref NumClicks oldValue) => true;
 
-        public void CopyUpdater(ref AdId key, ref AdInput input, ref NumClicks oldValue, ref NumClicks newValue)
+        public override void CopyUpdater(ref AdId key, ref AdInput input, ref NumClicks oldValue, ref NumClicks newValue)
         {
             newValue.numClicks += oldValue.numClicks + input.numClicks.numClicks;
         }

--- a/cs/test/LockTests.cs
+++ b/cs/test/LockTests.cs
@@ -31,8 +31,8 @@ namespace FASTER.test
             public override bool InPlaceUpdater(ref int key, ref int input, ref int value, ref RecordInfo recordInfo, long address) => Increment(ref value);
 
             public override bool SupportsLocking => true;
-            public override void Lock(ref RecordInfo recordInfo, ref int key, ref int value, LockType lockType, ref long context) => recordInfo.SpinLock();
-            public override bool Unlock(ref RecordInfo recordInfo, ref int key, ref int value, LockType lockType, long context)
+            public override void Lock(ref RecordInfo recordInfo, ref int key, ref int value, LockType lockType, ref long lockContext) => recordInfo.SpinLock();
+            public override bool Unlock(ref RecordInfo recordInfo, ref int key, ref int value, LockType lockType, long lockContext)
             {
                 recordInfo.Unlock();
                 return true;

--- a/cs/test/LockTests.cs
+++ b/cs/test/LockTests.cs
@@ -5,7 +5,6 @@ using FASTER.core;
 using NUnit.Framework;
 using System;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,28 +15,28 @@ namespace FASTER.test
     {
         internal class Functions : AdvancedSimpleFunctions<int, int>
         {
-            private readonly RecordAccessor<int, int> recordAccessor;
-
-            internal Functions(RecordAccessor<int, int> accessor) => this.recordAccessor = accessor;
-
-            public override void ConcurrentReader(ref int key, ref int input, ref int value, ref int dst, long address)
+            public override void ConcurrentReader(ref int key, ref int input, ref int value, ref int dst, ref RecordInfo recordInfo, long address)
             {
-                this.recordAccessor.SpinLock(address);
                 dst = value;
-                this.recordAccessor.Unlock(address);
             }
 
-            bool LockAndIncrement(ref int dst, long address)
+            bool Increment(ref int dst)
             {
-                this.recordAccessor.SpinLock(address);
                 ++dst;
-                this.recordAccessor.Unlock(address);
                 return true;
             }
 
-            public override bool ConcurrentWriter(ref int key, ref int src, ref int dst, long address) => LockAndIncrement(ref dst, address);
+            public override bool ConcurrentWriter(ref int key, ref int src, ref int dst, ref RecordInfo recordInfo, long address) => Increment(ref dst);
 
-            public override bool InPlaceUpdater(ref int key, ref int input, ref int value, long address) => LockAndIncrement(ref value, address);
+            public override bool InPlaceUpdater(ref int key, ref int input, ref int value, ref RecordInfo recordInfo, long address) => Increment(ref value);
+
+            public override bool SupportsLocking => true;
+            public override void Lock(ref RecordInfo recordInfo, ref int key, ref int value, LockType lockType, ref long context) => recordInfo.SpinLock();
+            public override bool Unlock(ref RecordInfo recordInfo, ref int key, ref int value, LockType lockType, long context)
+            {
+                recordInfo.Unlock();
+                return true;
+            }
         }
 
         private FasterKV<int, int> fkv;
@@ -49,7 +48,7 @@ namespace FASTER.test
         {
             log = Devices.CreateLogDevice(TestContext.CurrentContext.TestDirectory + "/GenericStringTests.log", deleteOnClose: true);
             fkv = new FasterKV<int, int>(1L << 20, new LogSettings { LogDevice = log, ObjectLogDevice = null });
-            session = fkv.For(new Functions(fkv.RecordAccessor)).NewSession<Functions>();
+            session = fkv.For(new Functions()).NewSession<Functions>();
         }
 
         [TearDown]

--- a/cs/test/ObjectRecoveryTest2.cs
+++ b/cs/test/ObjectRecoveryTest2.cs
@@ -225,12 +225,12 @@ namespace FASTER.test.recovery.objects
     }
 
 
-    public class MyFunctions : IFunctions<MyKey, MyValue, MyInput, MyOutput, MyContext>
+    public class MyFunctions : FunctionsBase<MyKey, MyValue, MyInput, MyOutput, MyContext>
     {
-        public void InitialUpdater(ref MyKey key, ref MyInput input, ref MyValue value) => value.value = input.value;
-        public bool NeedCopyUpdate(ref MyKey key, ref MyInput input, ref MyValue oldValue) => true;
-        public void CopyUpdater(ref MyKey key, ref MyInput input, ref MyValue oldValue, ref MyValue newValue) => newValue = oldValue;
-        public bool InPlaceUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
+        public override void InitialUpdater(ref MyKey key, ref MyInput input, ref MyValue value) => value.value = input.value;
+        public override bool NeedCopyUpdate(ref MyKey key, ref MyInput input, ref MyValue oldValue) => true;
+        public override void CopyUpdater(ref MyKey key, ref MyInput input, ref MyValue oldValue, ref MyValue newValue) => newValue = oldValue;
+        public override bool InPlaceUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
         {
             if (value.value.Length < input.value.Length)
                 return false;
@@ -239,10 +239,10 @@ namespace FASTER.test.recovery.objects
         }
 
 
-        public void SingleReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst) => dst.value = value;
-        public void SingleWriter(ref MyKey key, ref MyValue src, ref MyValue dst) => dst = src;
-        public void ConcurrentReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst) => dst.value = value;
-        public bool ConcurrentWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
+        public override void SingleReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst) => dst.value = value;
+        public override void SingleWriter(ref MyKey key, ref MyValue src, ref MyValue dst) => dst = src;
+        public override void ConcurrentReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst) => dst.value = value;
+        public override bool ConcurrentWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
         {
             if (src == null)
                 return false;
@@ -254,10 +254,6 @@ namespace FASTER.test.recovery.objects
             return true;
         }
 
-        public void ReadCompletionCallback(ref MyKey key, ref MyInput input, ref MyOutput output, MyContext ctx, Status status) => ctx.Populate(ref status, ref output);
-        public void UpsertCompletionCallback(ref MyKey key, ref MyValue value, MyContext ctx) { }
-        public void RMWCompletionCallback(ref MyKey key, ref MyInput input, MyContext ctx, Status status) { }
-        public void DeleteCompletionCallback(ref MyKey key, MyContext ctx) { }
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint) { }
+        public override void ReadCompletionCallback(ref MyKey key, ref MyInput input, ref MyOutput output, MyContext ctx, Status status) => ctx.Populate(ref status, ref output);
     }
 }

--- a/cs/test/ObjectRecoveryTestTypes.cs
+++ b/cs/test/ObjectRecoveryTestTypes.cs
@@ -3,16 +3,8 @@
 
 #pragma warning disable 1591
 
-using System;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Linq;
 using FASTER.core;
-using System.Runtime.CompilerServices;
-using System.IO;
-using System.Diagnostics;
 
 namespace FASTER.test.recovery.objectstore
 {
@@ -76,66 +68,25 @@ namespace FASTER.test.recovery.objectstore
         public NumClicks value;
     }
 
-    public class Functions : IFunctions<AdId, NumClicks, Input, Output, Empty>
+    public class Functions : FunctionsBase<AdId, NumClicks, Input, Output, Empty>
     {
-        public void RMWCompletionCallback(ref AdId key, ref Input input, Empty ctx, Status status)
-        {
-        }
-
-        public void ReadCompletionCallback(ref AdId key, ref Input input, ref Output output, Empty ctx, Status status)
-        {
-        }
-
-        public void UpsertCompletionCallback(ref AdId key, ref NumClicks input, Empty ctx)
-        {
-        }
-
-        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
-        {
-        }
-
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-        }
-
         // Read functions
-        public void SingleReader(ref AdId key, ref Input input, ref NumClicks value, ref Output dst)
-        {
-            dst.value = value;
-        }
+        public override void SingleReader(ref AdId key, ref Input input, ref NumClicks value, ref Output dst) => dst.value = value;
 
-        public void ConcurrentReader(ref AdId key, ref Input input, ref NumClicks value, ref Output dst)
-        {
-            dst.value = value;
-        }
-
-        // Upsert functions
-        public void SingleWriter(ref AdId key, ref NumClicks src, ref NumClicks dst)
-        {
-            dst = src;
-        }
-
-        public bool ConcurrentWriter(ref AdId key, ref NumClicks src, ref NumClicks dst)
-        {
-            dst = src;
-            return true;
-        }
+        public override void ConcurrentReader(ref AdId key, ref Input input, ref NumClicks value, ref Output dst) => dst.value = value;
 
         // RMW functions
-        public void InitialUpdater(ref AdId key, ref Input input, ref NumClicks value)
-        {
-            value = input.numClicks;
-        }
+        public override void InitialUpdater(ref AdId key, ref Input input, ref NumClicks value) => value = input.numClicks;
 
-        public bool InPlaceUpdater(ref AdId key, ref Input input, ref NumClicks value)
+        public override bool InPlaceUpdater(ref AdId key, ref Input input, ref NumClicks value)
         {
             Interlocked.Add(ref value.numClicks, input.numClicks.numClicks);
             return true;
         }
 
-        public bool NeedCopyUpdate(ref AdId key, ref Input input, ref NumClicks oldValue) => true;
+        public override bool NeedCopyUpdate(ref AdId key, ref Input input, ref NumClicks oldValue) => true;
 
-        public void CopyUpdater(ref AdId key, ref Input input, ref NumClicks oldValue, ref NumClicks newValue)
+        public override void CopyUpdater(ref AdId key, ref Input input, ref NumClicks oldValue, ref NumClicks newValue)
         {
             newValue = new NumClicks { numClicks = oldValue.numClicks + input.numClicks.numClicks };
         }

--- a/cs/test/ObjectTestTypes.cs
+++ b/cs/test/ObjectTestTypes.cs
@@ -75,27 +75,27 @@ namespace FASTER.test
         public MyValue value;
     }
 
-    public class MyFunctions : IFunctions<MyKey, MyValue, MyInput, MyOutput, Empty>
+    public class MyFunctions : FunctionsBase<MyKey, MyValue, MyInput, MyOutput, Empty>
     {
-        public void InitialUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
+        public override void InitialUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
         {
             value = new MyValue { value = input.value };
         }
 
-        public bool InPlaceUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
+        public override bool InPlaceUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
         {
             value.value += input.value;
             return true;
         }
 
-        public bool NeedCopyUpdate(ref MyKey key, ref MyInput input, ref MyValue oldValue) => true;
+        public override bool NeedCopyUpdate(ref MyKey key, ref MyInput input, ref MyValue oldValue) => true;
 
-        public void CopyUpdater(ref MyKey key, ref MyInput input, ref MyValue oldValue, ref MyValue newValue)
+        public override void CopyUpdater(ref MyKey key, ref MyInput input, ref MyValue oldValue, ref MyValue newValue)
         {
             newValue = new MyValue { value = oldValue.value + input.value };
         }
 
-        public void ConcurrentReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst)
+        public override void ConcurrentReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst)
         {
             if (dst == default)
                 dst = new MyOutput();
@@ -103,87 +103,70 @@ namespace FASTER.test
             dst.value = value;
         }
 
-        public bool ConcurrentWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
+        public override bool ConcurrentWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
         {
             dst.value = src.value;
             return true;
         }
 
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-        }
-
-        public void ReadCompletionCallback(ref MyKey key, ref MyInput input, ref MyOutput output, Empty ctx, Status status)
+        public override void ReadCompletionCallback(ref MyKey key, ref MyInput input, ref MyOutput output, Empty ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
             Assert.IsTrue(key.key == output.value.value);
         }
 
-        public void RMWCompletionCallback(ref MyKey key, ref MyInput input, Empty ctx, Status status)
+        public override void RMWCompletionCallback(ref MyKey key, ref MyInput input, Empty ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
         }
 
-        public void UpsertCompletionCallback(ref MyKey key, ref MyValue value, Empty ctx)
-        {
-        }
-
-        public void DeleteCompletionCallback(ref MyKey key, Empty ctx)
-        {
-        }
-
-        public void SingleReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst)
+        public override void SingleReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst)
         {
             if (dst == default)
                 dst = new MyOutput();
             dst.value = value;
         }
 
-        public void SingleWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
+        public override void SingleWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
         {
             dst = src;
         }
     }
 
-    public class MyFunctionsDelete : IFunctions<MyKey, MyValue, MyInput, MyOutput, int>
+    public class MyFunctionsDelete : FunctionsBase<MyKey, MyValue, MyInput, MyOutput, int>
     {
-        public void InitialUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
+        public override void InitialUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
         {
             value = new MyValue { value = input.value };
         }
 
-        public bool InPlaceUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
+        public override bool InPlaceUpdater(ref MyKey key, ref MyInput input, ref MyValue value)
         {
             value.value += input.value;
             return true;
         }
 
-        public bool NeedCopyUpdate(ref MyKey key, ref MyInput input, ref MyValue oldValue) => true;
+        public override bool NeedCopyUpdate(ref MyKey key, ref MyInput input, ref MyValue oldValue) => true;
 
-        public void CopyUpdater(ref MyKey key, ref MyInput input, ref MyValue oldValue, ref MyValue newValue)
+        public override void CopyUpdater(ref MyKey key, ref MyInput input, ref MyValue oldValue, ref MyValue newValue)
         {
             newValue = new MyValue { value = oldValue.value + input.value };
         }
 
-        public void ConcurrentReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst)
+        public override void ConcurrentReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst)
         {
             if (dst == null)
                 dst = new MyOutput();
-
             dst.value = value;
         }
 
-        public bool ConcurrentWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
+        public override bool ConcurrentWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
         {
             dst = src;
             return true;
         }
 
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-        }
-
-        public void ReadCompletionCallback(ref MyKey key, ref MyInput input, ref MyOutput output, int ctx, Status status)
+        public override void ReadCompletionCallback(ref MyKey key, ref MyInput input, ref MyOutput output, int ctx, Status status)
         {
             if (ctx == 0)
             {
@@ -196,7 +179,7 @@ namespace FASTER.test
             }
         }
 
-        public void RMWCompletionCallback(ref MyKey key, ref MyInput input, int ctx, Status status)
+        public override void RMWCompletionCallback(ref MyKey key, ref MyInput input, int ctx, Status status)
         {
             if (ctx == 0)
                 Assert.IsTrue(status == Status.OK);
@@ -204,15 +187,7 @@ namespace FASTER.test
                 Assert.IsTrue(status == Status.NOTFOUND);
         }
 
-        public void UpsertCompletionCallback(ref MyKey key, ref MyValue value, int ctx)
-        {
-        }
-
-        public void DeleteCompletionCallback(ref MyKey key, int ctx)
-        {
-        }
-
-        public void SingleReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst)
+        public override void SingleReader(ref MyKey key, ref MyInput input, ref MyValue value, ref MyOutput dst)
         {
             if (dst == null)
                 dst = new MyOutput();
@@ -220,69 +195,49 @@ namespace FASTER.test
             dst.value = value;
         }
 
-        public void SingleWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
+        public override void SingleWriter(ref MyKey key, ref MyValue src, ref MyValue dst)
         {
             dst = src;
         }
     }
 
-    public class MixedFunctions : IFunctions<int, MyValue, MyInput, MyOutput, Empty>
+    public class MixedFunctions : FunctionsBase<int, MyValue, MyInput, MyOutput, Empty>
     {
-        public void InitialUpdater(ref int key, ref MyInput input, ref MyValue value)
+        public override void InitialUpdater(ref int key, ref MyInput input, ref MyValue value)
         {
             value = new MyValue { value = input.value };
         }
 
-        public bool InPlaceUpdater(ref int key, ref MyInput input, ref MyValue value)
+        public override bool InPlaceUpdater(ref int key, ref MyInput input, ref MyValue value)
         {
             value.value += input.value;
             return true;
         }
 
-        public bool NeedCopyUpdate(ref int key, ref MyInput input, ref MyValue oldValue) => true;
+        public override bool NeedCopyUpdate(ref int key, ref MyInput input, ref MyValue oldValue) => true;
 
-        public void CopyUpdater(ref int key, ref MyInput input, ref MyValue oldValue, ref MyValue newValue)
+        public override void CopyUpdater(ref int key, ref MyInput input, ref MyValue oldValue, ref MyValue newValue)
         {
             newValue = new MyValue { value = oldValue.value + input.value };
         }
 
-        public void ConcurrentReader(ref int key, ref MyInput input, ref MyValue value, ref MyOutput dst)
+        public override void ConcurrentReader(ref int key, ref MyInput input, ref MyValue value, ref MyOutput dst)
         {
             dst.value = value;
         }
 
-        public bool ConcurrentWriter(ref int key, ref MyValue src, ref MyValue dst)
+        public override bool ConcurrentWriter(ref int key, ref MyValue src, ref MyValue dst)
         {
             dst.value = src.value;
             return true;
         }
 
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-        }
-
-        public void ReadCompletionCallback(ref int key, ref MyInput input, ref MyOutput output, Empty ctx, Status status)
-        {
-        }
-
-        public void RMWCompletionCallback(ref int key, ref MyInput input, Empty ctx, Status status)
-        {
-        }
-
-        public void UpsertCompletionCallback(ref int key, ref MyValue value, Empty ctx)
-        {
-        }
-
-        public void DeleteCompletionCallback(ref int key, Empty ctx)
-        {
-        }
-
-        public void SingleReader(ref int key, ref MyInput input, ref MyValue value, ref MyOutput dst)
+        public override void SingleReader(ref int key, ref MyInput input, ref MyValue value, ref MyOutput dst)
         {
             dst.value = value;
         }
 
-        public void SingleWriter(ref int key, ref MyValue src, ref MyValue dst)
+        public override void SingleWriter(ref int key, ref MyValue src, ref MyValue dst)
         {
             dst = src;
         }
@@ -328,66 +283,34 @@ namespace FASTER.test
         public MyLargeValue value;
     }
 
-    public class MyLargeFunctions : IFunctions<MyKey, MyLargeValue, MyInput, MyLargeOutput, Empty>
+    public class MyLargeFunctions : FunctionsBase<MyKey, MyLargeValue, MyInput, MyLargeOutput, Empty>
     {
-        public void RMWCompletionCallback(ref MyKey key, ref MyInput input, Empty ctx, Status status)
-        {
-        }
-
-        public void ReadCompletionCallback(ref MyKey key, ref MyInput input, ref MyLargeOutput output, Empty ctx, Status status)
+        public override void ReadCompletionCallback(ref MyKey key, ref MyInput input, ref MyLargeOutput output, Empty ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
             for (int i = 0; i < output.value.value.Length; i++)
             {
-                Assert.IsTrue(output.value.value[i] == (byte)(output.value.value.Length+i));
+                Assert.IsTrue(output.value.value[i] == (byte)(output.value.value.Length + i));
             }
         }
 
-
-        public void UpsertCompletionCallback(ref MyKey key, ref MyLargeValue value, Empty ctx)
-        {
-        }
-
-        public void DeleteCompletionCallback(ref MyKey key, Empty ctx)
-        {
-        }
-
-        public bool NeedCopyUpdate(ref MyKey key, ref MyInput input, ref MyLargeValue oldValue) => true;
-
-        public void CopyUpdater(ref MyKey key, ref MyInput input, ref MyLargeValue oldValue, ref MyLargeValue newValue)
-        {
-        }
-
-        public void InitialUpdater(ref MyKey key, ref MyInput input, ref MyLargeValue value)
-        {
-        }
-
-        public bool InPlaceUpdater(ref MyKey key, ref MyInput input, ref MyLargeValue value)
-        {
-            return true;
-        }
-
-        public void SingleReader(ref MyKey key, ref MyInput input, ref MyLargeValue value, ref MyLargeOutput dst)
+        public override void SingleReader(ref MyKey key, ref MyInput input, ref MyLargeValue value, ref MyLargeOutput dst)
         {
             dst.value = value;
         }
 
-        public void ConcurrentReader(ref MyKey key, ref MyInput input, ref MyLargeValue value, ref MyLargeOutput dst)
+        public override void ConcurrentReader(ref MyKey key, ref MyInput input, ref MyLargeValue value, ref MyLargeOutput dst)
         {
             dst.value = value;
         }
 
-        public bool ConcurrentWriter(ref MyKey key, ref MyLargeValue src, ref MyLargeValue dst)
+        public override bool ConcurrentWriter(ref MyKey key, ref MyLargeValue src, ref MyLargeValue dst)
         {
             dst = src;
             return true;
         }
 
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-        }
-
-        public void SingleWriter(ref MyKey key, ref MyLargeValue src, ref MyLargeValue dst)
+        public override void SingleWriter(ref MyKey key, ref MyLargeValue src, ref MyLargeValue dst)
         {
             dst = src;
         }

--- a/cs/test/ReadAddressTests.cs
+++ b/cs/test/ReadAddressTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 
 namespace FASTER.test.readaddress
 {
+#if false // TODO temporarily deactivated due to removal of addresses from single-writer callbacks
     [TestFixture]
     public class ReadAddressTests
     {
@@ -68,16 +69,16 @@ namespace FASTER.test.readaddress
         {
             internal long lastWriteAddress = Constants.kInvalidAddress;
 
-            public override void ConcurrentReader(ref Key key, ref Value input, ref Value value, ref Value dst, long address) 
+            public override void ConcurrentReader(ref Key key, ref Value input, ref Value value, ref Value dst, ref RecordInfo recordInfo, long address) 
                 => dst.value = SetReadOutput(key.key, value.value);
 
             public override void SingleReader(ref Key key, ref Value input, ref Value value, ref Value dst, long address) 
                 => dst.value = SetReadOutput(key.key, value.value);
 
             // Return false to force a chain of values.
-            public override bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst, long address) => false;
+            public override bool ConcurrentWriter(ref Key key, ref Value src, ref Value dst, ref RecordInfo recordInfo, long address) => false;
 
-            public override bool InPlaceUpdater(ref Key key, ref Value input, ref Value value, long address) => false;
+            public override bool InPlaceUpdater(ref Key key, ref Value input, ref Value value, ref RecordInfo recordInfo, long address) => false;
 
             // Record addresses
             public override void SingleWriter(ref Key key, ref Value src, ref Value dst, long address)
@@ -86,16 +87,16 @@ namespace FASTER.test.readaddress
                 base.SingleWriter(ref key, ref src, ref dst, address);
             }
 
-            public override void InitialUpdater(ref Key key, ref Value input, ref Value value, long address)
+            public override void InitialUpdater(ref Key key, ref Value input, ref Value value)
             {
                 this.lastWriteAddress = address;
-                base.InitialUpdater(ref key, ref input, ref value, address);
+                base.InitialUpdater(ref key, ref input, ref value);
             }
 
-            public override void CopyUpdater(ref Key key, ref Value input, ref Value oldValue, ref Value newValue, long oldAddress, long newAddress)
+            public override void CopyUpdater(ref Key key, ref Value input, ref Value oldValue, ref Value newValue)
             {
                 this.lastWriteAddress = newAddress;
-                base.CopyUpdater(ref key, ref input, ref oldValue, ref newValue, oldAddress, newAddress);
+                base.CopyUpdater(ref key, ref input, ref oldValue, ref newValue);
             }
 
             // Track the recordInfo for its PreviousAddress.
@@ -574,4 +575,5 @@ namespace FASTER.test.readaddress
             await testStore.Flush();
         }
     }
+#endif
 }

--- a/cs/test/RecoverContinueTests.cs
+++ b/cs/test/RecoverContinueTests.cs
@@ -1,15 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using FASTER.core;
 using System.IO;
 using NUnit.Framework;
-using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace FASTER.test.recovery.sumstore.recover_continue
@@ -73,14 +68,14 @@ namespace FASTER.test.recovery.sumstore.recover_continue
         {
             long sno = 0;
 
-            var firstsession = fht1.For(new SimpleFunctions()).NewSession<SimpleFunctions>("first");
+            var firstsession = fht1.For(new AdSimpleFunctions()).NewSession<AdSimpleFunctions>("first");
             IncrementAllValues(ref firstsession, ref sno);
             fht1.TakeFullCheckpoint(out _);
             fht1.CompleteCheckpointAsync().GetAwaiter().GetResult();
             firstsession.Dispose();
 
             // Check if values after checkpoint are correct
-            var session1 = fht1.For(new SimpleFunctions()).NewSession<SimpleFunctions>();
+            var session1 = fht1.For(new AdSimpleFunctions()).NewSession<AdSimpleFunctions>();
             CheckAllValues(ref session1, 1);
             session1.Dispose();
 
@@ -89,12 +84,12 @@ namespace FASTER.test.recovery.sumstore.recover_continue
                 await fht2.RecoverAsync();
             else
                 fht2.Recover();
-            var session2 = fht2.For(new SimpleFunctions()).NewSession<SimpleFunctions>();
+            var session2 = fht2.For(new AdSimpleFunctions()).NewSession<AdSimpleFunctions>();
             CheckAllValues(ref session2, 1);
             session2.Dispose();
 
             // Continue and increment values
-            var continuesession = fht2.For(new SimpleFunctions()).ResumeSession<SimpleFunctions>("first", out CommitPoint cp);
+            var continuesession = fht2.For(new AdSimpleFunctions()).ResumeSession<AdSimpleFunctions>("first", out CommitPoint cp);
             long newSno = cp.UntilSerialNo;
             Assert.IsTrue(newSno == sno - 1);
             IncrementAllValues(ref continuesession, ref sno);
@@ -103,7 +98,7 @@ namespace FASTER.test.recovery.sumstore.recover_continue
             continuesession.Dispose();
 
             // Check if values after continue checkpoint are correct
-            var session3 = fht2.For(new SimpleFunctions()).NewSession<SimpleFunctions>();
+            var session3 = fht2.For(new AdSimpleFunctions()).NewSession<AdSimpleFunctions>();
             CheckAllValues(ref session3, 2);
             session3.Dispose();
 
@@ -113,7 +108,7 @@ namespace FASTER.test.recovery.sumstore.recover_continue
             else
                 fht3.Recover();
 
-            var nextsession = fht3.For(new SimpleFunctions()).ResumeSession<SimpleFunctions>("first", out cp);
+            var nextsession = fht3.For(new AdSimpleFunctions()).ResumeSession<AdSimpleFunctions>("first", out cp);
             long newSno2 = cp.UntilSerialNo;
             Assert.IsTrue(newSno2 == sno - 1);
             CheckAllValues(ref nextsession, 2);
@@ -121,7 +116,7 @@ namespace FASTER.test.recovery.sumstore.recover_continue
         }
 
         private void CheckAllValues(
-            ref ClientSession<AdId, NumClicks, AdInput, Output, Empty, SimpleFunctions> fht,
+            ref ClientSession<AdId, NumClicks, AdInput, Output, Empty, AdSimpleFunctions> fht,
             int value)
         {
             AdInput inputArg = default;
@@ -143,7 +138,7 @@ namespace FASTER.test.recovery.sumstore.recover_continue
         }
 
         private void IncrementAllValues(
-            ref ClientSession<AdId, NumClicks, AdInput, Output, Empty, SimpleFunctions> fht, 
+            ref ClientSession<AdId, NumClicks, AdInput, Output, Empty, AdSimpleFunctions> fht, 
             ref long sno)
         {
             AdInput inputArg = default;
@@ -159,68 +154,34 @@ namespace FASTER.test.recovery.sumstore.recover_continue
 
     }
 
-    public class SimpleFunctions : IFunctions<AdId, NumClicks, AdInput, Output, Empty>
+    public class AdSimpleFunctions : FunctionsBase<AdId, NumClicks, AdInput, Output, Empty>
     {
-        public void RMWCompletionCallback(ref AdId key, ref AdInput input, Empty ctx, Status status)
-        {
-        }
-
-        public void ReadCompletionCallback(ref AdId key, ref AdInput input, ref Output output, Empty ctx, Status status)
+        public override void ReadCompletionCallback(ref AdId key, ref AdInput input, ref Output output, Empty ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
             Assert.IsTrue(output.value.numClicks == key.adId);
         }
 
-        public void UpsertCompletionCallback(ref AdId key, ref NumClicks input, Empty ctx)
-        {
-        }
-
-        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
-        {
-        }
-
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-        }
-
         // Read functions
-        public void SingleReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst)
-        {
-            dst.value = value;
-        }
+        public override void SingleReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst) => dst.value = value;
 
-        public void ConcurrentReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst)
-        {
-            dst.value = value;
-        }
-
-        // Upsert functions
-        public void SingleWriter(ref AdId key, ref NumClicks src, ref NumClicks dst)
-        {
-            dst = src;
-        }
-
-        public bool ConcurrentWriter(ref AdId key, ref NumClicks src, ref NumClicks dst)
-        {
-            dst = src;
-            return true;
-        }
+        public override void ConcurrentReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst) => dst.value = value;
 
         // RMW functions
-        public void InitialUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
+        public override void InitialUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
         {
             value = input.numClicks;
         }
 
-        public bool InPlaceUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
+        public override bool InPlaceUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
         {
             Interlocked.Add(ref value.numClicks, input.numClicks.numClicks);
             return true;
         }
 
-        public bool NeedCopyUpdate(ref AdId key, ref AdInput input, ref NumClicks oldValue) => true;
+        public override bool NeedCopyUpdate(ref AdId key, ref AdInput input, ref NumClicks oldValue) => true;
 
-        public void CopyUpdater(ref AdId key, ref AdInput input, ref NumClicks oldValue, ref NumClicks newValue)
+        public override void CopyUpdater(ref AdId key, ref AdInput input, ref NumClicks oldValue, ref NumClicks newValue)
         {
             newValue.numClicks += oldValue.numClicks + input.numClicks.numClicks;
         }

--- a/cs/test/RecoveryTestTypes.cs
+++ b/cs/test/RecoveryTestTypes.cs
@@ -44,66 +44,34 @@ namespace FASTER.test.recovery.sumstore
         public NumClicks value;
     }
 
-    public class Functions : IFunctions<AdId, NumClicks, AdInput, Output, Empty>
+    public class Functions : FunctionsBase<AdId, NumClicks, AdInput, Output, Empty>
     {
-        public void RMWCompletionCallback(ref AdId key, ref AdInput input, Empty ctx, Status status)
-        {
-        }
-
-        public void ReadCompletionCallback(ref AdId key, ref AdInput input, ref Output output, Empty ctx, Status status)
-        {
-        }
-
-        public void UpsertCompletionCallback(ref AdId key, ref NumClicks input, Empty ctx)
-        {
-        }
-
-        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
-        {
-        }
-
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-        }
-
         // Read functions
-        public void SingleReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst)
+        public override void SingleReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst)
         {
             dst.value = value;
         }
 
-        public void ConcurrentReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst)
+        public override void ConcurrentReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst)
         {
             dst.value = value;
-        }
-
-        // Upsert functions
-        public void SingleWriter(ref AdId key, ref NumClicks src, ref NumClicks dst)
-        {
-            dst = src;
-        }
-
-        public bool ConcurrentWriter(ref AdId key, ref NumClicks src, ref NumClicks dst)
-        {
-            dst = src;
-            return true;
         }
 
         // RMW functions
-        public void InitialUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
+        public override void InitialUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
         {
             value = input.numClicks;
         }
 
-        public bool InPlaceUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
+        public override bool InPlaceUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
         {
             Interlocked.Add(ref value.numClicks, input.numClicks.numClicks);
             return true;
         }
 
-        public bool NeedCopyUpdate(ref AdId key, ref AdInput input, ref NumClicks oldValue) => true;
+        public override bool NeedCopyUpdate(ref AdId key, ref AdInput input, ref NumClicks oldValue) => true;
 
-        public void CopyUpdater(ref AdId key, ref AdInput input, ref NumClicks oldValue, ref NumClicks newValue)
+        public override void CopyUpdater(ref AdId key, ref AdInput input, ref NumClicks oldValue, ref NumClicks newValue)
         {
             newValue.numClicks += oldValue.numClicks + input.numClicks.numClicks;
         }

--- a/cs/test/SimpleRecoveryTest.cs
+++ b/cs/test/SimpleRecoveryTest.cs
@@ -91,7 +91,7 @@ namespace FASTER.test.recovery.sumstore.simple
             AdInput inputArg = default;
             Output output = default;
 
-            var session1 = fht1.NewSession(new SimpleFunctions());
+            var session1 = fht1.NewSession(new AdSimpleFunctions());
             for (int key = 0; key < numOps; key++)
             {
                 value.numClicks = key;
@@ -106,7 +106,7 @@ namespace FASTER.test.recovery.sumstore.simple
             else
                 fht2.Recover(token);
 
-            var session2 = fht2.NewSession(new SimpleFunctions());
+            var session2 = fht2.NewSession(new AdSimpleFunctions());
             for (int key = 0; key < numOps; key++)
             {
                 var status = session2.Read(ref inputArray[key], ref inputArg, ref output, Empty.Default, 0);
@@ -164,7 +164,7 @@ namespace FASTER.test.recovery.sumstore.simple
             AdInput inputArg = default;
             Output output = default;
 
-            var session1 = fht1.NewSession(new SimpleFunctions());
+            var session1 = fht1.NewSession(new AdSimpleFunctions());
             for (int key = 0; key < numOps; key++)
             {
                 value.numClicks = key;
@@ -179,7 +179,7 @@ namespace FASTER.test.recovery.sumstore.simple
             else 
                 fht2.Recover(token);
 
-            var session2 = fht2.NewSession(new SimpleFunctions());
+            var session2 = fht2.NewSession(new AdSimpleFunctions());
             for (int key = 0; key < numOps; key++)
             {
                 var status = session2.Read(ref inputArray[key], ref inputArg, ref output, Empty.Default, 0);
@@ -233,7 +233,7 @@ namespace FASTER.test.recovery.sumstore.simple
 
             NumClicks value;
 
-            var session1 = fht1.NewSession(new SimpleFunctions());
+            var session1 = fht1.NewSession(new AdSimpleFunctions());
             var address = 0L;
             for (int key = 0; key < numOps; key++)
             {
@@ -264,68 +264,34 @@ namespace FASTER.test.recovery.sumstore.simple
         }
     }
 
-    public class SimpleFunctions : IFunctions<AdId, NumClicks, AdInput, Output, Empty>
+    public class AdSimpleFunctions : FunctionsBase<AdId, NumClicks, AdInput, Output, Empty>
     {
-        public void RMWCompletionCallback(ref AdId key, ref AdInput input, Empty ctx, Status status)
-        {
-        }
-
-        public void ReadCompletionCallback(ref AdId key, ref AdInput input, ref Output output, Empty ctx, Status status)
+        public override void ReadCompletionCallback(ref AdId key, ref AdInput input, ref Output output, Empty ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
             Assert.IsTrue(output.value.numClicks == key.adId);
         }
 
-        public void UpsertCompletionCallback(ref AdId key, ref NumClicks input, Empty ctx)
-        {
-        }
-
-        public void DeleteCompletionCallback(ref AdId key, Empty ctx)
-        {
-        }
-
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-        }
-
         // Read functions
-        public void SingleReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst)
-        {
-            dst.value = value;
-        }
+        public override void SingleReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst) => dst.value = value;
 
-        public void ConcurrentReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst)
-        {
-            dst.value = value;
-        }
-
-        // Upsert functions
-        public void SingleWriter(ref AdId key, ref NumClicks src, ref NumClicks dst)
-        {
-            dst = src;
-        }
-
-        public bool ConcurrentWriter(ref AdId key, ref NumClicks src, ref NumClicks dst)
-        {
-            dst = src;
-            return true;
-        }
+        public override void ConcurrentReader(ref AdId key, ref AdInput input, ref NumClicks value, ref Output dst) => dst.value = value;
 
         // RMW functions
-        public void InitialUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
+        public override void InitialUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
         {
             value = input.numClicks;
         }
 
-        public bool InPlaceUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
+        public override bool InPlaceUpdater(ref AdId key, ref AdInput input, ref NumClicks value)
         {
             Interlocked.Add(ref value.numClicks, input.numClicks.numClicks);
             return true;
         }
 
-        public bool NeedCopyUpdate(ref AdId key, ref AdInput input, ref NumClicks oldValue) => true;
+        public override bool NeedCopyUpdate(ref AdId key, ref AdInput input, ref NumClicks oldValue) => true;
 
-        public void CopyUpdater(ref AdId key, ref AdInput input, ref NumClicks oldValue, ref NumClicks newValue)
+        public override void CopyUpdater(ref AdId key, ref AdInput input, ref NumClicks oldValue, ref NumClicks newValue)
         {
             newValue.numClicks += oldValue.numClicks + input.numClicks.numClicks;
         }

--- a/cs/test/TestTypes.cs
+++ b/cs/test/TestTypes.cs
@@ -52,86 +52,56 @@ namespace FASTER.test
         public ValueStruct value;
     }
 
-    public class Functions : IFunctions<KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty>
+    public class Functions : FunctionsBase<KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty>
     {
-        public void RMWCompletionCallback(ref KeyStruct key, ref InputStruct input, Empty ctx, Status status)
+        public override void RMWCompletionCallback(ref KeyStruct key, ref InputStruct input, Empty ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
         }
 
-        public void ReadCompletionCallback(ref KeyStruct key, ref InputStruct input, ref OutputStruct output, Empty ctx, Status status)
+        public override void ReadCompletionCallback(ref KeyStruct key, ref InputStruct input, ref OutputStruct output, Empty ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
             Assert.IsTrue(output.value.vfield1 == key.kfield1);
             Assert.IsTrue(output.value.vfield2 == key.kfield2);
         }
 
-        public void UpsertCompletionCallback(ref KeyStruct key, ref ValueStruct output, Empty ctx)
-        {
-        }
-
-        public void DeleteCompletionCallback(ref KeyStruct key, Empty ctx)
-        {
-        }
-
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-        }
-
         // Read functions
-        public void SingleReader(ref KeyStruct key, ref InputStruct input, ref ValueStruct value, ref OutputStruct dst)
-        {
-            dst.value = value;
-        }
+        public override void SingleReader(ref KeyStruct key, ref InputStruct input, ref ValueStruct value, ref OutputStruct dst) => dst.value = value;
 
-        public void ConcurrentReader(ref KeyStruct key, ref InputStruct input, ref ValueStruct value, ref OutputStruct dst)
-        {
-            dst.value = value;
-        }
-
-        // Upsert functions
-        public void SingleWriter(ref KeyStruct key, ref ValueStruct src, ref ValueStruct dst)
-        {
-            dst = src;
-        }
-
-        public bool ConcurrentWriter(ref KeyStruct key, ref ValueStruct src, ref ValueStruct dst)
-        {
-            dst = src;
-            return true;
-        }
+        public override void ConcurrentReader(ref KeyStruct key, ref InputStruct input, ref ValueStruct value, ref OutputStruct dst) => dst.value = value;
 
         // RMW functions
-        public void InitialUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct value)
+        public override void InitialUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct value)
         {
             value.vfield1 = input.ifield1;
             value.vfield2 = input.ifield2;
         }
 
-        public bool InPlaceUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct value)
+        public override bool InPlaceUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct value)
         {
             value.vfield1 += input.ifield1;
             value.vfield2 += input.ifield2;
             return true;
         }
 
-        public bool NeedCopyUpdate(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue) => true;
+        public override bool NeedCopyUpdate(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue) => true;
 
-        public void CopyUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue, ref ValueStruct newValue)
+        public override void CopyUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue, ref ValueStruct newValue)
         {
             newValue.vfield1 = oldValue.vfield1 + input.ifield1;
             newValue.vfield2 = oldValue.vfield2 + input.ifield2;
         }
     }
 
-    public class FunctionsCompaction : IFunctions<KeyStruct, ValueStruct, InputStruct, OutputStruct, int>
+    public class FunctionsCompaction : FunctionsBase<KeyStruct, ValueStruct, InputStruct, OutputStruct, int>
     {
-        public void RMWCompletionCallback(ref KeyStruct key, ref InputStruct input, int ctx, Status status)
+        public override void RMWCompletionCallback(ref KeyStruct key, ref InputStruct input, int ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
         }
 
-        public void ReadCompletionCallback(ref KeyStruct key, ref InputStruct input, ref OutputStruct output, int ctx, Status status)
+        public override void ReadCompletionCallback(ref KeyStruct key, ref InputStruct input, ref OutputStruct output, int ctx, Status status)
         {
             if (ctx == 0)
             {
@@ -145,65 +115,35 @@ namespace FASTER.test
             }
         }
 
-        public void UpsertCompletionCallback(ref KeyStruct key, ref ValueStruct output, int ctx)
-        {
-        }
-
-        public void DeleteCompletionCallback(ref KeyStruct key, int ctx)
-        {
-        }
-
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-        }
-
         // Read functions
-        public void SingleReader(ref KeyStruct key, ref InputStruct input, ref ValueStruct value, ref OutputStruct dst)
-        {
-            dst.value = value;
-        }
+        public override void SingleReader(ref KeyStruct key, ref InputStruct input, ref ValueStruct value, ref OutputStruct dst) => dst.value = value;
 
-        public void ConcurrentReader(ref KeyStruct key, ref InputStruct input, ref ValueStruct value, ref OutputStruct dst)
-        {
-            dst.value = value;
-        }
-
-        // Upsert functions
-        public void SingleWriter(ref KeyStruct key, ref ValueStruct src, ref ValueStruct dst)
-        {
-            dst = src;
-        }
-
-        public bool ConcurrentWriter(ref KeyStruct key, ref ValueStruct src, ref ValueStruct dst)
-        {
-            dst = src;
-            return true;
-        }
+        public override void ConcurrentReader(ref KeyStruct key, ref InputStruct input, ref ValueStruct value, ref OutputStruct dst) => dst.value = value;
 
         // RMW functions
-        public void InitialUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct value)
+        public override void InitialUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct value)
         {
             value.vfield1 = input.ifield1;
             value.vfield2 = input.ifield2;
         }
 
-        public bool InPlaceUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct value)
+        public override bool InPlaceUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct value)
         {
             value.vfield1 += input.ifield1;
             value.vfield2 += input.ifield2;
             return true;
         }
 
-        public bool NeedCopyUpdate(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue) => true;
+        public override bool NeedCopyUpdate(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue) => true;
 
-        public void CopyUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue, ref ValueStruct newValue)
+        public override void CopyUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue, ref ValueStruct newValue)
         {
             newValue.vfield1 = oldValue.vfield1 + input.ifield1;
             newValue.vfield2 = oldValue.vfield2 + input.ifield2;
         }
     }
 
-    public class FunctionsCopyOnWrite : IFunctions<KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty>
+    public class FunctionsCopyOnWrite : FunctionsBase<KeyStruct, ValueStruct, InputStruct, OutputStruct, Empty>
     {
         private int _concurrentWriterCallCount;
         private int _inPlaceUpdaterCallCount;
@@ -211,69 +151,48 @@ namespace FASTER.test
         public int ConcurrentWriterCallCount => _concurrentWriterCallCount;
         public int InPlaceUpdaterCallCount => _inPlaceUpdaterCallCount;
 
-        public void RMWCompletionCallback(ref KeyStruct key, ref InputStruct input, Empty ctx, Status status)
+        public override void RMWCompletionCallback(ref KeyStruct key, ref InputStruct input, Empty ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
         }
 
-        public void ReadCompletionCallback(ref KeyStruct key, ref InputStruct input, ref OutputStruct output, Empty ctx, Status status)
+        public override void ReadCompletionCallback(ref KeyStruct key, ref InputStruct input, ref OutputStruct output, Empty ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
             Assert.IsTrue(output.value.vfield1 == key.kfield1);
             Assert.IsTrue(output.value.vfield2 == key.kfield2);
         }
 
-        public void UpsertCompletionCallback(ref KeyStruct key, ref ValueStruct output, Empty ctx)
-        {
-        }
-
-        public void DeleteCompletionCallback(ref KeyStruct key, Empty ctx)
-        {
-        }
-
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-        }
-
         // Read functions
-        public void SingleReader(ref KeyStruct key, ref InputStruct input, ref ValueStruct value, ref OutputStruct dst)
-        {
-            dst.value = value;
-        }
+        public override void SingleReader(ref KeyStruct key, ref InputStruct input, ref ValueStruct value, ref OutputStruct dst) => dst.value = value;
 
-        public void ConcurrentReader(ref KeyStruct key, ref InputStruct input, ref ValueStruct value, ref OutputStruct dst)
-        {
-            dst.value = value;
-        }
+        public override void ConcurrentReader(ref KeyStruct key, ref InputStruct input, ref ValueStruct value, ref OutputStruct dst) => dst.value = value;
 
         // Upsert functions
-        public void SingleWriter(ref KeyStruct key, ref ValueStruct src, ref ValueStruct dst)
-        {
-            dst = src;
-        }
+        public override void SingleWriter(ref KeyStruct key, ref ValueStruct src, ref ValueStruct dst) => dst = src;
 
-        public bool ConcurrentWriter(ref KeyStruct key, ref ValueStruct src, ref ValueStruct dst)
+        public override bool ConcurrentWriter(ref KeyStruct key, ref ValueStruct src, ref ValueStruct dst)
         {
             Interlocked.Increment(ref _concurrentWriterCallCount);
             return false;
         }
 
         // RMW functions
-        public void InitialUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct value)
+        public override void InitialUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct value)
         {
             value.vfield1 = input.ifield1;
             value.vfield2 = input.ifield2;
         }
 
-        public bool InPlaceUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct value)
+        public override bool InPlaceUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct value)
         {
             Interlocked.Increment(ref _inPlaceUpdaterCallCount);
             return false;
         }
 
-        public bool NeedCopyUpdate(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue) => true;
+        public override bool NeedCopyUpdate(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue) => true;
 
-        public void CopyUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue, ref ValueStruct newValue)
+        public override void CopyUpdater(ref KeyStruct key, ref InputStruct input, ref ValueStruct oldValue, ref ValueStruct newValue)
         {
             newValue.vfield1 = oldValue.vfield1 + input.ifield1;
             newValue.vfield2 = oldValue.vfield2 + input.ifield2;

--- a/cs/test/VLTestTypes.cs
+++ b/cs/test/VLTestTypes.cs
@@ -2,15 +2,8 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Linq;
 using FASTER.core;
 using System.Runtime.CompilerServices;
-using System.IO;
-using System.Diagnostics;
 using NUnit.Framework;
 using System.Runtime.InteropServices;
 
@@ -112,14 +105,14 @@ namespace FASTER.test
         public long input;
     }
 
-    public class VLFunctions : IFunctions<Key, VLValue, Input, int[], Empty>
+    public class VLFunctions : FunctionsBase<Key, VLValue, Input, int[], Empty>
     {
-        public void RMWCompletionCallback(ref Key key, ref Input input, Empty ctx, Status status)
+        public override void RMWCompletionCallback(ref Key key, ref Input input, Empty ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
         }
 
-        public void ReadCompletionCallback(ref Key key, ref Input input, ref int[] output, Empty ctx, Status status)
+        public override void ReadCompletionCallback(ref Key key, ref Input input, ref int[] output, Empty ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
             for (int i = 0; i < output.Length; i++)
@@ -128,69 +121,41 @@ namespace FASTER.test
             }
         }
 
-        public void UpsertCompletionCallback(ref Key key, ref VLValue output, Empty ctx)
-        {
-        }
-
-        public void DeleteCompletionCallback(ref Key key, Empty ctx)
-        {
-        }
-
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-        }
-
         // Read functions
-        public void SingleReader(ref Key key, ref Input input, ref VLValue value, ref int[] dst)
+        public override void SingleReader(ref Key key, ref Input input, ref VLValue value, ref int[] dst)
         {
             value.ToIntArray(ref dst);
         }
 
-        public void ConcurrentReader(ref Key key, ref Input input, ref VLValue value, ref int[] dst)
+        public override void ConcurrentReader(ref Key key, ref Input input, ref VLValue value, ref int[] dst)
         {
             value.ToIntArray(ref dst);
         }
 
         // Upsert functions
-        public void SingleWriter(ref Key key, ref VLValue src, ref VLValue dst)
+        public override void SingleWriter(ref Key key, ref VLValue src, ref VLValue dst)
         {
             src.CopyTo(ref dst);
         }
 
-        public bool ConcurrentWriter(ref Key key, ref VLValue src, ref VLValue dst)
+        public override bool ConcurrentWriter(ref Key key, ref VLValue src, ref VLValue dst)
         {
             if (src.length != dst.length)
                 return false;
 
             src.CopyTo(ref dst);
             return true;
-        }
-
-        // RMW functions
-        public void InitialUpdater(ref Key key, ref Input input, ref VLValue value)
-        {
-        }
-
-        public bool InPlaceUpdater(ref Key key, ref Input input, ref VLValue value)
-        {
-            return true;
-        }
-
-        public bool NeedCopyUpdate(ref Key key, ref Input input, ref VLValue oldValue) => true;
-
-        public void CopyUpdater(ref Key key, ref Input input, ref VLValue oldValue, ref VLValue newValue)
-        {
         }
     }
 
-    public class VLFunctions2 : IFunctions<VLValue, VLValue, Input, int[], Empty>
+    public class VLFunctions2 : FunctionsBase<VLValue, VLValue, Input, int[], Empty>
     {
-        public void RMWCompletionCallback(ref VLValue key, ref Input input, Empty ctx, Status status)
+        public override void RMWCompletionCallback(ref VLValue key, ref Input input, Empty ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
         }
 
-        public void ReadCompletionCallback(ref VLValue key, ref Input input, ref int[] output, Empty ctx, Status status)
+        public override void ReadCompletionCallback(ref VLValue key, ref Input input, ref int[] output, Empty ctx, Status status)
         {
             Assert.IsTrue(status == Status.OK);
             for (int i = 0; i < output.Length; i++)
@@ -199,58 +164,30 @@ namespace FASTER.test
             }
         }
 
-        public void UpsertCompletionCallback(ref VLValue key, ref VLValue output, Empty ctx)
-        {
-        }
-
-        public void DeleteCompletionCallback(ref VLValue key, Empty ctx)
-        {
-        }
-
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-        }
-
         // Read functions
-        public void SingleReader(ref VLValue key, ref Input input, ref VLValue value, ref int[] dst)
+        public override void SingleReader(ref VLValue key, ref Input input, ref VLValue value, ref int[] dst)
         {
             value.ToIntArray(ref dst);
         }
 
-        public void ConcurrentReader(ref VLValue key, ref Input input, ref VLValue value, ref int[] dst)
+        public override void ConcurrentReader(ref VLValue key, ref Input input, ref VLValue value, ref int[] dst)
         {
             value.ToIntArray(ref dst);
         }
 
         // Upsert functions
-        public void SingleWriter(ref VLValue key, ref VLValue src, ref VLValue dst)
+        public override void SingleWriter(ref VLValue key, ref VLValue src, ref VLValue dst)
         {
             src.CopyTo(ref dst);
         }
 
-        public bool ConcurrentWriter(ref VLValue key, ref VLValue src, ref VLValue dst)
+        public override bool ConcurrentWriter(ref VLValue key, ref VLValue src, ref VLValue dst)
         {
             if (src.length != dst.length)
                 return false;
 
             src.CopyTo(ref dst);
             return true;
-        }
-
-        // RMW functions
-        public void InitialUpdater(ref VLValue key, ref Input input, ref VLValue value)
-        {
-        }
-
-        public bool InPlaceUpdater(ref VLValue key, ref Input input, ref VLValue value)
-        {
-            return true;
-        }
-
-        public bool NeedCopyUpdate(ref VLValue key, ref Input input, ref VLValue oldValue) => true;
-
-        public void CopyUpdater(ref VLValue key, ref Input input, ref VLValue oldValue, ref VLValue newValue)
-        {
         }
     }
 }

--- a/docs/_docs/20-fasterkv-basics.md
+++ b/docs/_docs/20-fasterkv-basics.md
@@ -93,12 +93,15 @@ Apart from Key and Value, the IFunctions interface is defined on three additiona
 2. SingleWriter and ConcurrentWriter: These are used to write values to the store, from a source value. Concurrent writer can assume that there are no concurrent operations on the record.
 3. Completion callbacks: Called by FASTER when various operations complete after they have gone "pending" due to requiring IO.
 4. RMW Updaters: There are three updaters that the user specifies, InitialUpdater, InPlaceUpdater, and CopyUpdater. Together, they are used to implement the RMW operation.
+5. Locking: There is one property and two methods; if the SupportsLocking property returns true, then FASTER will call Lock and Unlock within a try/finally in the four concurrent callback methods: ConcurrentReader, ConcurrentWriter, ConcurrentDeleter (new in IAdvancedFunctions), and InPlaceUpdater. FunctionsBase illustrates the default implementation of Lock and Unlock as an exclusive lock using a bit in RecordInfo.
 
 #### IAdvancedFunctions
 
 `IAdvancedFunctions` is a superset of `IFunctions` and provides the same methods with some additional parameters:
 - ReadCompletionCallback receives the `RecordInfo` of the record that was read.
 - Other callbacks receive the logical address of the record, which can be useful for applications such as indexing.
+
+`IAdvancedFunctions` also contains a new method, ConcurrentDeleter, which may return false for default deletion handling (setting recordInfo.Tombstone true, and setting object types to null), or may implement its own delete handling (which must set recordInfo.Tombstone true) and return true.
 
 `IAdvancedFunctions` is a separate interface; it does not inherit from `IFunctions`.
 

--- a/docs/_docs/20-fasterkv-basics.md
+++ b/docs/_docs/20-fasterkv-basics.md
@@ -101,7 +101,7 @@ Apart from Key and Value, the IFunctions interface is defined on three additiona
 - ReadCompletionCallback receives the `RecordInfo` of the record that was read.
 - Other callbacks receive the logical address of the record, which can be useful for applications such as indexing.
 
-`IAdvancedFunctions` also contains a new method, ConcurrentDeleter, which may return false for default deletion handling (setting recordInfo.Tombstone true, and setting object types to null), or may implement its own delete handling (which must set recordInfo.Tombstone true) and return true.
+`IAdvancedFunctions` also contains a new method, ConcurrentDeleter, which may be used to implement user-defined post-deletion logic, such as calling object Dispose.
 
 `IAdvancedFunctions` is a separate interface; it does not inherit from `IFunctions`.
 


### PR DESCRIPTION
Add the following to IFunctions and IAdvancedFunctions. Functions implementations that do not inherit from (Advanced)FunctionsBase must provide an implementation of these.

        // If true, FASTER calls Lock() and Unlock() where appropriate. Currently this is the 4 concurrent callback methods:
        // ConcurrentReader, ConcurrentWriter, ConcurrentDeleter (new in IAdvancedFunctions), and InPlaceUpdater.
        bool SupportsLocking { get; }

        // FunctionsBase illustrates the default implementation of these as an exclusive lock using a bit in RecordInfo
        void Lock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, ref long lockContext);
        bool Unlock(ref RecordInfo recordInfo, ref Key key, ref Value value, LockType lockType, long lockContext);

Add a new method ConcurrentDeleter to IAdvancedFunctions. This may return false for default deletion handling (setting tombstone, and setting object types to null), or may implement its own delete handling (which must set tombstone) and return true.

Add FASTER.benchmark: -z, --locking option to exercise
