### PR TITLE
Added support in Subscriptions. TODO: prefix matching for subscriptions, publish deletes to keys

### DIFF
--- a/cs/remote/samples/VarLenClient/CustomTypeSamples.cs
+++ b/cs/remote/samples/VarLenClient/CustomTypeSamples.cs
@@ -52,6 +52,33 @@ namespace VarLenClient
             session.CompletePending(true);
         }
 
+        void SyncVarLenSubscriptionSamples(ClientSession<CustomType, CustomType, CustomType, CustomType, byte, CustomTypeFunctions, FixedLenSerializer<CustomType, CustomType, CustomType, CustomType>> session,
+                                            ClientSession<CustomType, CustomType, CustomType, CustomType, byte, CustomTypeFunctions, FixedLenSerializer<CustomType, CustomType, CustomType, CustomType>> session2)
+        {
+            session2.SubscribeKV(new CustomType(23));
+            session2.CompletePending(true);
+
+            session.Upsert(new CustomType(23), new CustomType(2300));
+            session.CompletePending(true);
+
+            for (int i = 0; i < 100; i++)
+                session.Upsert(new CustomType(i), new CustomType(i + 10000));
+
+            // Flushes partially filled batches, does not wait for responses
+            session.Flush();
+
+            session.Read(new CustomType(23));
+            session.CompletePending(true);
+
+            for (int i = 100; i < 200; i++)
+                session.Upsert(new CustomType(i), new CustomType(i + 10000));
+
+            session.Flush();
+
+            session.CompletePending(true);
+        }
+
+
         async Task AsyncVarLenSamples(ClientSession<CustomType, CustomType, CustomType, CustomType, byte, CustomTypeFunctions, FixedLenSerializer<CustomType, CustomType, CustomType, CustomType>> session)
         {
             // By default, we flush async operations as soon as they are issued

--- a/cs/remote/src/FASTER.client/ClientSession.cs
+++ b/cs/remote/src/FASTER.client/ClientSession.cs
@@ -425,6 +425,7 @@ namespace FASTER.client
                                 else if (status == Status.NOTFOUND)
                                 {
                                     readRmwPendingContext.TryGetValue(p, out var result);
+                                    result.Item1 = serializer.ReadKey(ref src);
                                     functions.SubscribeKVCallback(ref result.Item1, ref result.Item2, ref defaultOutput, result.Item4, Status.NOTFOUND);
                                 }
                                 else if (status == Status.PENDING)

--- a/cs/remote/src/FASTER.client/ClientSession.cs
+++ b/cs/remote/src/FASTER.client/ClientSession.cs
@@ -586,8 +586,7 @@ namespace FASTER.client
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe Status InternalRead(MessageType messageType, ref Key key, ref Input input, ref Output output, Context userContext = default, long serialNo = 0)
         {
-            if (subscriptionSession == true)
-                return Status.ERROR;
+            Debug.Assert(!subscriptionSession);
 
             while (true)
             {
@@ -631,8 +630,7 @@ namespace FASTER.client
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe Status InternalUpsert(MessageType messageType, ref Key key, ref Value desiredValue, Context userContext = default, long serialNo = 0)
         {
-            if (subscriptionSession == true)
-                return Status.ERROR;
+            Debug.Assert(!subscriptionSession);
 
             while (true)
             {
@@ -654,8 +652,7 @@ namespace FASTER.client
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe Status InternalRMW(MessageType messageType, ref Key key, ref Input input, Context userContext = default, long serialNo = 0)
         {
-            if (subscriptionSession == true)
-                return Status.ERROR;
+            Debug.Assert(!subscriptionSession);
 
             while (true)
             {
@@ -677,8 +674,7 @@ namespace FASTER.client
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe Status InternalDelete(MessageType messageType, ref Key key, Context userContext = default, long serialNo = 0)
         {
-            if (subscriptionSession == true)
-                return Status.ERROR;
+            Debug.Assert(!subscriptionSession);
 
             while (true)
             {

--- a/cs/remote/src/FASTER.client/ClientSession.cs
+++ b/cs/remote/src/FASTER.client/ClientSession.cs
@@ -385,7 +385,7 @@ namespace FASTER.client
                                 else if (status == Status.NOTFOUND)
                                 {
                                     readRmwPendingContext.TryGetValue(p, out var result);
-                                    functions.SubscribeKVCallback(ref result.Item1, ref result.Item2, ref defaultOutput, result.Item4, Status.OK);
+                                    functions.SubscribeKVCallback(ref result.Item1, ref result.Item2, ref defaultOutput, result.Item4, Status.NOTFOUND);
                                 }
                                 else if (status == Status.PENDING)
                                 {

--- a/cs/remote/src/FASTER.client/FixedLenSerializer.cs
+++ b/cs/remote/src/FASTER.client/FixedLenSerializer.cs
@@ -84,5 +84,10 @@ namespace FASTER.client
             }
             return true;
         }
+
+        public Key ReadKey(ref byte* src)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/cs/remote/src/FASTER.client/FixedLenSerializer.cs
+++ b/cs/remote/src/FASTER.client/FixedLenSerializer.cs
@@ -55,6 +55,14 @@ namespace FASTER.client
         }
 
         /// <inheritdoc />
+        public Key ReadKey(ref byte* src)
+        {
+            var _src = src;
+            src += Unsafe.SizeOf<Key>();
+            return Unsafe.AsRef<Key>(_src);
+        }
+
+        /// <inheritdoc />
         public Output ReadOutput(ref byte* src)
         {
             var _src = src;
@@ -83,11 +91,6 @@ namespace FASTER.client
                 return false;
             }
             return true;
-        }
-
-        public Key ReadKey(ref byte* src)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/cs/remote/src/FASTER.client/MemoryParameterSerializer.cs
+++ b/cs/remote/src/FASTER.client/MemoryParameterSerializer.cs
@@ -26,9 +26,15 @@ namespace FASTER.client
             this.memoryPool = memoryPool ?? MemoryPool<T>.Shared;
         }
 
+        /// <inheritdoc />
         public ReadOnlyMemory<T> ReadKey(ref byte* src)
         {
-            throw new NotImplementedException();
+            var len = (*(int*)src) / sizeof(T);
+            var mem = memoryPool.Rent(len);
+            new ReadOnlySpan<byte>(src + sizeof(int), (*(int*)src)).CopyTo(
+               MemoryMarshal.Cast<T, byte>(mem.Memory.Span));
+            src += sizeof(int) + (*(int*)src);
+            return (mem.Memory);
         }
 
         /// <inheritdoc />

--- a/cs/remote/src/FASTER.client/MemoryParameterSerializer.cs
+++ b/cs/remote/src/FASTER.client/MemoryParameterSerializer.cs
@@ -26,6 +26,11 @@ namespace FASTER.client
             this.memoryPool = memoryPool ?? MemoryPool<T>.Shared;
         }
 
+        public ReadOnlyMemory<T> ReadKey(ref byte* src)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <inheritdoc />
         public (IMemoryOwner<T>, int) ReadOutput(ref byte* src)
         {

--- a/cs/remote/src/FASTER.common/IClientSerializer.cs
+++ b/cs/remote/src/FASTER.common/IClientSerializer.cs
@@ -50,7 +50,7 @@ namespace FASTER.common
         /// Read key from source memory location, increment pointer by amount read
         /// </summary>
         /// <param name="src">Source memory location</param>
-        /// <returns>Output</returns>
+        /// <returns>Key</returns>
         Key ReadKey(ref byte* src);
 
     }

--- a/cs/remote/src/FASTER.common/IClientSerializer.cs
+++ b/cs/remote/src/FASTER.common/IClientSerializer.cs
@@ -45,5 +45,13 @@ namespace FASTER.common
         /// <param name="src">Source memory location</param>
         /// <returns>Output</returns>
         Output ReadOutput(ref byte* src);
+
+        /// <summary>
+        /// Read key from source memory location, increment pointer by amount read
+        /// </summary>
+        /// <param name="src">Source memory location</param>
+        /// <returns>Output</returns>
+        Key ReadKey(ref byte* src);
+
     }
 }

--- a/cs/remote/src/FASTER.common/IServerSerializer.cs
+++ b/cs/remote/src/FASTER.common/IServerSerializer.cs
@@ -15,6 +15,15 @@ namespace FASTER.common
         /// <summary>
         /// Write element to given destination, with length bytes of space available
         /// </summary>
+        /// <param name="k">Element to write</param>
+        /// <param name="dst">Destination memory</param>
+        /// <param name="length">Space (bytes) available at destination</param>
+        /// <returns>True if write succeeded, false if not (insufficient space)</returns>
+        bool Write(ref Key k, ref byte* dst, int length);
+
+        /// <summary>
+        /// Write element to given destination, with length bytes of space available
+        /// </summary>
         /// <param name="o">Element to write</param>
         /// <param name="dst">Destination memory</param>
         /// <param name="length">Space (bytes) available at destination</param>

--- a/cs/remote/src/FASTER.common/IServerSerializer.cs
+++ b/cs/remote/src/FASTER.common/IServerSerializer.cs
@@ -62,5 +62,12 @@ namespace FASTER.common
         /// </summary>
         /// <param name="src">Memory location</param>
         void SkipOutput(ref byte* src);
+
+        /// <summary>
+        /// Match pattern with key used for pub-sub
+        /// </summary>
+        /// <param name="k">key to be published</param>
+        /// <param name="pattern">pattern to check</param>
+        bool Match(ref Key k, ref Key pattern);
     }
 }

--- a/cs/remote/src/FASTER.common/MessageType.cs
+++ b/cs/remote/src/FASTER.common/MessageType.cs
@@ -47,8 +47,14 @@ namespace FASTER.common
         PendingResult,
 
         /// <summary>
-        /// A request to subscribe to some key-value prefix in a remote Faster instance
+        /// A request to subscribe to some key in a remote Faster instance
         /// </summary>
         SubscribeKV,
+
+        /// <summary>
+        /// A request to subscribe to some key prefix in a remote Faster instance
+        /// </summary>
+        PSubscribeKV,
+
     }
 }

--- a/cs/remote/src/FASTER.server/BinaryServerSession.cs
+++ b/cs/remote/src/FASTER.server/BinaryServerSession.cs
@@ -181,9 +181,12 @@ namespace FASTER.server
                             if ((int)(dend - dcurr) < 2)
                                 SendAndReset(ref d, ref dend);
 
+                            keyptr = src;
                             status = session.Delete(ref serializer.ReadKeyByRef(ref src));
                             hrw.Write(message, ref dcurr, (int)(dend - dcurr));
                             Write(ref status, ref dcurr, (int)(dend - dcurr));
+
+                            subscribeKVBroker.Publish(keyptr);
                             break;
 
                         case MessageType.SubscribeKV:
@@ -213,19 +216,7 @@ namespace FASTER.server
             }
         }
 
-        public Status ReadBeforePublish(ref Key key, ref Input input, ref Output output, int sid)
-        {
-            MessageType message = MessageType.SubscribeKV;
-
-            long ctx = ((long)message << 32) | (long)sid;
-            var status = session.Read(ref key, ref input, ref output, ctx, 0);
-            if (status == Status.PENDING)
-                session.CompletePending(true);
-
-            return status;
-        }
-
-        public void Publish(ref Key key, ref Input input, int sid, Status status, ref Output output)
+        public void Publish(int sid, Status status, ref Output output)
         {
             MessageType message = MessageType.SubscribeKV;
             GetResponseObject();
@@ -253,7 +244,7 @@ namespace FASTER.server
                 hrw.Write(message, ref dcurr, (int)(dend - dcurr));
                 Write(ref status, ref dcurr, (int)(dend - dcurr));
                 Write(sid, ref dcurr, (int)(dend - dcurr));
-                outputCopy = serializer.Write(ref output, ref dcurr, (int)(dend - dcurr));
+                serializer.Write(ref output, ref dcurr, (int)(dend - dcurr));
 
                 if (status == Status.OK)
                     serializer.SkipOutput(ref dcurr);

--- a/cs/remote/src/FASTER.server/FasterKVServer.cs
+++ b/cs/remote/src/FASTER.server/FasterKVServer.cs
@@ -51,6 +51,7 @@ namespace FASTER.server
             servSocket = new Socket(ip.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             servSocket.Bind(endPoint);
             servSocket.Listen(512);
+            subscribeKVBroker.assignSubscriptionSession(new BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>(servSocket, store, functionsGen(WireFormat.Binary), serializer, this.maxSizeSettings, subscribeKVBroker));
             acceptEventArg = new SocketAsyncEventArgs
             {
                 UserToken = (store, functionsGen, serializer)
@@ -190,6 +191,8 @@ namespace FASTER.server
                 DisposeConnectionSession(e);
                 return false;
             }
+
+            
             return true;
         }
 
@@ -203,6 +206,7 @@ namespace FASTER.server
             {
                 if (activeSessions.TryRemove(_session, out _))
                 {
+                    subscribeKVBroker.removeSubscription(_session);
                     _session.Dispose();
                     Interlocked.Decrement(ref activeSessionCount);
                 }

--- a/cs/remote/src/FASTER.server/FixedLenSerializer.cs
+++ b/cs/remote/src/FASTER.server/FixedLenSerializer.cs
@@ -100,5 +100,14 @@ namespace FASTER.server
             }
             return true;
         }
+
+        /// <inheritdoc />
+        public bool Match(ref Key k, ref Key pattern)
+        {
+            if (k.Equals(pattern))
+                return true;
+
+            return false;
+        }
     }
 }

--- a/cs/remote/src/FASTER.server/FixedLenSerializer.cs
+++ b/cs/remote/src/FASTER.server/FixedLenSerializer.cs
@@ -55,6 +55,15 @@ namespace FASTER.server
         }
 
         /// <inheritdoc />
+        public bool Write(ref Key k, ref byte* dst, int length)
+        {
+            if (length < Unsafe.SizeOf<Key>()) return false;
+            Unsafe.AsRef<Key>(dst) = k;
+            dst += Unsafe.SizeOf<Key>();
+            return true;
+        }
+
+        /// <inheritdoc />
         public bool Write(ref Output o, ref byte* dst, int length)
         {
             if (length < Unsafe.SizeOf<Output>()) return false;

--- a/cs/remote/src/FASTER.server/SpanByteClientSerializer.cs
+++ b/cs/remote/src/FASTER.server/SpanByteClientSerializer.cs
@@ -34,7 +34,16 @@ namespace FASTER.client
             var mem = memoryPool.Rent(length);
             new ReadOnlySpan<byte>(src + sizeof(int), length).CopyTo(mem.Memory.Span);
             src += length + sizeof(int);
-            return new SpanByteAndMemory(mem, length); ;
+            return new SpanByteAndMemory(mem, length);
+        }
+
+        /// <inheritdoc />
+        public SpanByte ReadKey(ref byte* src)
+        {
+            int length = *(int*)src;
+            byte* mem = src;
+            src += length + sizeof(int);
+            return SpanByte.FromPointer((mem + sizeof(int)), length);
         }
 
         /// <inheritdoc />

--- a/cs/remote/src/FASTER.server/SpanByteSerializer.cs
+++ b/cs/remote/src/FASTER.server/SpanByteSerializer.cs
@@ -105,5 +105,19 @@ namespace FASTER.server
 
         /// <inheritdoc />
         public int GetLength(ref SpanByteAndMemory o) => o.Length;
+
+        /// <inheritdoc />
+        public bool Match(ref SpanByte k, ref SpanByte pattern)
+        {
+            if (pattern.Length > k.Length)
+                return false;
+
+            Span<byte> keySpan = k.AsSpan();
+            ReadOnlySpan<byte> patternSpan = pattern.AsReadOnlySpan();
+            if (keySpan.StartsWith(patternSpan))
+                return true;
+
+            return false;            
+        }
     }
 }

--- a/cs/remote/src/FASTER.server/SpanByteServerSerializer.cs
+++ b/cs/remote/src/FASTER.server/SpanByteServerSerializer.cs
@@ -60,6 +60,16 @@ namespace FASTER.server
         }
 
         /// <inheritdoc />
+        public bool Write(ref SpanByte k, ref byte* dst, int length)
+        {
+            if (k.Length > length) return false;
+            k.CopyTo(dst);
+            dst += (k.Length + sizeof(int));
+            return true;
+        }
+
+
+        /// <inheritdoc />
         public bool Write(ref SpanByteAndMemory k, ref byte* dst, int length)
         {
             if (k.Length > length) return false;

--- a/cs/remote/src/FASTER.server/SpanByteServerSerializer.cs
+++ b/cs/remote/src/FASTER.server/SpanByteServerSerializer.cs
@@ -92,12 +92,16 @@ namespace FASTER.server
             if (pattern.Length > k.Length)
                 return false;
 
-            Span<byte> keySpan = k.AsSpan();
-            ReadOnlySpan<byte> patternSpan = pattern.AsReadOnlySpan();
-            if (keySpan.StartsWith(patternSpan))
-                return true;
+            byte[] kByte = k.ToByteArray();
+            byte[] patternByte = pattern.ToByteArray();
 
-            return false;            
+            for (int i = 0; i < patternByte.Length; i++)
+            {
+                if (kByte[i] != patternByte[i])
+                    return false;
+            }
+
+            return true;
         }
     }
 }

--- a/cs/remote/src/FASTER.server/SubscribeKVBroker.cs
+++ b/cs/remote/src/FASTER.server/SubscribeKVBroker.cs
@@ -26,8 +26,6 @@ namespace FASTER.server
         {
             this.serializer = serializer;
             this.subscriptionSession = subscriptionSession;
-            this.subscriptions = new ConcurrentDictionary<byte[], ConcurrentDictionary<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>, int>>(new ByteArrayComparer());
-            this.psubscriptions = new ConcurrentDictionary<byte[], ConcurrentDictionary<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>, int>>(new ByteArrayComparer());
         }
 
         public void removeSubscription(ServerSessionBase<Key, Value, Input, Output, Functions, ParameterSerializer> session)
@@ -175,6 +173,8 @@ namespace FASTER.server
             var id = Interlocked.Increment(ref sid);
             if (Interlocked.CompareExchange(ref publishQueue, new AsyncQueue<byte[]>(), null) == null)
             {
+                this.subscriptions = new ConcurrentDictionary<byte[], ConcurrentDictionary<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>, int>>(new ByteArrayComparer());
+                this.psubscriptions = new ConcurrentDictionary<byte[], ConcurrentDictionary<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>, int>>(new ByteArrayComparer());
                 Task.Run(() => Start());
             }
             var subscriptionKey = new Span<byte>(start, (int)(key - start)).ToArray();
@@ -190,6 +190,8 @@ namespace FASTER.server
             var id = Interlocked.Increment(ref sid);
             if (Interlocked.CompareExchange(ref publishQueue, new AsyncQueue<byte[]>(), null) == null)
             {
+                this.subscriptions = new ConcurrentDictionary<byte[], ConcurrentDictionary<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>, int>>(new ByteArrayComparer());
+                this.psubscriptions = new ConcurrentDictionary<byte[], ConcurrentDictionary<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>, int>>(new ByteArrayComparer());
                 Task.Run(() => Start());
             }
             var subscriptionPrefix = new Span<byte>(start, (int)(prefix - start)).ToArray();

--- a/cs/remote/src/FASTER.server/SubscribeKVBroker.cs
+++ b/cs/remote/src/FASTER.server/SubscribeKVBroker.cs
@@ -11,46 +11,85 @@ using FASTER.core;
 
 namespace FASTER.server
 {
-    internal unsafe sealed class SubscribeKVBroker<Key, Value, Input, Output, Functions, ParameterSerializer>
+    internal sealed class SubscribeKVBroker<Key, Value, Input, Output, Functions, ParameterSerializer>
         where Functions : IFunctions<Key, Value, Input, Output, long>
         where ParameterSerializer : IServerSerializer<Key, Value, Input, Output>
     {
         readonly ParameterSerializer serializer;
-        int sid = 0;
-        ConcurrentDictionary<byte[], (int, BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>)> subscriptions;
+        private BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer> subscribeServerSession;
+        private int sid = 0;
+        private ConcurrentDictionary<byte[], (int, HashSet<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>>)> subscriptions;
+        private AsyncQueue<(Key, byte[])> publishQueue;
+
+        public void removeSubscription(ServerSessionBase<Key, Value, Input, Output, Functions, ParameterSerializer> session)
+        {
+            foreach (var key in subscriptions.Keys)
+                subscriptions[key].Item2.Remove((BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>)session);
+        }
 
         public SubscribeKVBroker(ParameterSerializer serializer)
         {
             this.serializer = serializer;
         }
 
-        public async Task Start()
+        public void assignSubscriptionSession(BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer> subscribeServerSession)
         {
-            // Read from queue and send to all subscribed sessions
+            this.subscribeServerSession = subscribeServerSession;
         }
 
-        public int Subscribe(ref byte* key, BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer> session)
+        public async Task Start()
+        {
+            Input input = default;
+            var uniqueKeys = new ConcurrentDictionary<byte[], Key>(new ByteArrayComparer());
+
+            // Read from queue and send to all subscribed sessions
+            while (true) {
+                while (publishQueue.Count > 0)
+                {
+                    var subscriptionKey = await publishQueue.DequeueAsync();
+                    uniqueKeys.TryAdd(subscriptionKey.Item2, subscriptionKey.Item1);
+
+                    foreach (var byteKey in uniqueKeys.Keys)
+                    {
+                        Output output = default;
+                        uniqueKeys.TryGetValue(byteKey, out var typedKey);
+                        subscriptions.TryGetValue(byteKey, out var value);
+                        var status = subscribeServerSession.ReadBeforePublish(ref typedKey, ref input, ref output, value.Item1);
+                        foreach (var session in value.Item2)
+                            session.Publish(ref typedKey, ref input, value.Item1, status, ref output);
+                    }
+                }
+            }
+        }
+
+        public unsafe int Subscribe(ref byte* key, BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer> session)
         {
             var start = key;
             serializer.ReadKeyByRef(ref key);
             var id = Interlocked.Increment(ref sid);
             if (subscriptions == null)
-                Interlocked.CompareExchange(ref subscriptions, new ConcurrentDictionary<byte[], (int, BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>)>(new ByteArrayComparer()), null);
-            subscriptions.TryAdd(new Span<byte>(start, (int)(key - start)).ToArray(), (id, session));
+                Interlocked.CompareExchange(ref subscriptions, new ConcurrentDictionary<byte[], (int, HashSet<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>>)>(new ByteArrayComparer()), null);
+            if (publishQueue == null)
+            {
+                Interlocked.CompareExchange(ref publishQueue, new AsyncQueue<(Key, byte[])>(), null);
+                Task.Run(() => Start());
+            }
+            var subscriptionKey = new Span<byte>(start, (int)(key - start)).ToArray();
+            subscriptions.TryAdd(subscriptionKey, (id, new HashSet<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>>()));
+            subscriptions[subscriptionKey].Item2.Add(session);
             return id;
         }
 
-        public void Publish(byte* key)
+        public unsafe void Publish(byte* key)
         {
-            Input input = default;
             if (subscriptions == null) return;
 
             var start = key;
             ref Key k = ref serializer.ReadKeyByRef(ref key);
-            if (subscriptions.TryGetValue(new Span<byte>(start, (int)(key - start)).ToArray(), out var value))
-            {
-                value.Item2.Publish(ref k, ref input, value.Item1);
-            }
+            var subscriptionsKey = new Span<byte>(start, (int)(key - start)).ToArray();
+            //subscriptions.TryGetValue(subscriptionsKey, out var value);
+            publishQueue.Enqueue((k, subscriptionsKey));
+            //Start();
             // Add to async queue and return
         }
     }

--- a/cs/remote/src/FASTER.server/SubscribeKVBroker.cs
+++ b/cs/remote/src/FASTER.server/SubscribeKVBroker.cs
@@ -275,7 +275,7 @@ namespace FASTER.server
 
             if (publishQueue != null && subscriptions.ContainsKey(keyBytes))
                 publishQueue.Enqueue(keyBytes);
-            else if (prefixPublishQueue != null)
+            if (prefixPublishQueue != null)
                 prefixPublishQueue.Enqueue(keyBytes);
         }
     }

--- a/cs/remote/src/FASTER.server/SubscribeKVBroker.cs
+++ b/cs/remote/src/FASTER.server/SubscribeKVBroker.cs
@@ -16,11 +16,11 @@ namespace FASTER.server
         where ParameterSerializer : IServerSerializer<Key, Value, Input, Output>
     {
         readonly ParameterSerializer serializer;
-        private BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer> subscribeServerSession;
+        private ClientSession<Key, Value, Input, Output, long, ServerFunctions<Key, Value, Input, Output, Functions, ParameterSerializer>> subscriptionSession;
         private int sid = 0;
-        private ConcurrentDictionary<byte[], (int, HashSet<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>>)> subscriptions;
+        private ConcurrentDictionary<byte[], ConcurrentDictionary<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>, int>> subscriptions;
         //private Trie<byte[], (int, HashSet<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>>)> subscriptionsTrie;
-        private AsyncQueue<(Key, byte[])> publishQueue;        
+        private AsyncQueue<byte[]> publishQueue;        
 
         public SubscribeKVBroker(ParameterSerializer serializer)
         {
@@ -34,40 +34,72 @@ namespace FASTER.server
 
             foreach (var key in subscriptions.Keys)
             {
-                subscriptions[key].Item2.Remove((BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>)session);
-
+                foreach (var subscribedSession in subscriptions[key].Keys)
+                {
+                    if (subscribedSession == session)
+                    {
+                        subscriptions[key].TryRemove(subscribedSession, out _);
+                    }
+                }
             }
 
             //foreach (var key in subscriptionsTrie.Keys)
             //    subscriptionsTrie[key].Item2.Remove((BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>)session);
         }
 
-        public void assignSubscriptionSession(BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer> subscribeServerSession)
+        public void assignSubscriptionSession(ClientSession<Key, Value, Input, Output, long, ServerFunctions<Key, Value, Input, Output, Functions, ParameterSerializer>> subscriptionSession)
         {
-            this.subscribeServerSession = subscribeServerSession;
+            this.subscriptionSession = subscriptionSession;
+        }
+
+        public unsafe (Status, Output) ReadBeforePublish(ref byte* keyBytePtr, ref Input input, ref byte* outputBytePtr, int lengthOutput, int sid)
+        {
+            MessageType message = MessageType.SubscribeKV;
+
+            ref Key key = ref serializer.ReadKeyByRef(ref keyBytePtr);
+            ref Output output = ref serializer.AsRefOutput(outputBytePtr, (int)(lengthOutput));
+
+            long ctx = ((long)message << 32) | (long)sid;
+            var status = subscriptionSession.Read(ref key, ref input, ref output, ctx, 0);
+            if (status == Status.PENDING)
+                subscriptionSession.CompletePending(true);
+
+            return (status, output);
         }
 
         public async Task Start()
         {
             Input input = default;
-            var uniqueKeys = new ConcurrentDictionary<byte[], Key>(new ByteArrayComparer());
-
+            var uniqueKeys = new HashSet<byte[]>(new ByteArrayComparer());
+            // unique is a set of byte arrays non-conc
             // Read from queue and send to all subscribed sessions
             while (true) {
-                while (publishQueue.Count > 0)
+                while (publishQueue.Count > 0) // delete this line
                 {
                     var subscriptionKey = await publishQueue.DequeueAsync();
-                    uniqueKeys.TryAdd(subscriptionKey.Item2, subscriptionKey.Item1);
+                    uniqueKeys.Add(subscriptionKey);
+                }
 
-                    foreach (var byteKey in uniqueKeys.Keys)
+                unsafe
+                {
+                    foreach (var byteKey in uniqueKeys)
                     {
-                        Output output = default;
-                        uniqueKeys.TryGetValue(byteKey, out var typedKey);
-                        subscriptions.TryGetValue(byteKey, out var value);
-                        var status = subscribeServerSession.ReadBeforePublish(ref typedKey, ref input, ref output, value.Item1);
-                        foreach (var session in value.Item2)
-                            session.Publish(ref typedKey, ref input, value.Item1, status, ref output);
+                        byte[] outputBytes = new byte[1024];
+                        fixed (byte* ptr1 = &byteKey[0], ptr2 = &outputBytes[0])
+                        {
+                            byte* keyPtr = ptr1;
+                            byte* outputPtr = ptr2;
+
+                            subscriptions.TryGetValue(byteKey, out var value);
+                            var (status, output) = ReadBeforePublish(ref keyPtr, ref input, ref outputPtr, outputBytes.Length, 0);
+                            foreach (var session in value.Keys)
+                            {
+                                subscriptions[byteKey].TryGetValue(session, out var sid);
+                                session.Publish(sid, status, ref output);
+                            }
+                        }
                     }
+                    uniqueKeys.Clear();
                 }
             }
         }
@@ -79,18 +111,20 @@ namespace FASTER.server
             var id = Interlocked.Increment(ref sid);
             if (subscriptions == null)
             {
-                Interlocked.CompareExchange(ref subscriptions, new ConcurrentDictionary<byte[], (int, HashSet<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>>)>(new ByteArrayComparer()), null);
+                // BC: we need a map of prefix => Set<(int, session)>
+                Interlocked.CompareExchange(ref subscriptions, new ConcurrentDictionary<byte[], ConcurrentDictionary<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>, int>>(new ByteArrayComparer()), null);
                 //Interlocked.CompareExchange(ref subscriptionsTrie, new Trie<byte[], (int, HashSet<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>>) > (new ByteArrayComparer()), null);
             }
-            if (publishQueue == null)
+            if (Interlocked.CompareExchange(ref publishQueue, new AsyncQueue<byte[]>(), null) == null)
             {
-                Interlocked.CompareExchange(ref publishQueue, new AsyncQueue<(Key, byte[])>(), null);
+                // only if CAS succshould you start
+                // asyncueue should just be a queue of byte[]
                 Task.Run(() => Start());
             }
             var subscriptionKey = new Span<byte>(start, (int)(key - start)).ToArray();
-            subscriptions.TryAdd(subscriptionKey, (id, new HashSet<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>>()));
-            subscriptions[subscriptionKey].Item2.Add(session);
-
+            subscriptions.TryAdd(subscriptionKey, new ConcurrentDictionary<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>, int>());
+            subscriptions[subscriptionKey].TryAdd(session, id);
+            // use a conc hash set
             //IEnumerator<byte[]> subscriptionKeyEnumerator = (IEnumerator<byte[]>)subscriptionKey.GetEnumerator();
             //subscriptionsTrie.Add((IEnumerable<byte[]>)subscriptionKeyEnumerator, (id, new HashSet<BinaryServerSession<Key, Value, Input, Output, Functions, ParameterSerializer>>()));
             //subscriptionsTrie[(IEnumerable<byte[]>)subscriptionKeyEnumerator].Item2.Add(session);
@@ -130,7 +164,7 @@ namespace FASTER.server
                     byte* src = subscribedKeyPtr;
                     ref Key subscribedKeyTyped = ref serializer.ReadKeyByRef(ref src);
                     if (serializer.Match(ref k, ref subscribedKeyTyped) == true)
-                        publishQueue.Enqueue((k, subscriptionsKey));
+                        publishQueue.Enqueue(subscriptionsKey);
                 }
             }
             //publishQueue.Enqueue((k, subscriptionsKey));


### PR DESCRIPTION
This PR contains code with features added as follows:
1. Support publish to push to multiple BinaryServerSessions per key
2. Add publish call to RMW on BinaryServerSession
3. Publish uses a dedicated Start task that retrieves keys from async queue and calls publish on sessions
4. If same key occurs multiple times in the async queue, we can send push just for the last one
5. Ensuring that pub/sub is not used for normal operations
6. Added separate samples in FixedLenClient and VarLenClient
7. Handle cleanup of subscription list when a client session disconnects 



