### PR TITLE
[C#] SpanByteFasterKVProvider

### DIFF
--- a/cs/remote/samples/VarLenServer/Program.cs
+++ b/cs/remote/samples/VarLenServer/Program.cs
@@ -38,7 +38,7 @@ namespace VarLenServer
             if (opts.Recover) store.Recover();
 
             // This variable-length session provider can be used with compatible clients such as VarLenClient
-            var provider = new FasterKVProvider<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, SpanByteFunctionsForServer<long>, SpanByteSerializer>(store, wp => new SpanByteFunctionsForServer<long>(wp), new SpanByteSerializer());
+            var provider = new SpanByteFasterKVProvider(store);
 
             // Create server
             var server = new FasterServer(opts.Address, opts.Port);

--- a/cs/remote/src/FASTER.server/SpanByteClientSerializer.cs
+++ b/cs/remote/src/FASTER.server/SpanByteClientSerializer.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using FASTER.common;
+using FASTER.core;
+using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+
+namespace FASTER.client
+{
+    /// <summary>
+    /// Serializer for SpanByte (can be used on client side)
+    /// </summary>
+    public unsafe class SpanByteClientSerializer : IClientSerializer<SpanByte, SpanByte, SpanByte, SpanByteAndMemory>
+    {
+        readonly MemoryPool<byte> memoryPool;
+        readonly SpanByteVarLenStruct settings;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="memoryPool"></param>
+        public SpanByteClientSerializer(MemoryPool<byte> memoryPool = default)
+        {
+            settings = new SpanByteVarLenStruct();
+            this.memoryPool = memoryPool ?? MemoryPool<byte>.Shared;
+        }
+
+        /// <inheritdoc />
+        public SpanByteAndMemory ReadOutput(ref byte* src)
+        {
+            int length = *(int*)src;
+            var mem = memoryPool.Rent(length);
+            new ReadOnlySpan<byte>(src + sizeof(int), length).CopyTo(mem.Memory.Span);
+            src += length + sizeof(int);
+            return new SpanByteAndMemory(mem, length);
+        }
+
+        /// <inheritdoc />
+        public SpanByte ReadKey(ref byte* src)
+        {
+            int length = *(int*)src;
+            byte* mem = src;
+            src += length + sizeof(int);
+            return SpanByte.FromPointer((mem + sizeof(int)), length);
+        }
+
+        /// <inheritdoc />
+        public bool Write(ref SpanByte k, ref byte* dst, int length)
+        {
+            var len = settings.GetLength(ref k);
+            if (length < len) return false;
+            k.CopyTo(dst);
+            dst += len;
+            return true;
+        }
+    }
+}

--- a/cs/remote/src/FASTER.server/SpanByteClientSerializer.cs
+++ b/cs/remote/src/FASTER.server/SpanByteClientSerializer.cs
@@ -23,7 +23,6 @@ namespace FASTER.client
         /// <param name="memoryPool"></param>
         public SpanByteClientSerializer(MemoryPool<byte> memoryPool = default)
         {
-            settings = new SpanByteVarLenStruct();
             this.memoryPool = memoryPool ?? MemoryPool<byte>.Shared;
         }
 
@@ -35,15 +34,6 @@ namespace FASTER.client
             new ReadOnlySpan<byte>(src + sizeof(int), length).CopyTo(mem.Memory.Span);
             src += length + sizeof(int);
             return new SpanByteAndMemory(mem, length);
-        }
-
-        /// <inheritdoc />
-        public SpanByte ReadKey(ref byte* src)
-        {
-            int length = *(int*)src;
-            byte* mem = src;
-            src += length + sizeof(int);
-            return SpanByte.FromPointer((mem + sizeof(int)), length);
         }
 
         /// <inheritdoc />

--- a/cs/remote/src/FASTER.server/SpanByteClientSerializer.cs
+++ b/cs/remote/src/FASTER.server/SpanByteClientSerializer.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using FASTER.common;
 using FASTER.core;
-using System;
 using System.Buffers;
-using System.Runtime.InteropServices;
 
 namespace FASTER.client
 {
@@ -15,7 +14,6 @@ namespace FASTER.client
     public unsafe class SpanByteClientSerializer : IClientSerializer<SpanByte, SpanByte, SpanByte, SpanByteAndMemory>
     {
         readonly MemoryPool<byte> memoryPool;
-        readonly SpanByteVarLenStruct settings;
 
         /// <summary>
         /// Constructor
@@ -39,7 +37,7 @@ namespace FASTER.client
         /// <inheritdoc />
         public bool Write(ref SpanByte k, ref byte* dst, int length)
         {
-            var len = settings.GetLength(ref k);
+            var len = k.TotalSize;
             if (length < len) return false;
             k.CopyTo(dst);
             dst += len;

--- a/cs/remote/src/FASTER.server/SpanByteFasterKVProvider.cs
+++ b/cs/remote/src/FASTER.server/SpanByteFasterKVProvider.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Sockets;
+using System.Threading;
+using FASTER.common;
+using FASTER.core;
+
+namespace FASTER.server
+{
+
+    /// <summary>
+    /// Session provider for FasterKV store based on
+    /// [K, V, I, O, C] = [SpanByte, SpanByte, SpanByte, SpanByteAndMemory, long]
+    /// </summary>
+    public sealed class SpanByteFasterKVProvider : ISessionProvider, IDisposable
+    {
+        readonly FasterKV<SpanByte, SpanByte> store;
+        readonly SpanByteServerSerializer serializer;
+        readonly MaxSizeSettings maxSizeSettings;
+
+        /// <summary>
+        /// Create SpanByte FasterKV backend
+        /// </summary>
+        /// <param name="store"></param>
+        /// <param name="maxSizeSettings"></param>
+        public SpanByteFasterKVProvider(FasterKV<SpanByte, SpanByte> store, MaxSizeSettings maxSizeSettings = default)
+        {
+            this.store = store;
+            this.serializer = new SpanByteServerSerializer();
+            this.maxSizeSettings = maxSizeSettings ?? new MaxSizeSettings();
+        }
+
+        /// <inheritdoc />
+        public IServerSession GetSession(WireFormat wireFormat, Socket socket)
+        {
+            return new BinaryServerSession<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, SpanByteFunctionsForServer<long>, SpanByteServerSerializer>
+                (socket, store, new SpanByteFunctionsForServer<long>(wireFormat), serializer, maxSizeSettings);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/cs/remote/src/FASTER.server/SpanByteServerSerializer.cs
+++ b/cs/remote/src/FASTER.server/SpanByteServerSerializer.cs
@@ -5,7 +5,6 @@ using System;
 using System.Runtime.CompilerServices;
 using FASTER.core;
 using FASTER.common;
-using System.Diagnostics;
 
 namespace FASTER.server
 {

--- a/cs/remote/test/FASTER.remote.test/VarLenServer.cs
+++ b/cs/remote/test/FASTER.remote.test/VarLenServer.cs
@@ -21,7 +21,7 @@ namespace FASTER.remote.test
             store = new FasterKV<SpanByte, SpanByte>(indexSize, logSettings, checkpointSettings);
 
             // Create session provider for VarLen
-            var provider = new FasterKVProvider<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, SpanByteFunctionsForServer<long>, SpanByteSerializer>(store, wp => new SpanByteFunctionsForServer<long>(wp), new SpanByteSerializer());
+            var provider = new SpanByteFasterKVProvider(store);
 
             server = new FasterServer(address, port);
             server.Register(WireFormat.DefaultVarLenKV, provider);

--- a/cs/src/core/VarLen/SpanByteAndMemory.cs
+++ b/cs/src/core/VarLen/SpanByteAndMemory.cs
@@ -53,6 +53,19 @@ namespace FASTER.core
         }
 
         /// <summary>
+        /// Constructor using given IMemoryOwner and length
+        /// </summary>
+        /// <param name="memory"></param>
+        /// <param name="length"></param>
+        public SpanByteAndMemory(IMemoryOwner<byte> memory, int length)
+        {
+            SpanByte = default;
+            SpanByte.Invalid = true;
+            Memory = memory;
+            SpanByte.Length = length;
+        }
+
+        /// <summary>
         /// View a fixed Span&lt;byte&gt; as a SpanByteAndMemory
         /// </summary>
         /// <param name="span"></param>


### PR DESCRIPTION
This PR adds a specialized remote provider called SpanByteFasterKVProvider that is optimized for `SpanByte` as `Key`, `Value`, `Input`; and `SpanByteAndMemory` as `Output`.

Changes in the PR:
1. Addition of `SpanByteFasterKVProvider.cs`
2. Separation of `SpanByteSerializer` to `SpanByteServerSerializer` and `SpanByteClientSerializer`
