### PR TITLE
[C#] SpanByte improvements

### DIFF
--- a/cs/remote/src/FASTER.server/BinaryServerSession.cs
+++ b/cs/remote/src/FASTER.server/BinaryServerSession.cs
@@ -21,7 +21,7 @@ namespace FASTER.server
         byte* dcurr;
 
         public BinaryServerSession(Socket socket, FasterKV<Key, Value> store, Functions functions, ParameterSerializer serializer, MaxSizeSettings maxSizeSettings)
-            : base(socket, store, functions, serializer, maxSizeSettings)
+            : base(socket, store, functions, null, serializer, maxSizeSettings)
         {
             readHead = 0;
 

--- a/cs/remote/src/FASTER.server/ConnectionArgs.cs
+++ b/cs/remote/src/FASTER.server/ConnectionArgs.cs
@@ -9,5 +9,6 @@ namespace FASTER.server
     {
         public Socket socket;
         public IServerSession session;
+        public int bytesRead;
     }
 }

--- a/cs/remote/src/FASTER.server/FasterKVServerSessionBase.cs
+++ b/cs/remote/src/FASTER.server/FasterKVServerSessionBase.cs
@@ -12,11 +12,12 @@ namespace FASTER.server
         protected readonly ParameterSerializer serializer;
 
         public FasterKVServerSessionBase(Socket socket, FasterKV<Key, Value> store, Functions functions,
+            SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings,
             ParameterSerializer serializer, MaxSizeSettings maxSizeSettings)
             : base(socket, maxSizeSettings)
         {
             session = store.For(new ServerKVFunctions<Key, Value, Input, Output, Functions, ParameterSerializer>(functions, this))
-                .NewSession<ServerKVFunctions<Key, Value, Input, Output, Functions, ParameterSerializer>>();
+                .NewSession<ServerKVFunctions<Key, Value, Input, Output, Functions, ParameterSerializer>>(sessionVariableLengthStructSettings: sessionVariableLengthStructSettings);
             this.serializer = serializer;
         }
         

--- a/cs/remote/src/FASTER.server/FasterServer.cs
+++ b/cs/remote/src/FASTER.server/FasterServer.cs
@@ -120,30 +120,40 @@ namespace FASTER.server
 
         private void AcceptEventArg_Completed(object sender, SocketAsyncEventArgs e)
         {
-            do
+            try
             {
-                if (!HandleNewConnection(e)) break;
-                e.AcceptSocket = null;
-            } while (!servSocket.AcceptAsync(e));
+                do
+                {
+                    if (!HandleNewConnection(e)) break;
+                    e.AcceptSocket = null;
+                } while (!servSocket.AcceptAsync(e));
+            }
+            // socket disposed
+            catch (ObjectDisposedException) { }
         }
 
         private void DisposeActiveSessions()
         {
-            while (activeSessionCount > 0)
+            while (true)
             {
-                foreach (var kvp in activeSessions)
+                while (activeSessionCount > 0)
                 {
-                    var _session = kvp.Key;
-                    if (_session != null)
+                    foreach (var kvp in activeSessions)
                     {
-                        if (activeSessions.TryRemove(_session, out _))
+                        var _session = kvp.Key;
+                        if (_session != null)
                         {
-                            _session.Dispose();
-                            Interlocked.Decrement(ref activeSessionCount);
+                            if (activeSessions.TryRemove(_session, out _))
+                            {
+                                _session.Dispose();
+                                Interlocked.Decrement(ref activeSessionCount);
+                            }
                         }
                     }
+                    Thread.Yield();
                 }
-                Thread.Yield();
+                if (Interlocked.CompareExchange(ref activeSessionCount, int.MinValue, 0) == 0)
+                    break;
             }
         }
 
@@ -159,8 +169,7 @@ namespace FASTER.server
 
             if (connArgs.session == null)
             {
-                if (!CreateSession(e))
-                    return false;
+                return CreateSession(e);
             }
 
             connArgs.session.AddBytesRead(e.BytesTransferred);
@@ -171,9 +180,16 @@ namespace FASTER.server
 
         private unsafe bool CreateSession(SocketAsyncEventArgs e)
         {
-            var connArgs = (ConnectionArgs) e.UserToken;
+            var connArgs = (ConnectionArgs)e.UserToken;
 
-            if (e.BytesTransferred < 4) return false;
+            connArgs.bytesRead += e.BytesTransferred;
+
+            // We need at least 4 bytes to determine session
+            if (connArgs.bytesRead < 4)
+            {
+                e.SetBuffer(connArgs.bytesRead, e.Buffer.Length - connArgs.bytesRead);
+                return true;
+            }
 
             WireFormat protocol;
 
@@ -181,7 +197,11 @@ namespace FASTER.server
             // This results in a fourth byte value (little endian) > 127, denoting a non-ASCII wire format.
             if (e.Buffer[3] > 127)
             {
-                if (e.BytesTransferred < 4 + BatchHeader.Size) return false;
+                if (connArgs.bytesRead < 4 + BatchHeader.Size)
+                {
+                    e.SetBuffer(connArgs.bytesRead, e.Buffer.Length - connArgs.bytesRead);
+                    return true;
+                }
                 fixed (void* bh = &e.Buffer[4])
                     protocol = ((BatchHeader*)bh)->Protocol;
             }
@@ -192,21 +212,30 @@ namespace FASTER.server
 
             if (!sessionProviders.TryGetValue(protocol, out var provider))
             {
-                throw new FasterException($"Unsupported wire format {protocol}");
+                Console.WriteLine($"Unsupported incoming wire format {protocol}");
+                DisposeConnectionSession(e);
+                return false;
+            }
+
+            if (Interlocked.Increment(ref activeSessionCount) <= 0)
+            {
+                DisposeConnectionSession(e);
+                return false;
             }
 
             connArgs.session = provider.GetSession(protocol, connArgs.socket);
 
-            if (activeSessions.TryAdd(connArgs.session, default))
-                Interlocked.Increment(ref activeSessionCount);
-            else
-                throw new Exception("Unexpected: unable to add session to activeSessions");
+            activeSessions.TryAdd(connArgs.session, default);
 
             if (disposed)
             {
                 DisposeConnectionSession(e);
                 return false;
             }
+
+            connArgs.session.AddBytesRead(connArgs.bytesRead);
+            var _newHead = connArgs.session.TryConsumeMessages(e.Buffer);
+            e.SetBuffer(_newHead, e.Buffer.Length - _newHead);
             return true;
         }
 
@@ -237,8 +266,11 @@ namespace FASTER.server
                     if (!HandleReceiveCompletion(e)) break;
                 } while (!connArgs.socket.ReceiveAsync(e));
             }
-            // ignore session socket disposed due to server dispose
-            catch (ObjectDisposedException) { }
+            // socket disposed
+            catch (ObjectDisposedException)
+            {
+                DisposeConnectionSession(e);
+            }
         }
     }
 }

--- a/cs/remote/src/FASTER.server/ServerSessionBase.cs
+++ b/cs/remote/src/FASTER.server/ServerSessionBase.cs
@@ -94,13 +94,22 @@ namespace FASTER.server
             }
         }
 
-        
         /// <summary>
         /// Dispose
         /// </summary>
         public virtual void Dispose()
         {
             socket.Dispose();
+            if (responseObject.obj != null)
+                responseObject.Dispose();
+            messageManager.Dispose();
+        }
+
+        /// <summary>
+        /// Wait for ongoing outgoing calls to complete
+        /// </summary>
+        public virtual void CompleteSends()
+        {
             if (responseObject.obj != null)
                 responseObject.Dispose();
             messageManager.Dispose();

--- a/cs/remote/src/FASTER.server/SpanByteServerSerializer.cs
+++ b/cs/remote/src/FASTER.server/SpanByteServerSerializer.cs
@@ -73,7 +73,7 @@ namespace FASTER.server
         /// <inheritdoc />
         public ref SpanByteAndMemory AsRefOutput(byte* src, int length)
         {
-            *(int*)src = length - sizeof(int);
+            // *(int*)src = length - sizeof(int);
             output = SpanByteAndMemory.FromFixedSpan(new Span<byte>(src, length));
             return ref output;
         }

--- a/cs/src/core/VarLen/SpanByte.cs
+++ b/cs/src/core/VarLen/SpanByte.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -10,14 +11,19 @@ namespace FASTER.core
 {
     /// <summary>
     /// Represents a pinned variable length byte array that is viewable as a fixed (pinned) Span&lt;byte&gt;
-    /// Format: [4-byte (int) length of payload][payload bytes...]
+    /// Format: [4-byte (int) length of payload][[optional 8-byte metadata] payload bytes...]
+    /// First 4 bits of length are used as a mask for various properties, so max length is 256MB
     /// </summary>
     [StructLayout(LayoutKind.Explicit)]
     public unsafe struct SpanByte
     {
         // Byte #30 and #31 are used for read-only and lock respectively
-        const int kTypeBitMask = 1 << 29;
-        const int kHeaderMask = 7 << 29;
+        // Byte #29 is used to denote unserialized (1) or serialized (0) data 
+        const int kUnserializedBitMask = 1 << 29;
+        // Byte #28 is used to denote extra metadata present (1) or absent (0) in payload
+        const int kExtraMetadataBitMask = 1 << 28;
+        // Mask for header
+        const int kHeaderMask = 0xf << 28;
 
         /// <summary>
         /// Length of the payload
@@ -34,7 +40,7 @@ namespace FASTER.core
         internal IntPtr Pointer => payload;
 
         /// <summary>
-        /// Length of payload
+        /// Length of payload, including metadata if any
         /// </summary>
         public int Length
         {
@@ -43,15 +49,24 @@ namespace FASTER.core
         }
 
         /// <summary>
-        /// Format of structure
+        /// Length of payload, not including metadata if any
         /// </summary>
-        public bool Serialized => (length & kTypeBitMask) == 0;
+        public int LengthWithoutMetadata => (length & ~kHeaderMask) - MetadataSize;
 
         /// <summary>
-        /// Total serialized size in bytes, including header
+        /// Format of structure
         /// </summary>
-        public int TotalSize => Length + sizeof(int);
+        public bool Serialized => (length & kUnserializedBitMask) == 0;
 
+        /// <summary>
+        /// Total serialized size in bytes, including header and metadata if any
+        /// </summary>
+        public int TotalSize => sizeof(int) + Length;
+
+        /// <summary>
+        /// Size of metadata header, if any (returns 0 or 8)
+        /// </summary>
+        public int MetadataSize => (length & kExtraMetadataBitMask) >> (28 - 3);
 
         /// <summary>
         /// Constructor
@@ -60,8 +75,52 @@ namespace FASTER.core
         /// <param name="payload"></param>
         public SpanByte(int length, IntPtr payload)
         {
-            this.length = length | kTypeBitMask;
+            Debug.Assert(length <= ~kHeaderMask);
+            this.length = length | kUnserializedBitMask;
             this.payload = payload;
+        }
+
+        /// <summary>
+        /// Extra metadata header
+        /// </summary>
+        public long ExtraMetadata
+        {
+            get
+            {
+                if (Serialized)
+                    return MetadataSize > 0 ? *(long*)Unsafe.AsPointer(ref payload) : 0;
+                else
+                    return MetadataSize > 0 ? *(long*)payload : 0;
+            }
+            set
+            {
+                if (value > 0)
+                {
+                    length |= kExtraMetadataBitMask;
+                    Debug.Assert(Length > MetadataSize);
+                    if (Serialized)
+                        *(long*)Unsafe.AsPointer(ref payload) = value;
+                    else
+                        *(long*)payload = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Mark SpanByte as having 8-byte metadata in header of payload
+        /// </summary>
+        public void MarkExtraMetadata()
+        {
+            Debug.Assert(Length >= 8);
+            length |= kExtraMetadataBitMask;
+        }
+
+        /// <summary>
+        /// Unmark SpanByte as having 8-byte metadata in header of payload
+        /// </summary>
+        public void UnmarkExtraMetadata()
+        {
+            length &= ~kExtraMetadataBitMask;
         }
 
         /// <summary>
@@ -69,11 +128,11 @@ namespace FASTER.core
         /// </summary>
         public bool Invalid
         {
-            get { return ((length & kTypeBitMask) != 0) && payload == IntPtr.Zero; }
+            get { return ((length & kUnserializedBitMask) != 0) && payload == IntPtr.Zero; }
             set { 
                 if (value) 
                 { 
-                    length |= kTypeBitMask;
+                    length |= kUnserializedBitMask;
                     payload = IntPtr.Zero;
                 }
                 else
@@ -84,27 +143,51 @@ namespace FASTER.core
         }
 
         /// <summary>
-        /// Get Span&lt;byte&gt; for this SpanByte's payload
+        /// Get Span&lt;byte&gt; for this SpanByte's payload (excluding metadata if any)
         /// </summary>
         /// <returns></returns>
         public Span<byte> AsSpan()
         {
             if (Serialized)
-                return new Span<byte>(Unsafe.AsPointer(ref payload), Length);
+                return new Span<byte>(MetadataSize + (byte*)Unsafe.AsPointer(ref payload), Length - MetadataSize);
             else
-                return new Span<byte>((void*)payload, Length);
+                return new Span<byte>(MetadataSize + (byte*)payload, Length - MetadataSize);
         }
 
         /// <summary>
-        /// Get ReadOnlySpan&lt;byte&gt; for this SpanByte's payload
+        /// Get ReadOnlySpan&lt;byte&gt; for this SpanByte's payload (excluding metadata if any)
         /// </summary>
         /// <returns></returns>
         public ReadOnlySpan<byte> AsReadOnlySpan()
         {
             if (Serialized)
-                return new ReadOnlySpan<byte>(Unsafe.AsPointer(ref payload), Length);
+                return new ReadOnlySpan<byte>(MetadataSize + (byte*)Unsafe.AsPointer(ref payload), Length - MetadataSize);
             else
-                return new ReadOnlySpan<byte>((void*)payload, Length);
+                return new ReadOnlySpan<byte>(MetadataSize + (byte*)payload, Length - MetadataSize);
+        }
+
+        /// <summary>
+        /// Get Span&lt;byte&gt; for this SpanByte's payload (including metadata if any)
+        /// </summary>
+        /// <returns></returns>
+        public Span<byte> AsSpanWithMetadata()
+        {
+            if (Serialized)
+                return new Span<byte>((byte*)Unsafe.AsPointer(ref payload), Length);
+            else
+                return new Span<byte>((byte*)payload, Length);
+        }
+
+        /// <summary>
+        /// Get ReadOnlySpan&lt;byte&gt; for this SpanByte's payload (including metadata if any)
+        /// </summary>
+        /// <returns></returns>
+        public ReadOnlySpan<byte> AsReadOnlySpanWithMetadata()
+        {
+            if (Serialized)
+                return new ReadOnlySpan<byte>((byte*)Unsafe.AsPointer(ref payload), Length);
+            else
+                return new ReadOnlySpan<byte>((byte*)payload, Length);
         }
 
         /// <summary>
@@ -115,7 +198,7 @@ namespace FASTER.core
         public SpanByte Deserialize()
         {
             if (!Serialized) return this;
-            return new SpanByte(Length, (IntPtr)Unsafe.AsPointer(ref payload));
+            return new SpanByte(Length - MetadataSize, (IntPtr)(MetadataSize + (byte*)Unsafe.AsPointer(ref payload)));
         }
 
         /// <summary>
@@ -125,6 +208,8 @@ namespace FASTER.core
         /// <returns></returns>
         public static ref SpanByte Reinterpret(Span<byte> span)
         {
+            Debug.Assert(span.Length - sizeof(int) <= ~kHeaderMask);
+
             fixed (byte* ptr = span)
             {
                 *(int*)ptr = span.Length - sizeof(int);
@@ -254,7 +339,8 @@ namespace FASTER.core
         /// <param name="dst"></param>
         public void CopyTo(ref SpanByte dst)
         {
-            AsReadOnlySpan().CopyTo(dst.AsSpan());
+            dst.ExtraMetadata = ExtraMetadata;
+            AsReadOnlySpan().CopyTo(dst.AsSpan());            
         }
 
         /// <summary>
@@ -315,7 +401,9 @@ namespace FASTER.core
                     var span = dst.SpanByte.AsSpan();
                     fixed (byte* ptr = span)
                         *(int*)ptr = Length;
-                    AsReadOnlySpan().CopyTo(span.Slice(sizeof(int)));
+                    dst.SpanByte.ExtraMetadata = ExtraMetadata;
+
+                    AsReadOnlySpan().CopyTo(span.Slice(sizeof(int) + MetadataSize));
                     return;
                 }
                 dst.ConvertToHeap();
@@ -325,7 +413,8 @@ namespace FASTER.core
             dst.Length = TotalSize;
             fixed (byte* ptr = dst.Memory.Memory.Span)
                 *(int*)ptr = Length;
-            AsReadOnlySpan().CopyTo(dst.Memory.Memory.Span.Slice(sizeof(int)));
+            dst.SpanByte.ExtraMetadata = ExtraMetadata;
+            AsReadOnlySpan().CopyTo(dst.Memory.Memory.Span.Slice(sizeof(int) + MetadataSize));
         }
 
         /// <summary>
@@ -334,13 +423,14 @@ namespace FASTER.core
         /// <param name="destination"></param>
         public void CopyTo(byte* destination)
         {
-            *(int*)destination = Length;
             if (Serialized)
             {
+                *(int*)destination = length;
                 Buffer.MemoryCopy(Unsafe.AsPointer(ref payload), destination + sizeof(int), Length, Length);
             }
             else
             {
+                *(int*)destination = length & ~kUnserializedBitMask;
                 Buffer.MemoryCopy((void*)payload, destination + sizeof(int), Length, Length);
             }
         }

--- a/cs/src/core/VarLen/SpanByteComparer.cs
+++ b/cs/src/core/VarLen/SpanByteComparer.cs
@@ -18,7 +18,7 @@ namespace FASTER.core
             if (spanByte.Serialized)
             {
                 byte* ptr = (byte*)Unsafe.AsPointer(ref spanByte);
-                return Utility.HashBytes(ptr + sizeof(int), *(int*)ptr);
+                return Utility.HashBytes(ptr + sizeof(int), spanByte.Length);
             }
             else
             {
@@ -27,11 +27,12 @@ namespace FASTER.core
             }
         }
 
-        /// <inheritdoc />
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            /// <inheritdoc />
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe bool Equals(ref SpanByte k1, ref SpanByte k2)
         {
-            return k1.AsReadOnlySpan().SequenceEqual(k2.AsReadOnlySpan());
+            return k1.AsReadOnlySpanWithMetadata().SequenceEqual(k2.AsReadOnlySpanWithMetadata())
+                && (k1.MetadataSize == k2.MetadataSize);
         }
     }
 }


### PR DESCRIPTION
* `SpanByte` now supports optional extra metadata in the payload (as first 8 bytes of payload), uses 1 bit in `SpanByte` header to indicate that metadata is present in the payload. This makes its max size as 256MB
* Read payload without metadata using `SpanByte.AsSpan()`
* Read payload with metadata using `SpanByte.AsSpanWithMetadata()`
* Read length of payload with metadata, using `SpanByte.Length`
* Read length of payload excluding metadata, using `SpanByte.LengthWithoutMetadata`
* Get metadata size (0 or 8 bytes) using `SpanByte.MetadataSize`
* Get or set metadata content using `SpanByte.ExtraMetadata`
* Mark existing `SpanByte` as having/not having metadata via `SpanByte.MarkExtraMetadata()` and `SpanByte.UnmarkExtraMetadata()`

This change to `SpanByte` is backwards compatible with the prior version.