### PR TITLE
[C#] Fixes to WaitAsync, list Azure device contents

### DIFF
--- a/cs/src/core/Index/FasterLog/FasterLogIterator.cs
+++ b/cs/src/core/Index/FasterLog/FasterLogIterator.cs
@@ -116,6 +116,8 @@ namespace FASTER.core
 
             if (!scanUncommitted)
             {
+                if (NextAddress >= endAddress)
+                    return new ValueTask<bool>(false);
                 if (NextAddress < fasterLog.CommittedUntilAddress)
                     return new ValueTask<bool>(true);
 

--- a/cs/src/devices/AzureStorageDevice/AzureStorageNamedDeviceFactory.cs
+++ b/cs/src/devices/AzureStorageDevice/AzureStorageNamedDeviceFactory.cs
@@ -91,7 +91,7 @@ namespace FASTER.devices
                 };
             }
 
-            foreach (var entry in baseRef.ListBlobs().Where(b => b as CloudPageBlob != null)
+            foreach (var entry in baseRef.GetDirectoryReference(path).ListBlobs().Where(b => b as CloudPageBlob != null)
                 .OrderByDescending(f => ((CloudPageBlob)f).Properties.LastModified))
             {
                 yield return new FileDescriptor


### PR DESCRIPTION
WaitAsync should return false if iterator has reached end of scan range:

Fix https://github.com/microsoft/FASTER/issues/477

Fix to path in AzureStorage device factory list contents:

Fix https://github.com/microsoft/FASTER/issues/478