### PR TITLE
[C#] Support FasterLog commit dir specification in settings

### DIFF
--- a/cs/src/core/Device/LocalMemoryDevice.cs
+++ b/cs/src/core/Device/LocalMemoryDevice.cs
@@ -43,8 +43,9 @@ namespace FASTER.core
         /// <param name="parallelism">Number of IO processing threads</param>
         /// <param name="latencyMs">Induced callback latency in ms (for testing purposes)</param>
         /// <param name="sector_size">Sector size for device (default 64)</param>
-        public LocalMemoryDevice(long capacity, long sz_segment, int parallelism, int latencyMs = 0, uint sector_size = 64)
-            : base("/userspace/ram/storage", sector_size, capacity)
+        /// <param name="fileName">Virtual path for the device</param>
+        public LocalMemoryDevice(long capacity, long sz_segment, int parallelism, int latencyMs = 0, uint sector_size = 64, string fileName = "/userspace/ram/storage")
+            : base(fileName, sector_size, capacity)
         {
             if (capacity == Devices.CAPACITY_UNSPECIFIED) throw new Exception("Local memory device must have a capacity!");
             Console.WriteLine("LocalMemoryDevice: Creating a " + capacity + " sized local memory device.");

--- a/cs/src/core/Index/FasterLog/FasterLog.cs
+++ b/cs/src/core/Index/FasterLog/FasterLog.cs
@@ -139,7 +139,7 @@ namespace FASTER.core
                 new DeviceLogCommitCheckpointManager
                 (new LocalStorageNamedDeviceFactory(),
                     new DefaultCheckpointNamingScheme(
-                        logSettings.LogCommitPath ??
+                        logSettings.LogCommitDir ??
                         new FileInfo(logSettings.LogDevice.FileName).Directory.FullName));
 
             if (logSettings.LogCommitManager == null)

--- a/cs/src/core/Index/FasterLog/FasterLog.cs
+++ b/cs/src/core/Index/FasterLog/FasterLog.cs
@@ -139,6 +139,7 @@ namespace FASTER.core
                 new DeviceLogCommitCheckpointManager
                 (new LocalStorageNamedDeviceFactory(),
                     new DefaultCheckpointNamingScheme(
+                        logSettings.LogCommitPath ??
                         new FileInfo(logSettings.LogDevice.FileName).Directory.FullName));
 
             if (logSettings.LogCommitManager == null)

--- a/cs/src/core/Index/FasterLog/FasterLogSettings.cs
+++ b/cs/src/core/Index/FasterLog/FasterLogSettings.cs
@@ -63,10 +63,10 @@ namespace FASTER.core
         public ILogCommitManager LogCommitManager = null;
 
         /// <summary>
-        /// Use specified directory for storing and retrieving checkpoints
+        /// Use specified directory (path) for storing and retrieving checkpoints. If not provided, use
+        /// base path of the log device.
         /// </summary>
-        [Obsolete("This field is obsolete. The default log commit manager uses its own naming system. To use the old commit manager, set FasterLogSettings.LogCommitManager = new LocalLogCommitManager(LogCommitFile).", false)]
-        public string LogCommitFile = null;
+        public string LogCommitPath = null;
 
         /// <summary>
         /// User callback to allocate memory for read entries

--- a/cs/src/core/Index/FasterLog/FasterLogSettings.cs
+++ b/cs/src/core/Index/FasterLog/FasterLogSettings.cs
@@ -63,10 +63,11 @@ namespace FASTER.core
         public ILogCommitManager LogCommitManager = null;
 
         /// <summary>
-        /// Use specified directory (path) for storing and retrieving checkpoints. If not provided, use
-        /// base path of the log device.
+        /// Use specified directory (path) as base for storing and retrieving log commits. By default,
+        /// commits will be stored in a folder named log-commits under this directory. If not provided, 
+        /// we use the base path of the log device by default.
         /// </summary>
-        public string LogCommitPath = null;
+        public string LogCommitDir = null;
 
         /// <summary>
         /// User callback to allocate memory for read entries

--- a/cs/src/core/VarLen/SpanByte.cs
+++ b/cs/src/core/VarLen/SpanByte.cs
@@ -108,6 +108,17 @@ namespace FASTER.core
         }
 
         /// <summary>
+        /// If SpanByte is in a serialized form, return a non-serialized SpanByte wrapper that points to the same payload.
+        /// The resulting SpanByte is safe to heap-copy, as long as the underlying payload remains fixed.
+        /// </summary>
+        /// <returns></returns>
+        public SpanByte Deserialize()
+        {
+            if (!Serialized) return this;
+            return new SpanByte(Length, (IntPtr)Unsafe.AsPointer(ref payload));
+        }
+
+        /// <summary>
         /// Reinterpret a fixed Span&lt;byte&gt; as a serialized SpanByte. Automatically adds Span length to the first 4 bytes.
         /// </summary>
         /// <param name="span"></param>

--- a/cs/src/core/VarLen/SpanByteAndMemory.cs
+++ b/cs/src/core/VarLen/SpanByteAndMemory.cs
@@ -28,6 +28,7 @@ namespace FASTER.core
         /// <param name="spanByte"></param>
         public SpanByteAndMemory(SpanByte spanByte)
         {
+            if (spanByte.Serialized) throw new Exception("Cannot create new SpanByteAndMemory using serialized SpanByte");
             SpanByte = spanByte;
             Memory = default;
         }


### PR DESCRIPTION
Includes another feature:
* Convert serialized `SpanByte` into its non-serialized form, which is a normal value-type struct that include a length header and a pointer to the (same) raw payload bytes. This non-serialized form is safe to heap-copy as long as the underlying payload is fixed.
Fix https://github.com/microsoft/FASTER/issues/518