### PR TITLE
[C++] Rmw bugfix

### DIFF
--- a/cc/src/core/address.h
+++ b/cc/src/core/address.h
@@ -66,6 +66,11 @@ class Address {
     control_ += delta;
     return *this;
   }
+  inline Address operator+(const uint64_t delta) {
+    Address addr (*this);
+    addr += delta;
+    return addr;
+  }
   inline Address operator-(const Address& other) {
     return control_ - other.control_;
   }

--- a/cc/src/core/faster.h
+++ b/cc/src/core/faster.h
@@ -1594,15 +1594,25 @@ OperationStatus FasterKv<K, V, D>::InternalContinuePendingRmw(ExecutionContext& 
   Address head_address = hlog.head_address.load();
 
   // Make sure that atomic_entry is OK to update.
-  if(address >= head_address) {
+  if(address >= head_address && address != pending_context->entry.address()) {
     record_t* record = reinterpret_cast<record_t*>(hlog.Get(address));
     if(!pending_context->is_key_equal(record->key())) {
-      address = TraceBackForKeyMatchCtxt(*pending_context, record->header.previous_address(), head_address);
+      Address min_offset = std::max(pending_context->entry.address() + 1, head_address);
+      address = TraceBackForKeyMatchCtxt(*pending_context, record->header.previous_address(), min_offset);
     }
   }
+  assert(address >= pending_context->entry.address()); // part of the same hash chain
 
   if(address > pending_context->entry.address()) {
-    // We can't trace the current hash bucket entry back to the record we read.
+    // This handles two mutually exclusive cases. In both cases InternalRmw will be called immediately:
+    //  1) Found a newer record in the in-memory region (i.e. address >= head_address)
+    //     Calling InternalRmw will result in taking into account the newer version,
+    //     instead of the record we've just read from disk.
+    //  2) We can't trace the current hash bucket entry back to the record we've read (i.e. address < head_address)
+    //     This is because part of the hash chain now extends to disk, thus we cannot check it right away
+    //     Calling InternalRmw will result in launching a new search in the hash chain, by reading
+    //     the newly introduced entries in the chain, so we won't miss any potential entries with same key.
+    //
     pending_context->continue_async(address, expected_entry);
     return OperationStatus::RETRY_NOW;
   }


### PR DESCRIPTION
The bug is related to how the in-memory trace back of the hash index chain was performed. During testing, the following assertion (L1609 -- now L1619) was not true:

```C++
assert(address < hlog.begin_address.load() || address == pending_context->entry.address());
```
The in-memory trace back of the hash index chain was ignoring the case where the `pending_context->entry.address()` (aka expected entry address) was  greater than the head address, **and** there was no full key match in `[expected entry address, tail address]`. In this case, the trace back would continue past the expected entry address, until either found a record with the same key and address greater or equal to the head address, or reached a record with address less than the head address. Therefore, it was possible for the address returned from the trace back to be **less** than the expected entry address, which should never happen.

This bugfix addresses the aforementioned case: now, we perform the in-memory hash index trace back, only until the head address or the expected entry address (i.e. whichever is greater). This ensures that the address returned from the trace back will be either greater (if a newer record with the same key has been inserted in the meantime), or equal (if no same-key record has been inserted) to the expected entry address.
