### PR TITLE
[C#] MLSD and FasterLog improvements

### DIFF
--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -1435,10 +1435,17 @@ namespace FASTER.core
                 {
                     // Enqueue work in shared queue
                     var index = GetPageIndexForAddress(asyncResult.fromAddress);
-                    PendingFlush[index].Add(asyncResult);
-                    if (PendingFlush[index].RemoveAdjacent(FlushedUntilAddress, out PageAsyncFlushResult<Empty> request))
+                    if (PendingFlush[index].Add(asyncResult))
                     {
-                        WriteAsync(request.fromAddress >> LogPageSizeBits, AsyncFlushPageCallback, request);
+                        if (PendingFlush[index].RemoveAdjacent(FlushedUntilAddress, out PageAsyncFlushResult<Empty> request))
+                        {
+                            WriteAsync(request.fromAddress >> LogPageSizeBits, AsyncFlushPageCallback, request);
+                        }
+                    }
+                    else
+                    {
+                        // Could not add to pending flush list, treat as a failed write
+                        AsyncFlushPageCallback(1, 0, asyncResult);
                     }
                 }
                 else

--- a/cs/src/core/Allocator/PendingFlushList.cs
+++ b/cs/src/core/Allocator/PendingFlushList.cs
@@ -35,12 +35,35 @@ namespace FASTER.core
             return false;
         }
 
-        public bool RemoveAdjacent(long address, out PageAsyncFlushResult<Empty> request)
+        /// <summary>
+        /// Remove item from flush list with from-address equal to the specified address
+        /// </summary>
+        public bool RemoveNextAdjacent(long address, out PageAsyncFlushResult<Empty> request)
         {
             for (int i=0; i<maxSize; i++)
             {
                 request = list[i];
                 if (request?.fromAddress == address)
+                {
+                    if (Interlocked.CompareExchange(ref list[i], null, request) == request)
+                    {
+                        return true;
+                    }
+                }
+            }
+            request = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Remove item from flush list with until-address equal to the specified address
+        /// </summary>
+        public bool RemovePreviousAdjacent(long address, out PageAsyncFlushResult<Empty> request)
+        {
+            for (int i = 0; i < maxSize; i++)
+            {
+                request = list[i];
+                if (request?.untilAddress == address)
                 {
                     if (Interlocked.CompareExchange(ref list[i], null, request) == request)
                     {

--- a/cs/src/core/Allocator/PendingFlushList.cs
+++ b/cs/src/core/Allocator/PendingFlushList.cs
@@ -16,7 +16,7 @@ namespace FASTER.core
             list = new PageAsyncFlushResult<Empty>[maxSize];
         }
 
-        public void Add(PageAsyncFlushResult<Empty> t)
+        public bool Add(PageAsyncFlushResult<Empty> t)
         {
             int retries = 0;
             do
@@ -27,12 +27,12 @@ namespace FASTER.core
                     {
                         if (Interlocked.CompareExchange(ref list[i], t, default) == default)
                         {
-                            return;
+                            return true;
                         }
                     }
                 }
             } while (retries++ < maxRetries);
-            throw new FasterException("Unable to add item to list");
+            return false;
         }
 
         public bool RemoveAdjacent(long address, out PageAsyncFlushResult<Empty> request)

--- a/cs/src/core/Device/FixedPool.cs
+++ b/cs/src/core/Device/FixedPool.cs
@@ -24,44 +24,48 @@ namespace FASTER.core
 
         public (T, int) Get()
         {
-            while (true)
+            for (int i = 0; i < size; i++)
             {
-                for (int i = 0; i < size; i++)
+                if (disposed)
+                    throw new FasterException("Accessing a disposed handle in device");
+
+                var val = owners[i];
+                if (val == 0)
                 {
-                    if (disposed)
-                        throw new FasterException("Accessing a disposed handle in device");
-
-                    var val = owners[i];
-                    if (val == 0)
+                    if (Interlocked.CompareExchange(ref owners[i], 2, val) == val)
                     {
-                        if (Interlocked.CompareExchange(ref owners[i], 2, val) == val)
+                        try
                         {
-                            try
-                            {
-                                items[i] = creator();
-                            }
-                            catch
-                            {
-                                Interlocked.Exchange(ref owners[i], val);
-                                throw;
-                            }
-
-                            return (items[i], i);
+                            items[i] = creator();
                         }
+                        catch
+                        {
+                            Interlocked.Exchange(ref owners[i], val);
+                            throw;
+                        }
+
+                        return (items[i], i);
                     }
-                    else if (val == 1)
+                }
+                else if (val == 1)
+                {
+                    if (Interlocked.CompareExchange(ref owners[i], 2, val) == val)
                     {
-                        if (Interlocked.CompareExchange(ref owners[i], 2, val) == val)
-                        {
-                            return (items[i], i);
-                        }
+                        return (items[i], i);
                     }
                 }
             }
+            return (creator(), int.MaxValue);
         }
 
-        public void Return(int offset)
+        public void Return(int offset, T item)
         {
+            if (offset == int.MaxValue)
+            {
+                item.Dispose();
+                return;
+            }
+
             if (!disposed)
                 Interlocked.CompareExchange(ref owners[offset], 1, 2);
             else

--- a/cs/src/core/Device/FixedPool.cs
+++ b/cs/src/core/Device/FixedPool.cs
@@ -58,13 +58,10 @@ namespace FASTER.core
             return (creator(), int.MaxValue);
         }
 
-        public void Return(int offset, T item)
+        public void Return(int offset)
         {
             if (offset == int.MaxValue)
-            {
-                item.Dispose();
                 return;
-            }
 
             if (!disposed)
                 Interlocked.CompareExchange(ref owners[offset], 1, 2);
@@ -104,6 +101,15 @@ namespace FASTER.core
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Dispose temporary handles that are not pooled
+        /// </summary>
+        internal void DisposeIfNeeded(int offset, T item)
+        {
+            if (offset == int.MaxValue)
+                item.Dispose();
         }
     }
 }

--- a/cs/src/core/Device/ManagedLocalStorageDevice.cs
+++ b/cs/src/core/Device/ManagedLocalStorageDevice.cs
@@ -215,9 +215,12 @@ namespace FASTER.core
                     await logWriteHandle.WriteAsync(umm.Memory);
 #else
                     SectorAlignedMemory memory = pool.Get((int)numBytesToWrite);
-                    fixed (void* destination = memory.buffer)
+                    unsafe
                     {
-                        Buffer.MemoryCopy((void*)sourceAddress, destination, numBytesToWrite, numBytesToWrite);
+                        fixed (void* destination = memory.buffer)
+                        {
+                            Buffer.MemoryCopy((void*)sourceAddress, destination, numBytesToWrite, numBytesToWrite);
+                        }
                     }
 
                     await logWriteHandle.WriteAsync(memory.buffer, 0, (int)numBytesToWrite);

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -254,9 +254,16 @@ namespace FASTER.core
 
             return status;
         }
-#endregion
+        #endregion
 
-#region Upsert Operation
+        #region Upsert Operation
+
+        private enum LatchDestination
+        {
+            CreateNewRecord,
+            CreatePendingContext,
+            NormalProcessing
+        }
 
         /// <summary>
         /// Upsert operation. Replaces the value corresponding to 'key' with provided 'value', if one exists 
@@ -299,12 +306,11 @@ namespace FASTER.core
                             long lsn)
             where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
         {
-            var status = default(OperationStatus);
             var bucket = default(HashBucket*);
             var slot = default(int);
-            var logicalAddress = Constants.kInvalidAddress;
-            var physicalAddress = default(long);
-            var latchOperation = default(LatchOperation);
+            var status = default(OperationStatus);
+            var latchOperation = LatchOperation.None;
+            var latchDestination = LatchDestination.NormalProcessing;
 
             var hash = comparer.GetHashCode64(ref key);
             var tag = (ushort)((ulong)hash >> Constants.kHashTagShift);
@@ -315,7 +321,8 @@ namespace FASTER.core
 #region Trace back for record in in-memory HybridLog
             var entry = default(HashBucketEntry);
             FindOrCreateTag(hash, tag, ref bucket, ref slot, ref entry, hlog.BeginAddress);
-            logicalAddress = entry.Address;
+            var logicalAddress = entry.Address;
+            var physicalAddress = default(long);
 
             if (UseReadCache)
                 SkipAndInvalidateReadCache(ref logicalAddress, ref key);
@@ -349,86 +356,24 @@ namespace FASTER.core
 #region Entry latch operation
             if (sessionCtx.phase != Phase.REST)
             {
-                switch (sessionCtx.phase)
-                {
-                    case Phase.PREPARE:
-                        {
-                            if (HashBucket.TryAcquireSharedLatch(bucket))
-                            {
-                                // Set to release shared latch (default)
-                                latchOperation = LatchOperation.Shared;
-                                if (GetLatestRecordVersion(ref entry, sessionCtx.version) > sessionCtx.version)
-                                {
-                                    status = OperationStatus.CPR_SHIFT_DETECTED;
-                                    goto CreatePendingContext; // Pivot Thread
-                                }
-                                break; // Normal Processing
-                            }
-                            else
-                            {
-                                status = OperationStatus.CPR_SHIFT_DETECTED;
-                                goto CreatePendingContext; // Pivot Thread
-                            }
-                        }
-                    case Phase.IN_PROGRESS:
-                        {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
-                            {
-                                if (HashBucket.TryAcquireExclusiveLatch(bucket))
-                                {
-                                    // Set to release exclusive latch (default)
-                                    latchOperation = LatchOperation.Exclusive;
-                                    goto CreateNewRecord; // Create a (v+1) record
-                                }
-                                else
-                                {
-                                    status = OperationStatus.RETRY_LATER;
-                                    goto CreatePendingContext; // Go Pending
-                                }
-                            }
-                            break; // Normal Processing
-                        }
-                    case Phase.WAIT_PENDING:
-                        {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
-                            {
-                                if (HashBucket.NoSharedLatches(bucket))
-                                {
-                                    goto CreateNewRecord; // Create a (v+1) record
-                                }
-                                else
-                                {
-                                    status = OperationStatus.RETRY_LATER;
-                                    goto CreatePendingContext; // Go Pending
-                                }
-                            }
-                            break; // Normal Processing
-                        }
-                    case Phase.WAIT_FLUSH:
-                        {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
-                            {
-                                goto CreateNewRecord; // Create a (v+1) record
-                            }
-                            break; // Normal Processing
-                        }
-                    default:
-                        break;
-                }
+                latchDestination = AcquireLatchUpsert(sessionCtx, bucket, ref status, ref latchOperation, ref entry);
             }
-#endregion
+            #endregion
 
             Debug.Assert(GetLatestRecordVersion(ref entry, sessionCtx.version) <= sessionCtx.version);
 
-#region Normal processing
+            #region Normal processing
 
             // Mutable Region: Update the record in-place
-            if (logicalAddress >= hlog.ReadOnlyAddress && !hlog.GetInfo(physicalAddress).Tombstone)
+            if (latchDestination == LatchDestination.NormalProcessing)
             {
-                if (fasterSession.ConcurrentWriter(ref key, ref value, ref hlog.GetValue(physicalAddress), logicalAddress))
+                if (logicalAddress >= hlog.ReadOnlyAddress && !hlog.GetInfo(physicalAddress).Tombstone)
                 {
-                    status = OperationStatus.SUCCESS;
-                    goto LatchRelease; // Release shared latch (if acquired)
+                    if (fasterSession.ConcurrentWriter(ref key, ref value, ref hlog.GetValue(physicalAddress), logicalAddress))
+                    {
+                        status = OperationStatus.SUCCESS;
+                        goto LatchRelease; // Release shared latch (if acquired)
+                    }
                 }
             }
 
@@ -437,46 +382,16 @@ namespace FASTER.core
 
 #region Create new record in the mutable region
         CreateNewRecord:
+            if (latchDestination != LatchDestination.CreatePendingContext)
             {
                 // Immutable region or new record
-                var (actualSize, allocateSize) = hlog.GetRecordSize(ref key, ref value);
-                BlockAllocate(allocateSize, out long newLogicalAddress, sessionCtx, fasterSession);
-                var newPhysicalAddress = hlog.GetPhysicalAddress(newLogicalAddress);
-                RecordInfo.WriteInfo(ref hlog.GetInfo(newPhysicalAddress),
-                               sessionCtx.version,
-                               tombstone:false, invalidBit:false,
-                               latestLogicalAddress);
-                hlog.Serialize(ref key, newPhysicalAddress);
-                fasterSession.SingleWriter(ref key, ref value,
-                                       ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize), newLogicalAddress);
-
-                var updatedEntry = default(HashBucketEntry);
-                updatedEntry.Tag = tag;
-                updatedEntry.Address = newLogicalAddress & Constants.kAddressMask;
-                updatedEntry.Pending = entry.Pending;
-                updatedEntry.Tentative = false;
-
-                var foundEntry = default(HashBucketEntry);
-                foundEntry.word = Interlocked.CompareExchange(
-                                        ref bucket->bucket_entries[slot],
-                                        updatedEntry.word, entry.word);
-
-                if (foundEntry.word == entry.word)
-                {
-                    status = OperationStatus.SUCCESS;
-                    goto LatchRelease;
-                }
-                else
-                {
-                    hlog.GetInfo(newPhysicalAddress).Invalid = true;
-                    status = OperationStatus.RETRY_NOW;
-                    goto LatchRelease;
-                }
+                status = CreateNewRecordUpsert(ref key, ref value, ref pendingContext, fasterSession, sessionCtx, bucket, slot, tag, entry, latestLogicalAddress);
+                goto LatchRelease;
             }
-#endregion
+            #endregion
 
-#region Create pending context
-        CreatePendingContext:
+            #region Create pending context
+            Debug.Assert(latchDestination == LatchDestination.CreatePendingContext, $"Upsert CreatePendingContext encountered latchDest == {latchDestination}");
             {
                 pendingContext.type = OperationType.UPSERT;
                 pendingContext.key = hlog.GetKeyContainer(ref key);
@@ -507,6 +422,110 @@ namespace FASTER.core
 #endregion
 
             return status;
+        }
+
+        private LatchDestination AcquireLatchUpsert<Input, Output, Context>(FasterExecutionContext<Input, Output, Context> sessionCtx, HashBucket* bucket, ref OperationStatus status, ref LatchOperation latchOperation, ref HashBucketEntry entry)
+        {
+            switch (sessionCtx.phase)
+            {
+                case Phase.PREPARE:
+                    {
+                        if (HashBucket.TryAcquireSharedLatch(bucket))
+                        {
+                            // Set to release shared latch (default)
+                            latchOperation = LatchOperation.Shared;
+                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) > sessionCtx.version)
+                            {
+                                status = OperationStatus.CPR_SHIFT_DETECTED;
+                                return LatchDestination.CreatePendingContext; // Pivot Thread
+                            }
+                            break; // Normal Processing
+                        }
+                        else
+                        {
+                            status = OperationStatus.CPR_SHIFT_DETECTED;
+                            return LatchDestination.CreatePendingContext; // Pivot Thread
+                        }
+                    }
+                case Phase.IN_PROGRESS:
+                    {
+                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        {
+                            if (HashBucket.TryAcquireExclusiveLatch(bucket))
+                            {
+                                // Set to release exclusive latch (default)
+                                latchOperation = LatchOperation.Exclusive;
+                                return LatchDestination.CreateNewRecord; // Create a (v+1) record
+                            }
+                            else
+                            {
+                                status = OperationStatus.RETRY_LATER;
+                                return LatchDestination.CreatePendingContext; // Go Pending
+                            }
+                        }
+                        break; // Normal Processing
+                    }
+                case Phase.WAIT_PENDING:
+                    {
+                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        {
+                            if (HashBucket.NoSharedLatches(bucket))
+                            {
+                                return LatchDestination.CreateNewRecord; // Create a (v+1) record
+                            }
+                            else
+                            {
+                                status = OperationStatus.RETRY_LATER;
+                                return LatchDestination.CreatePendingContext; // Go Pending
+                            }
+                        }
+                        break; // Normal Processing
+                    }
+                case Phase.WAIT_FLUSH:
+                    {
+                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        {
+                            return LatchDestination.CreateNewRecord; // Create a (v+1) record
+                        }
+                        break; // Normal Processing
+                    }
+                default:
+                    break;
+            }
+            return LatchDestination.NormalProcessing;
+        }
+
+        private OperationStatus CreateNewRecordUpsert<Input, Output, Context, FasterSession>(ref Key key, ref Value value, ref PendingContext<Input, Output, Context> pendingContext, FasterSession fasterSession, FasterExecutionContext<Input, Output, Context> sessionCtx, HashBucket* bucket, int slot, ushort tag, HashBucketEntry entry, long latestLogicalAddress) where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
+        {
+            var (actualSize, allocateSize) = hlog.GetRecordSize(ref key, ref value);
+            BlockAllocate(allocateSize, out long newLogicalAddress, sessionCtx, fasterSession);
+            var newPhysicalAddress = hlog.GetPhysicalAddress(newLogicalAddress);
+            RecordInfo.WriteInfo(ref hlog.GetInfo(newPhysicalAddress),
+                           sessionCtx.version,
+                           tombstone: false, invalidBit: false,
+                           latestLogicalAddress);
+            hlog.Serialize(ref key, newPhysicalAddress);
+            fasterSession.SingleWriter(ref key, ref value,
+                                   ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize), newLogicalAddress);
+
+            var updatedEntry = default(HashBucketEntry);
+            updatedEntry.Tag = tag;
+            updatedEntry.Address = newLogicalAddress & Constants.kAddressMask;
+            updatedEntry.Pending = entry.Pending;
+            updatedEntry.Tentative = false;
+
+            var foundEntry = default(HashBucketEntry);
+            foundEntry.word = Interlocked.CompareExchange(ref bucket->bucket_entries[slot], updatedEntry.word, entry.word);
+
+            if (foundEntry.word == entry.word)
+            {
+                pendingContext.logicalAddress = newLogicalAddress;
+                return OperationStatus.SUCCESS;
+            }
+
+            // CAS failed
+            hlog.GetInfo(newPhysicalAddress).Invalid = true;
+            return OperationStatus.RETRY_NOW;
         }
 
 #endregion
@@ -561,11 +580,11 @@ namespace FASTER.core
         {
             var bucket = default(HashBucket*);
             var slot = default(int);
-            var logicalAddress = Constants.kInvalidAddress;
             var physicalAddress = default(long);
             var status = default(OperationStatus);
             var latchOperation = LatchOperation.None;
             var heldOperation = LatchOperation.None;
+            var latchDestination = LatchDestination.NormalProcessing;
 
             var hash = comparer.GetHashCode64(ref key);
             var tag = (ushort)((ulong)hash >> Constants.kHashTagShift);
@@ -576,7 +595,7 @@ namespace FASTER.core
 #region Trace back for record in in-memory HybridLog
             var entry = default(HashBucketEntry);
             FindOrCreateTag(hash, tag, ref bucket, ref slot, ref entry, hlog.BeginAddress);
-            logicalAddress = entry.Address;
+            var logicalAddress = entry.Address;
 
             // For simplicity, we don't let RMW operations use read cache
             if (UseReadCache)
@@ -590,10 +609,11 @@ namespace FASTER.core
                 if (!comparer.Equals(ref key, ref hlog.GetKey(physicalAddress)))
                 {
                     logicalAddress = hlog.GetInfo(physicalAddress).PreviousAddress;
-                    TraceBackForKeyMatch(ref key, logicalAddress,
-                                            hlog.HeadAddress,
-                                            out logicalAddress,
-                                            out physicalAddress);
+                    TraceBackForKeyMatch(ref key,
+                                        logicalAddress,
+                                        hlog.HeadAddress,
+                                        out logicalAddress,
+                                        out physicalAddress);
                 }
             }
 #endregion
@@ -611,224 +631,91 @@ namespace FASTER.core
 #region Entry latch operation
             if (sessionCtx.phase != Phase.REST)
             {
-                switch (sessionCtx.phase)
-                {
-                    case Phase.PREPARE:
-                        {
-                            Debug.Assert(pendingContext.heldLatch != LatchOperation.Exclusive);
-                            if (pendingContext.heldLatch == LatchOperation.Shared || HashBucket.TryAcquireSharedLatch(bucket))
-                            {
-                                // Set to release shared latch (default)
-                                latchOperation = LatchOperation.Shared;
-                                if (GetLatestRecordVersion(ref entry, sessionCtx.version) > sessionCtx.version)
-                                {
-                                    status = OperationStatus.CPR_SHIFT_DETECTED;
-                                    goto CreateFailureContext; // Pivot Thread
-                                }
-                                break; // Normal Processing
-                            }
-                            else
-                            {
-                                status = OperationStatus.CPR_SHIFT_DETECTED;
-                                goto CreateFailureContext; // Pivot Thread
-                            }
-                        }
-                    case Phase.IN_PROGRESS:
-                        {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
-                            {
-                                Debug.Assert(pendingContext.heldLatch != LatchOperation.Shared);
-                                if (pendingContext.heldLatch == LatchOperation.Exclusive || HashBucket.TryAcquireExclusiveLatch(bucket))
-                                {
-                                    // Set to release exclusive latch (default)
-                                    latchOperation = LatchOperation.Exclusive;
-                                    if (logicalAddress >= hlog.HeadAddress)
-                                        goto CreateNewRecord; // Create a (v+1) record
-                                }
-                                else
-                                {
-                                    status = OperationStatus.RETRY_LATER;
-                                    goto CreateFailureContext; // Go Pending
-                                }
-                            }
-                            break; // Normal Processing
-                        }
-                    case Phase.WAIT_PENDING:
-                        {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
-                            {
-                                if (HashBucket.NoSharedLatches(bucket))
-                                {
-                                    if (logicalAddress >= hlog.HeadAddress)
-                                        goto CreateNewRecord; // Create a (v+1) record
-                                }
-                                else
-                                {
-                                    status = OperationStatus.RETRY_LATER;
-                                    goto CreateFailureContext; // Go Pending
-                                }
-                            }
-                            break; // Normal Processing
-                        }
-                    case Phase.WAIT_FLUSH:
-                        {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
-                            {
-                                if (logicalAddress >= hlog.HeadAddress)
-                                    goto CreateNewRecord; // Create a (v+1) record
-                            }
-                            break; // Normal Processing
-                        }
-                    default:
-                        break;
-                }
+                latchDestination = AcquireLatchRMW(pendingContext, sessionCtx, bucket, ref status, ref latchOperation, ref entry, logicalAddress);
             }
-#endregion
+            #endregion
 
             Debug.Assert(GetLatestRecordVersion(ref entry, sessionCtx.version) <= sessionCtx.version);
 
-#region Normal processing
+            #region Normal processing
 
             // Mutable Region: Update the record in-place
-            if (logicalAddress >= hlog.ReadOnlyAddress && !hlog.GetInfo(physicalAddress).Tombstone)
+            if (latchDestination == LatchDestination.NormalProcessing)
             {
-                if (FoldOverSnapshot)
+                if (logicalAddress >= hlog.ReadOnlyAddress && !hlog.GetInfo(physicalAddress).Tombstone)
                 {
-                    Debug.Assert(hlog.GetInfo(physicalAddress).Version == sessionCtx.version);
-                }
-
-                if (fasterSession.InPlaceUpdater(ref key, ref input, ref hlog.GetValue(physicalAddress), logicalAddress))
-                {
-                    status = OperationStatus.SUCCESS;
-                    goto LatchRelease; // Release shared latch (if acquired)
-                }
-            }
-
-            // Fuzzy Region: Must go pending due to lost-update anomaly
-            else if (logicalAddress >= hlog.SafeReadOnlyAddress && !hlog.GetInfo(physicalAddress).Tombstone)
-            {
-                status = OperationStatus.RETRY_LATER;
-                // Do not retain latch for pendings ops in relaxed CPR
-                if (!RelaxedCPR)
-                {
-                    // Retain the shared latch (if acquired)
-                    if (latchOperation == LatchOperation.Shared)
+                    if (FoldOverSnapshot)
                     {
-                        heldOperation = latchOperation;
-                        latchOperation = LatchOperation.None;
+                        Debug.Assert(hlog.GetInfo(physicalAddress).Version == sessionCtx.version);
+                    }
+
+                    if (fasterSession.InPlaceUpdater(ref key, ref input, ref hlog.GetValue(physicalAddress), logicalAddress))
+                    {
+                        status = OperationStatus.SUCCESS;
+                        goto LatchRelease; // Release shared latch (if acquired)
                     }
                 }
-                goto CreateFailureContext; // Go pending
-            }
 
-            // Safe Read-Only Region: Create a record in the mutable region
-            else if (logicalAddress >= hlog.HeadAddress)
-            {
-                goto CreateNewRecord;
-            }
-
-            // Disk Region: Need to issue async io requests
-            else if (logicalAddress >= hlog.BeginAddress)
-            {
-                status = OperationStatus.RECORD_ON_DISK;
-                // Do not retain latch for pendings ops in relaxed CPR
-                if (!RelaxedCPR)
+                // Fuzzy Region: Must go pending due to lost-update anomaly
+                else if (logicalAddress >= hlog.SafeReadOnlyAddress && !hlog.GetInfo(physicalAddress).Tombstone)
                 {
-                    // Retain the shared latch (if acquired)
-                    if (latchOperation == LatchOperation.Shared)
+                    status = OperationStatus.RETRY_LATER;
+                    // Do not retain latch for pendings ops in relaxed CPR
+                    if (!RelaxedCPR)
                     {
-                        heldOperation = latchOperation;
-                        latchOperation = LatchOperation.None;
+                        // Retain the shared latch (if acquired)
+                        if (latchOperation == LatchOperation.Shared)
+                        {
+                            heldOperation = latchOperation;
+                            latchOperation = LatchOperation.None;
+                        }
                     }
+                    latchDestination = LatchDestination.CreatePendingContext; // Go pending
                 }
-                goto CreateFailureContext; // Go pending
-            }
 
-            // No record exists - create new
-            else
-            {
-                goto CreateNewRecord;
+                // Safe Read-Only Region: Create a record in the mutable region
+                else if (logicalAddress >= hlog.HeadAddress)
+                {
+                    goto CreateNewRecord;
+                }
+
+                // Disk Region: Need to issue async io requests
+                else if (logicalAddress >= hlog.BeginAddress)
+                {
+                    status = OperationStatus.RECORD_ON_DISK;
+                    // Do not retain latch for pendings ops in relaxed CPR
+                    if (!RelaxedCPR)
+                    {
+                        // Retain the shared latch (if acquired)
+                        if (latchOperation == LatchOperation.Shared)
+                        {
+                            heldOperation = latchOperation;
+                            latchOperation = LatchOperation.None;
+                        }
+                    }
+                    latchDestination = LatchDestination.CreatePendingContext; // Go pending
+                }
+
+                // No record exists - create new
+                else
+                {
+                    goto CreateNewRecord;
+                }
             }
 
 #endregion
 
 #region Create new record
         CreateNewRecord:
+            if (latchDestination != LatchDestination.CreatePendingContext)
             {
-                if (logicalAddress >= hlog.HeadAddress && !hlog.GetInfo(physicalAddress).Tombstone)
-                {
-                    if (!fasterSession.NeedCopyUpdate(ref key, ref input, ref hlog.GetValue(physicalAddress)))
-                    {
-                        status = OperationStatus.SUCCESS;
-                        goto LatchRelease;
-                    }
-                }
-
-                var (actualSize, allocatedSize) = (logicalAddress < hlog.BeginAddress) ?
-                                hlog.GetInitialRecordSize(ref key, ref input, fasterSession) :
-                                hlog.GetRecordSize(physicalAddress, ref input, fasterSession);
-                BlockAllocate(allocatedSize, out long newLogicalAddress, sessionCtx, fasterSession);
-                var newPhysicalAddress = hlog.GetPhysicalAddress(newLogicalAddress);
-                RecordInfo.WriteInfo(ref hlog.GetInfo(newPhysicalAddress), sessionCtx.version,
-                                tombstone:false, invalidBit:false,
-                                latestLogicalAddress);
-                hlog.Serialize(ref key, newPhysicalAddress);
-
-                if (logicalAddress < hlog.BeginAddress)
-                {
-                    fasterSession.InitialUpdater(ref key, ref input, ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize), newLogicalAddress);
-                    status = OperationStatus.NOTFOUND;
-                }
-                else if (logicalAddress >= hlog.HeadAddress)
-                {
-                    if (hlog.GetInfo(physicalAddress).Tombstone)
-                    {
-                        fasterSession.InitialUpdater(ref key, ref input, ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize), newLogicalAddress);
-                        status = OperationStatus.NOTFOUND;
-                    }
-                    else
-                    {
-                        fasterSession.CopyUpdater(ref key, ref input,
-                                                ref hlog.GetValue(physicalAddress),
-                                                ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize), logicalAddress, newLogicalAddress);
-                        status = OperationStatus.SUCCESS;
-                    }
-                }
-                else
-                {
-                    // ah, old record slipped onto disk
-                    hlog.GetInfo(newPhysicalAddress).Invalid = true;
-                    status = OperationStatus.RETRY_NOW;
-                    goto LatchRelease;
-                }
-
-                var updatedEntry = default(HashBucketEntry);
-                updatedEntry.Tag = tag;
-                updatedEntry.Address = newLogicalAddress & Constants.kAddressMask;
-                updatedEntry.Pending = entry.Pending;
-                updatedEntry.Tentative = false;
-
-                var foundEntry = default(HashBucketEntry);
-                foundEntry.word = Interlocked.CompareExchange(
-                                        ref bucket->bucket_entries[slot],
-                                        updatedEntry.word, entry.word);
-
-                if (foundEntry.word == entry.word)
-                {
-                    goto LatchRelease;
-                }
-                else
-                {
-                    // CAS failed
-                    hlog.GetInfo(newPhysicalAddress).Invalid = true;
-                    status = OperationStatus.RETRY_NOW;
-                    goto LatchRelease;
-                }
+                status = CreateNewRecordRMW(ref key, ref input, ref pendingContext, fasterSession, sessionCtx, bucket, slot, logicalAddress, physicalAddress, tag, entry, latestLogicalAddress);
+                goto LatchRelease;
             }
 #endregion
 
 #region Create failure context
-        CreateFailureContext:
+            Debug.Assert(latchDestination == LatchDestination.CreatePendingContext, $"RMW CreatePendingContext encountered latchDest == {latchDestination}");
             {
                 pendingContext.type = OperationType.RMW;
                 pendingContext.key = hlog.GetKeyContainer(ref key);
@@ -858,6 +745,151 @@ namespace FASTER.core
                 }
             }
 #endregion
+
+            return status;
+        }
+
+        private LatchDestination AcquireLatchRMW<Input, Output, Context>(PendingContext<Input, Output, Context> pendingContext, FasterExecutionContext<Input, Output, Context> sessionCtx,
+                                                                         HashBucket* bucket, ref OperationStatus status, ref LatchOperation latchOperation, ref HashBucketEntry entry, long logicalAddress)
+        {
+            switch (sessionCtx.phase)
+            {
+                case Phase.PREPARE:
+                    {
+                        Debug.Assert(pendingContext.heldLatch != LatchOperation.Exclusive);
+                        if (pendingContext.heldLatch == LatchOperation.Shared || HashBucket.TryAcquireSharedLatch(bucket))
+                        {
+                            // Set to release shared latch (default)
+                            latchOperation = LatchOperation.Shared;
+                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) > sessionCtx.version)
+                            {
+                                status = OperationStatus.CPR_SHIFT_DETECTED;
+                                return LatchDestination.CreatePendingContext; // Pivot Thread
+                            }
+                            break; // Normal Processing
+                        }
+                        else
+                        {
+                            status = OperationStatus.CPR_SHIFT_DETECTED;
+                            return LatchDestination.CreatePendingContext; // Pivot Thread
+                        }
+                    }
+                case Phase.IN_PROGRESS:
+                    {
+                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        {
+                            Debug.Assert(pendingContext.heldLatch != LatchOperation.Shared);
+                            if (pendingContext.heldLatch == LatchOperation.Exclusive || HashBucket.TryAcquireExclusiveLatch(bucket))
+                            {
+                                // Set to release exclusive latch (default)
+                                latchOperation = LatchOperation.Exclusive;
+                                if (logicalAddress >= hlog.HeadAddress)
+                                    return LatchDestination.CreateNewRecord; // Create a (v+1) record
+                            }
+                            else
+                            {
+                                status = OperationStatus.RETRY_LATER;
+                                return LatchDestination.CreatePendingContext; // Go Pending
+                            }
+                        }
+                        break; // Normal Processing
+                    }
+                case Phase.WAIT_PENDING:
+                    {
+                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        {
+                            if (HashBucket.NoSharedLatches(bucket))
+                            {
+                                if (logicalAddress >= hlog.HeadAddress)
+                                    return LatchDestination.CreateNewRecord; // Create a (v+1) record
+                            }
+                            else
+                            {
+                                status = OperationStatus.RETRY_LATER;
+                                return LatchDestination.CreatePendingContext; // Go Pending
+                            }
+                        }
+                        break; // Normal Processing
+                    }
+                case Phase.WAIT_FLUSH:
+                    {
+                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        {
+                            if (logicalAddress >= hlog.HeadAddress)
+                                return LatchDestination.CreateNewRecord; // Create a (v+1) record
+                        }
+                        break; // Normal Processing
+                    }
+                default:
+                    break;
+            }
+            return LatchDestination.NormalProcessing;
+        }
+
+        private OperationStatus CreateNewRecordRMW<Input, Output, Context, FasterSession>(ref Key key, ref Input input, ref PendingContext<Input, Output, Context> pendingContext, FasterSession fasterSession, FasterExecutionContext<Input, Output, Context> sessionCtx, HashBucket* bucket, int slot, long logicalAddress, long physicalAddress, ushort tag, HashBucketEntry entry, long latestLogicalAddress) where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
+        {
+            if (logicalAddress >= hlog.HeadAddress && !hlog.GetInfo(physicalAddress).Tombstone)
+            {
+                if (!fasterSession.NeedCopyUpdate(ref key, ref input, ref hlog.GetValue(physicalAddress)))
+                    return OperationStatus.SUCCESS;
+            }
+
+            var (actualSize, allocatedSize) = (logicalAddress < hlog.BeginAddress) ?
+                            hlog.GetInitialRecordSize(ref key, ref input, fasterSession) :
+                            hlog.GetRecordSize(physicalAddress, ref input, fasterSession);
+            BlockAllocate(allocatedSize, out long newLogicalAddress, sessionCtx, fasterSession);
+            var newPhysicalAddress = hlog.GetPhysicalAddress(newLogicalAddress);
+            RecordInfo.WriteInfo(ref hlog.GetInfo(newPhysicalAddress), sessionCtx.version,
+                            tombstone: false, invalidBit: false,
+                            latestLogicalAddress);
+            hlog.Serialize(ref key, newPhysicalAddress);
+
+            OperationStatus status;
+            if (logicalAddress < hlog.BeginAddress)
+            {
+                fasterSession.InitialUpdater(ref key, ref input, ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize), newLogicalAddress);
+                status = OperationStatus.NOTFOUND;
+            }
+            else if (logicalAddress >= hlog.HeadAddress)
+            {
+                if (hlog.GetInfo(physicalAddress).Tombstone)
+                {
+                    fasterSession.InitialUpdater(ref key, ref input, ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize), newLogicalAddress);
+                    status = OperationStatus.NOTFOUND;
+                }
+                else
+                {
+                    fasterSession.CopyUpdater(ref key, ref input,
+                                            ref hlog.GetValue(physicalAddress),
+                                            ref hlog.GetValue(newPhysicalAddress, newPhysicalAddress + actualSize), logicalAddress, newLogicalAddress);
+                    status = OperationStatus.SUCCESS;
+                }
+            }
+            else
+            {
+                // ah, old record slipped onto disk
+                hlog.GetInfo(newPhysicalAddress).Invalid = true;
+                return OperationStatus.RETRY_NOW;
+            }
+
+            var updatedEntry = default(HashBucketEntry);
+            updatedEntry.Tag = tag;
+            updatedEntry.Address = newLogicalAddress & Constants.kAddressMask;
+            updatedEntry.Pending = entry.Pending;
+            updatedEntry.Tentative = false;
+
+            var foundEntry = default(HashBucketEntry);
+            foundEntry.word = Interlocked.CompareExchange(ref bucket->bucket_entries[slot], updatedEntry.word, entry.word);
+            if (foundEntry.word == entry.word)
+            {
+                pendingContext.logicalAddress = newLogicalAddress;
+            }
+            else
+            {
+                // CAS failed
+                hlog.GetInfo(newPhysicalAddress).Invalid = true;
+                status = OperationStatus.RETRY_NOW;
+            }
 
             return status;
         }

--- a/cs/src/core/Index/FasterLog/FasterLog.cs
+++ b/cs/src/core/Index/FasterLog/FasterLog.cs
@@ -183,7 +183,8 @@ namespace FASTER.core
         public long Enqueue(byte[] entry)
         {
             long logicalAddress;
-            while (!TryEnqueue(entry, out logicalAddress)) ;
+            while (!TryEnqueue(entry, out logicalAddress))
+                Thread.Yield();
             return logicalAddress;
         }
 
@@ -195,7 +196,8 @@ namespace FASTER.core
         public long Enqueue(ReadOnlySpan<byte> entry)
         {
             long logicalAddress;
-            while (!TryEnqueue(entry, out logicalAddress)) ;
+            while (!TryEnqueue(entry, out logicalAddress))
+                Thread.Yield();
             return logicalAddress;
         }
 
@@ -207,7 +209,8 @@ namespace FASTER.core
         public long Enqueue(IReadOnlySpanBatch readOnlySpanBatch)
         {
             long logicalAddress;
-            while (!TryEnqueue(readOnlySpanBatch, out logicalAddress)) ;
+            while (!TryEnqueue(readOnlySpanBatch, out logicalAddress))
+                Thread.Yield();
             return logicalAddress;
         }
         #endregion
@@ -545,7 +548,8 @@ namespace FASTER.core
         public long EnqueueAndWaitForCommit(byte[] entry)
         {
             long logicalAddress;
-            while (!TryEnqueue(entry, out logicalAddress)) ;
+            while (!TryEnqueue(entry, out logicalAddress))
+                Thread.Yield();
             while (CommittedUntilAddress < logicalAddress + 1) Thread.Yield();
             return logicalAddress;
         }
@@ -559,7 +563,8 @@ namespace FASTER.core
         public long EnqueueAndWaitForCommit(ReadOnlySpan<byte> entry)
         {
             long logicalAddress;
-            while (!TryEnqueue(entry, out logicalAddress)) ;
+            while (!TryEnqueue(entry, out logicalAddress))
+                Thread.Yield();
             while (CommittedUntilAddress < logicalAddress + 1) Thread.Yield();
             return logicalAddress;
         }
@@ -573,7 +578,8 @@ namespace FASTER.core
         public long EnqueueAndWaitForCommit(IReadOnlySpanBatch readOnlySpanBatch)
         {
             long logicalAddress;
-            while (!TryEnqueue(readOnlySpanBatch, out logicalAddress)) ;
+            while (!TryEnqueue(readOnlySpanBatch, out logicalAddress))
+                Thread.Yield();
             while (CommittedUntilAddress < logicalAddress + 1) Thread.Yield();
             return logicalAddress;
         }

--- a/cs/test/ManagedLocalStorageTests.cs
+++ b/cs/test/ManagedLocalStorageTests.cs
@@ -37,7 +37,7 @@ namespace FASTER.test
 
             // Create devices \ log for test
             device = new ManagedLocalStorageDevice(commitPath + "ManagedLocalStore.log", deleteOnClose: true);
-            log = new FasterLog(new FasterLogSettings { LogDevice = device });
+            log = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 10, MemorySizeBits = 12 });
 
             deviceFullParams = new ManagedLocalStorageDevice(commitPath + "ManagedLocalStoreFullParams.log", deleteOnClose: false, recoverDevice: true, preallocateFile: true, capacity: 1 << 30);
             logFullParams = new FasterLog(new FasterLogSettings { LogDevice = device });


### PR DESCRIPTION
* Better handling of async tasks in `ManagedLocalStorageDevice` to work efficiently on Linux with large number of tasks.
* Avoid exception on full `PendingFlushList` and instead fail the commit.
* Use locks to correctly invoke `FileStream.ReadAsync` and `FileStream.WriteAsync` in MLSD.
* Merge adjacent unissued commit requests in `PendingFlushList` for improved commit behavior.
* Remove spin from `FixedPool` when no space left, and instead issue new object for immediate disposal.

Fix https://github.com/microsoft/FASTER/issues/434
Fix https://github.com/microsoft/FASTER/issues/433
Co-authored with @hiteshmadan