### PR TITLE
[C#] Support dynamically varying the allocator log memory usage

### DIFF
--- a/cs/samples/MemOnlyCache/CacheSizeTracker.cs
+++ b/cs/samples/MemOnlyCache/CacheSizeTracker.cs
@@ -89,7 +89,16 @@ namespace MemOnlyCache
             else if (TotalSizeBytes < TargetSizeBytes)
                 store.Log.EmptyPageCount--;
         }
+
+        /// <summary>
+        /// OnCompleted
+        /// </summary>
         public void OnCompleted() { }
+
+        /// <summary>
+        /// OnError
+        /// </summary>
+        /// <param name="error"></param>
         public void OnError(Exception error) { }
     }
 }

--- a/cs/samples/MemOnlyCache/Program.cs
+++ b/cs/samples/MemOnlyCache/Program.cs
@@ -56,6 +56,11 @@ namespace MemOnlyCache
         static FasterKV<CacheKey, CacheValue> h;
         static CacheSizeTracker sizeTracker;
         static long totalReads = 0;
+        static long targetSize = 1_000_000_000; // target size for FASTER, we vary this during the run
+
+        // Cache hit stats
+        static long statusNotFound = 0;
+        static long statusFound = 0;
 
         static void Main()
         {
@@ -123,13 +128,39 @@ namespace MemOnlyCache
             sw.Start();
             var _lastReads = totalReads;
             var _lastTime = sw.ElapsedMilliseconds;
+            int count = 0;
             while (true)
             {
-                Thread.Sleep(1000);
+                Thread.Sleep(1500);
                 var tmp = totalReads;
                 var tmp2 = sw.ElapsedMilliseconds;
 
-                Console.WriteLine("Throughput: {0:0.00}K ops/sec", (_lastReads - tmp) / (double)(_lastTime - tmp2));
+                Console.WriteLine("Throughput: {0,8:0.00}K ops/sec; Hit rate: {1:N2}; Memory footprint: {2,11:N2}KB", (_lastReads - tmp) / (double)(_lastTime - tmp2), statusFound / (double)(statusFound + statusNotFound), sizeTracker.TotalSizeBytes / 1024.0);
+
+                Interlocked.Exchange(ref statusFound, 0);
+                Interlocked.Exchange(ref statusNotFound, 0);
+
+                // Optional: perform GC collection to verify accurate memory reporting in task manager
+                // GC.Collect();
+                // GC.WaitForFullGCComplete();
+
+                // As demo, reduce target size by 100MB each time we report memory footprint
+                count++;
+                if (count % 4 == 0)
+                {
+                    if (targetSize > 300_000_000)
+                    {
+                        targetSize -= 100_000_000;
+                        sizeTracker.SetTargetSizeBytes(targetSize);
+                    }
+                    else
+                    {
+                        targetSize = 1_000_000_000;
+                        sizeTracker.SetTargetSizeBytes(targetSize);
+                    }
+                    Console.WriteLine("**** Setting target memory: {0,11:N2}KB", targetSize / 1024.0);
+                }
+
                 _lastReads = tmp;
                 _lastTime = tmp2;
             }
@@ -144,31 +175,18 @@ namespace MemOnlyCache
             var rnd = new Random(threadid);
             var zipf = new ZipfGenerator(rnd, DbSize, Theta);
 
-            int statusNotFound = 0;
-            int statusFound = 0;
             CacheValue output = default;
+            int localStatusFound = 0, localStatusNotFound = 0;
 
             int i = 0;
             while (true)
             {
                 if ((i % 256 == 0) && (i > 0))
                 {
+                    Interlocked.Add(ref statusFound, localStatusFound);
+                    Interlocked.Add(ref statusNotFound, localStatusNotFound);
                     Interlocked.Add(ref totalReads, 256);
-                    if (i % (1024 * 1024 * 4) == 0) // report after every 8M ops
-                    {
-                        // Optional: perform GC collection to verify accurate memory reporting in task manager
-                        // GC.Collect();
-                        // GC.WaitForFullGCComplete();
-                        Console.WriteLine("Hit rate: {0:N2}; Memory footprint: {1:N2}KB", statusFound / (double)(statusFound + statusNotFound), sizeTracker.TotalSizeBytes / (double)1024);
-
-                        // As demo, reduce target size by 50MB each time we report memory footprint
-                        long targetSize = sizeTracker.TotalSizeBytes - 50_000_000;
-                        if (targetSize > 200_000_000)
-                        {
-                            Console.WriteLine("Setting target size in bytes: {0:N2}", targetSize);
-                            sizeTracker.SetTargetSizeBytes(targetSize);
-                        }
-                    }
+                    localStatusFound = localStatusNotFound = 0;
                 }
                 int op = WritePercent == 0 ? 0 : rnd.Next(100);
                 long k = UseUniform ? rnd.Next(DbSize) : zipf.Next();
@@ -187,7 +205,7 @@ namespace MemOnlyCache
                     switch (status)
                     {
                         case Status.NOTFOUND:
-                            statusNotFound++;
+                            localStatusNotFound++;
                             if (UpsertOnCacheMiss)
                             {
                                 var value = new CacheValue(1 + rnd.Next(MaxValueSize - 1), (byte)key.key);
@@ -195,7 +213,7 @@ namespace MemOnlyCache
                             }
                             break;
                         case Status.OK:
-                            statusFound++;
+                            localStatusFound++;
                             if (output.value[0] != (byte)key.key)
                                 throw new Exception("Read error!");
                             break;

--- a/cs/samples/MemOnlyCache/Types.cs
+++ b/cs/samples/MemOnlyCache/Types.cs
@@ -55,19 +55,19 @@ namespace MemOnlyCache
         public override bool ConcurrentWriter(ref CacheKey key, ref CacheValue src, ref CacheValue dst, ref RecordInfo recordInfo, long address)
         {
             var old = Interlocked.Exchange(ref dst, src);
-            sizeTracker.AddSize(dst.GetSize - old.GetSize);
+            sizeTracker.AddTrackedSize(dst.GetSize - old.GetSize);
             return true;
         }
 
         public override void SingleWriter(ref CacheKey key, ref CacheValue src, ref CacheValue dst)
         {
             dst = src;
-            sizeTracker.AddSize(key.GetSize + src.GetSize);
+            sizeTracker.AddTrackedSize(key.GetSize + src.GetSize);
         }
 
         public override void ConcurrentDeleter(ref CacheKey key, ref CacheValue value, ref RecordInfo recordInfo, long address)
         {
-            sizeTracker.AddSize(-value.GetSize);
+            sizeTracker.AddTrackedSize(-value.GetSize);
         }
     }
 }

--- a/cs/samples/MemOnlyCache/Types.cs
+++ b/cs/samples/MemOnlyCache/Types.cs
@@ -68,6 +68,10 @@ namespace MemOnlyCache
         public override void ConcurrentDeleter(ref CacheKey key, ref CacheValue value, ref RecordInfo recordInfo, long address)
         {
             sizeTracker.AddTrackedSize(-value.GetSize);
+
+            // Record is marked invalid (failed to insert), dispose key as well
+            if (recordInfo.Invalid)
+                sizeTracker.AddTrackedSize(-key.GetSize);
         }
     }
 }

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -543,8 +543,18 @@ namespace FASTER.core
                 return OperationStatus.SUCCESS;
             }
 
-            // CAS failed
-            hlog.GetInfo(newPhysicalAddress).Invalid = true;
+            // CAS failed - let user dispose similar to a deleted record
+            ref RecordInfo insertedRecordInfo = ref hlog.GetInfo(newPhysicalAddress);
+            ref Value insertedValue = ref hlog.GetValue(newPhysicalAddress);
+            ref Key insertedKey = ref hlog.GetKey(newPhysicalAddress);
+            // First set Invalid to true so that ConcurrentDeleter knows to dispose key as well
+            insertedRecordInfo.Invalid = true;
+            fasterSession.ConcurrentDeleter(ref insertedKey, ref insertedValue, ref insertedRecordInfo, newLogicalAddress);
+            if (WriteDefaultOnDelete)
+            {
+                insertedKey = default;
+                insertedValue = default;
+            }
             return OperationStatus.RETRY_NOW;
         }
 

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -63,12 +63,12 @@ namespace FASTER.core
         public int FixedRecordSize => allocator.GetFixedRecordSize();
 
         /// <summary>
-        /// Extra lag
+        /// How many pages do we leave empty in the in-memory buffer (between 0 and BufferSize-1)
         /// </summary>
-        public int ExtraLag
+        public int EmptyPageCount
         {
-            get => allocator.ExtraLag;
-            set { allocator.ExtraLag = value; }
+            get => allocator.EmptyPageCount;
+            set { allocator.EmptyPageCount = value; }
         }
 
         /// <summary>

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -72,9 +72,14 @@ namespace FASTER.core
         }
 
         /// <summary>
-        /// Circular buffer size
+        /// Circular buffer size (in number of pages)
         /// </summary>
-        public int BufferSize => allocator.BufferSize;
+        public int BufferSizePages => allocator.BufferSize;
+
+        /// <summary>
+        /// Memory used by log (not including reference heap object sizes)
+        /// </summary>
+        public long MemorySizeBytes => ((long)allocator.BufferSize) << allocator.LogPageSizeBits;
 
         /// <summary>
         /// Truncate the log until, but not including, untilAddress. Make sure address corresponds to record boundary if snapToPageStart is set to false.

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -63,6 +63,20 @@ namespace FASTER.core
         public int FixedRecordSize => allocator.GetFixedRecordSize();
 
         /// <summary>
+        /// Extra lag
+        /// </summary>
+        public int ExtraLag
+        {
+            get => allocator.ExtraLag;
+            set { allocator.ExtraLag = value; }
+        }
+
+        /// <summary>
+        /// Circular buffer size
+        /// </summary>
+        public int BufferSize => allocator.BufferSize;
+
+        /// <summary>
         /// Truncate the log until, but not including, untilAddress. Make sure address corresponds to record boundary if snapToPageStart is set to false.
         /// </summary>
         /// <param name="untilAddress">Address to shift begin address until</param>


### PR DESCRIPTION
The FASTER in-memory portion consists of `store.Log.BufferSize` pages in a circular buffer, based on the user-provided log settings of `PageSizeBits` and `MemorySizeBits`.

When FASTER stores C# class objects, these buffer pages contain pointers to reference data which may take different sizes, making the control of total memory footprint of FASTER difficult in this scenario. This is because the total number of pointers in memory remains fixed, based on total memory size.

For example, when `PageSizeBits` is 14 (i.e., each page is 2^14 = 16KB) and `MemorySizeBits` is 25 (i.e., 2^25 = 32MB total memory), we have `BufferSize` is 2048 (i.e., 2^(25-14)) pages in memory. With a total memory size of 32MB, with C# objects as keys and values, since each record takes up 24 bytes (8 byte record header + 8 byte key pointer + 8 byte value pointer), the buffer stores a fixed number of 32M / 24 = ~1.39M key-value pairs. These could take up arbitrary space depending on sizes of the stored objects.

This PR introduces two capabilities:

1. It shows how to track the total memory used by FASTER, using a cache size [tracker](https://github.com/microsoft/FASTER/blob/dyn-heap-mem/cs/samples/MemOnlyCache/CacheSizeTracker.cs) that lets `IFunctions` notify it of record additions and deletions, and by subscribing to evictions from the head of the in-memory log. Details are in the  [MemOnlySample](https://github.com/microsoft/FASTER/tree/dyn-heap-mem/cs/samples/MemOnlyCache) sample, where we show how to track FASTER's total memory usage (including the heap objects, log, hash table, and overflow buckets) very accurately.
2. In order to reduce the number of key-value pairs in memory dynamically, we introduce a knob, called `store.Log.EmptyPageCount`, that indicates how many pages are kept empty in memory in the circular buffer. By adjusting this knob (default 0), we can reduce the effective count of objects in memory, and therefore the overall memory utilization. This knob can vary between 0 (full buffer is used) and `BufferSize-1` (only tail page is used). In the [MemOnlySample](https://github.com/microsoft/FASTER/tree/dyn-heap-mem/cs/samples/MemOnlyCache) sample,  we allow the application to dynamically adjust the total memory utilization of FASTER, by exploiting this `EmptyPageCount` knob in the cache size [tracker](https://github.com/microsoft/FASTER/blob/dyn-heap-mem/cs/samples/MemOnlyCache/CacheSizeTracker.cs) module. This knob is only useful when C# class key or value types are used (`GenericAllocator`).
