### PR TITLE
[C#] Mark LogCommitFile field (FasterLogSettings) as obsolete

### DIFF
--- a/cs/src/core/Index/FasterLog/FasterLog.cs
+++ b/cs/src/core/Index/FasterLog/FasterLog.cs
@@ -134,20 +134,12 @@ namespace FASTER.core
 
         private FasterLog(FasterLogSettings logSettings, bool oldCommitManager)
         {
-            if (oldCommitManager)
-            {
-                logCommitManager = logSettings.LogCommitManager ??
-                    new LocalLogCommitManager(logSettings.LogCommitFile ??
-                    logSettings.LogDevice.FileName + ".commit");
-            }
-            else
-            {
-                logCommitManager = logSettings.LogCommitManager ??
-                    new DeviceLogCommitCheckpointManager
-                    (new LocalStorageNamedDeviceFactory(),
-                        new DefaultCheckpointNamingScheme(
-                          new FileInfo(logSettings.LogDevice.FileName).Directory.FullName));
-            }
+            Debug.Assert(oldCommitManager == false);
+            logCommitManager = logSettings.LogCommitManager ??
+                new DeviceLogCommitCheckpointManager
+                (new LocalStorageNamedDeviceFactory(),
+                    new DefaultCheckpointNamingScheme(
+                        new FileInfo(logSettings.LogDevice.FileName).Directory.FullName));
 
             if (logSettings.LogCommitManager == null)
                 disposeLogCommitManager = true;

--- a/cs/src/core/Index/FasterLog/FasterLogSettings.cs
+++ b/cs/src/core/Index/FasterLog/FasterLogSettings.cs
@@ -3,6 +3,8 @@
 
 #pragma warning disable 0162
 
+using System;
+
 namespace FASTER.core
 {
     /// <summary>
@@ -56,15 +58,14 @@ namespace FASTER.core
         public int SegmentSizeBits = 30;
 
         /// <summary>
-        /// Log commit manager
+        /// Log commit manager - if you want to override the default implementation of commit.
         /// </summary>
         public ILogCommitManager LogCommitManager = null;
 
         /// <summary>
         /// Use specified directory for storing and retrieving checkpoints
-        /// This is a shortcut to providing the following:
-        ///   FasterLogSettings.LogCommitManager = new LocalLogCommitManager(LogCommitFile)
         /// </summary>
+        [Obsolete("This field is obsolete. The default log commit manager uses its own naming system. To use the old commit manager, set FasterLogSettings.LogCommitManager = new LocalLogCommitManager(LogCommitFile).", false)]
         public string LogCommitFile = null;
 
         /// <summary>

--- a/cs/test/FasterLogResumeTests.cs
+++ b/cs/test/FasterLogResumeTests.cs
@@ -49,7 +49,7 @@ namespace FASTER.test
             var input3 = new byte[] { 11, 12 };
             string readerName = "abc";
 
-            using (var l = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitFile = commitPath }))
+            using (var l = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum }))
             {
                 await l.EnqueueAsync(input1, cancellationToken);
                 await l.EnqueueAsync(input2);
@@ -63,7 +63,7 @@ namespace FASTER.test
                 await l.CommitAsync();
             }
 
-            using (var l = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitFile = commitPath }))
+            using (var l = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum }))
             {
                 using var recoveredIterator = l.Scan(0, long.MaxValue, readerName);
                 Assert.IsTrue(recoveredIterator.GetNext(out byte[] outBuf, out _, out _, out _));


### PR DESCRIPTION
Commit file naming is handled automatically by default commit manager.

Fix https://github.com/microsoft/FASTER/issues/490