### PR TITLE
[C#] Resolve version wrap around

### DIFF
--- a/cs/src/core/Index/Common/RecordInfo.cs
+++ b/cs/src/core/Index/Common/RecordInfo.cs
@@ -243,5 +243,8 @@ namespace FASTER.core
         {
             return kTotalSizeInBytes;
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetShortVersion(long version) => (int) (version & kVersionMaskInInteger);
     }
 }

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -13,6 +13,15 @@ namespace FASTER.core
 {
     public unsafe partial class FasterKV<Key, Value> : FasterBase, IFasterKV<Key, Value>
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool InVersionNew<Input, Output, Context>(ref HashBucketEntry entry, FasterExecutionContext<Input, Output, Context> sessionCtx)
+        {
+            // A version shift can only in an address after the checkpoint starts, as v_new threads RCU entries to the tail.
+            if (entry.Address < _hybridLogCheckpoint.info.startLogicalAddress) return false;
+            // Otherwise, check if the version suffix of the entry matches v_new.
+            return GetLatestRecordVersion(ref entry, sessionCtx.version) == RecordInfo.GetShortVersion(currentSyncStateMachine.ToVersion());
+        }
+        
         internal enum LatchOperation : byte
         {
             None,
@@ -109,7 +118,7 @@ namespace FASTER.core
                     }
                     else if (ReadFromCache(ref key, ref logicalAddress, ref physicalAddress))
                     {
-                        if (sessionCtx.phase == Phase.PREPARE && GetLatestRecordVersion(ref entry, sessionCtx.version) > sessionCtx.version)
+                        if (sessionCtx.phase == Phase.PREPARE && InVersionNew(ref entry, sessionCtx))
                         {
                             status = OperationStatus.CPR_SHIFT_DETECTED;
                             goto CreatePendingContext; // Pivot thread
@@ -151,7 +160,7 @@ namespace FASTER.core
             }
             #endregion
 
-            if (sessionCtx.phase == Phase.PREPARE && GetLatestRecordVersion(ref entry, sessionCtx.version) > sessionCtx.version)
+            if (sessionCtx.phase == Phase.PREPARE && InVersionNew(ref entry, sessionCtx))
             {
                 status = OperationStatus.CPR_SHIFT_DETECTED;
                 goto CreatePendingContext; // Pivot thread
@@ -362,7 +371,6 @@ namespace FASTER.core
             }
             #endregion
 
-            Debug.Assert(GetLatestRecordVersion(ref entry, sessionCtx.version) <= sessionCtx.version);
 
             #region Normal processing
 
@@ -439,7 +447,7 @@ namespace FASTER.core
                         {
                             // Set to release shared latch (default)
                             latchOperation = LatchOperation.Shared;
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) > sessionCtx.version)
+                            if (InVersionNew(ref entry, sessionCtx))
                             {
                                 status = OperationStatus.CPR_SHIFT_DETECTED;
                                 return LatchDestination.CreatePendingContext; // Pivot Thread
@@ -454,7 +462,7 @@ namespace FASTER.core
                     }
                 case Phase.IN_PROGRESS:
                     {
-                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        if (!InVersionNew(ref entry, sessionCtx))
                         {
                             if (HashBucket.TryAcquireExclusiveLatch(bucket))
                             {
@@ -472,7 +480,7 @@ namespace FASTER.core
                     }
                 case Phase.WAIT_PENDING:
                     {
-                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        if (!InVersionNew(ref entry, sessionCtx))
                         {
                             if (HashBucket.NoSharedLatches(bucket))
                             {
@@ -488,7 +496,7 @@ namespace FASTER.core
                     }
                 case Phase.WAIT_FLUSH:
                     {
-                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        if (!InVersionNew(ref entry, sessionCtx))
                         {
                             return LatchDestination.CreateNewRecord; // Create a (v+1) record
                         }
@@ -643,7 +651,6 @@ namespace FASTER.core
             }
             #endregion
 
-            Debug.Assert(GetLatestRecordVersion(ref entry, sessionCtx.version) <= sessionCtx.version);
 
             #region Normal processing
 
@@ -773,7 +780,7 @@ namespace FASTER.core
                         {
                             // Set to release shared latch (default)
                             latchOperation = LatchOperation.Shared;
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) > sessionCtx.version)
+                            if (InVersionNew(ref entry, sessionCtx))
                             {
                                 status = OperationStatus.CPR_SHIFT_DETECTED;
                                 return LatchDestination.CreatePendingContext; // Pivot Thread
@@ -788,7 +795,7 @@ namespace FASTER.core
                     }
                 case Phase.IN_PROGRESS:
                     {
-                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        if (!InVersionNew(ref entry, sessionCtx))
                         {
                             Debug.Assert(pendingContext.heldLatch != LatchOperation.Shared);
                             if (pendingContext.heldLatch == LatchOperation.Exclusive || HashBucket.TryAcquireExclusiveLatch(bucket))
@@ -808,7 +815,7 @@ namespace FASTER.core
                     }
                 case Phase.WAIT_PENDING:
                     {
-                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        if (!InVersionNew(ref entry, sessionCtx))
                         {
                             if (HashBucket.NoSharedLatches(bucket))
                             {
@@ -825,7 +832,7 @@ namespace FASTER.core
                     }
                 case Phase.WAIT_FLUSH:
                     {
-                        if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                        if (!InVersionNew(ref entry, sessionCtx))
                         {
                             if (logicalAddress >= hlog.HeadAddress)
                                 return LatchDestination.CreateNewRecord; // Create a (v+1) record
@@ -1004,7 +1011,7 @@ namespace FASTER.core
                             {
                                 // Set to release shared latch (default)
                                 latchOperation = LatchOperation.Shared;
-                                if (GetLatestRecordVersion(ref entry, sessionCtx.version) > sessionCtx.version)
+                                if (InVersionNew(ref entry, sessionCtx))
                                 {
                                     status = OperationStatus.CPR_SHIFT_DETECTED;
                                     goto CreatePendingContext; // Pivot Thread
@@ -1019,7 +1026,7 @@ namespace FASTER.core
                         }
                     case Phase.IN_PROGRESS:
                         {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                            if (!InVersionNew(ref entry, sessionCtx))
                             {
                                 if (HashBucket.TryAcquireExclusiveLatch(bucket))
                                 {
@@ -1037,7 +1044,7 @@ namespace FASTER.core
                         }
                     case Phase.WAIT_PENDING:
                         {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                            if (!InVersionNew(ref entry, sessionCtx))
                             {
                                 if (HashBucket.NoSharedLatches(bucket))
                                 {
@@ -1053,7 +1060,7 @@ namespace FASTER.core
                         }
                     case Phase.WAIT_FLUSH:
                         {
-                            if (GetLatestRecordVersion(ref entry, sessionCtx.version) < sessionCtx.version)
+                            if (!InVersionNew(ref entry, sessionCtx))
                             {
                                 goto CreateNewRecord; // Create a (v+1) record
                             }
@@ -1065,7 +1072,6 @@ namespace FASTER.core
             }
 #endregion
 
-            Debug.Assert(GetLatestRecordVersion(ref entry, sessionCtx.version) <= sessionCtx.version);
 
 #region Normal processing
 

--- a/cs/src/core/Index/Synchronization/ISynchronizationStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/ISynchronizationStateMachine.cs
@@ -13,6 +13,12 @@ namespace FASTER.core
     internal interface ISynchronizationStateMachine
     {
         /// <summary>
+        /// Returns the version that we expect this state machine to end up at when back to REST, or -1 if not yet known.
+        /// </summary>
+        /// <returns> The version that we expect this state machine to end up at when back to REST </returns>
+        long ToVersion();
+
+        /// <summary>
         /// This function models the transition function of a state machine.
         /// </summary>
         /// <param name="start">The current state of the state machine</param>
@@ -135,6 +141,8 @@ namespace FASTER.core
     internal abstract class SynchronizationStateMachineBase : ISynchronizationStateMachine
     {
         private readonly ISynchronizationTask[] tasks;
+        private long toVersion = -1;
+        
 
         /// <summary>
         /// Construct a new SynchronizationStateMachine with the given tasks. The order of tasks given is the
@@ -146,6 +154,15 @@ namespace FASTER.core
             this.tasks = tasks;
         }
 
+        /// <summary>
+        /// Sets ToVersion for return. Defaults to -1 if not set
+        /// </summary>
+        /// <param name="v"> toVersion </param>
+        protected void SetToVersion(long v) => toVersion = v;
+
+        /// <inheritdoc />
+        public long ToVersion() => toVersion;
+        
         /// <inheritdoc />
         public abstract SystemState NextState(SystemState start);
 

--- a/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -172,7 +174,8 @@ namespace FASTER.core
                 case Phase.PREPARE:
                     nextState.phase = Phase.IN_PROGRESS;
                     // TODO: Move to long for system state as well. 
-                    nextState.version = (int)(targetVersion == -1 ? start.version + 1 : targetVersion + 1);
+                    SetToVersion(targetVersion == -1 ? start.version + 1 : targetVersion);
+                    nextState.version = (int) ToVersion();
                     break;
                 case Phase.IN_PROGRESS:
                     // This phase has no effect if using relaxed CPR model


### PR DESCRIPTION
fix #442

Instead of using > or <, check version with:

1.  whether entry in question is in the fuzzy region created by a version shift (e.g., tail of log in checkpoint, where v_new entries could be due to RCU)
2. whether truncated version in record header equals the target version of current version shift.

This should have the same semantic as before (assuming version advances cannot differ by more than 8192) while handling wraparound correctly.

Not sure whether worth writing a test case for as it is very hard to create a buggy wrap-around trace on a unit-test scale. 