### PR TITLE
MemoryPool-based override for FasterLog.ReadAsync()

### DIFF
--- a/cs/test/LogReadAsyncTests.cs
+++ b/cs/test/LogReadAsyncTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Buffers;
 using System.Threading;
 using FASTER.core;
 using NUnit.Framework;
@@ -120,6 +121,16 @@ namespace FASTER.test
                     Assert.IsTrue(foundFlagged == (byte)entryFlag, $"Fail reading data - Found Flagged Entry:{foundFlagged}  Expected Flagged entry:{entryFlag}");
                     Assert.IsTrue(foundEntry == 1, $"Fail reading data - Found Normal Entry:{foundEntry} Expected Value: 1");
                     Assert.IsTrue(foundTotal == entryLength, $"Fail reading data - Found Total:{foundTotal}  Expected Total: {entryLength}");
+
+                    // Read one entry as IMemoryOwner and verify
+                    var recordMemoryOwner = log.ReadAsync(log.BeginAddress, MemoryPool<byte>.Shared, 104, cts);
+                    var foundFlaggedMem = recordMemoryOwner.Result.Item1.Memory.Span[0];   // 15
+                    var foundEntryMem = recordMemoryOwner.Result.Item1.Memory.Span[1];  // 1
+                    var foundTotalMem = recordMemoryOwner.Result.Item2;
+
+                    Assert.IsTrue(foundFlagged == foundFlaggedMem, $"MemoryPool-based ReadAsync result does not match that of the byte array one. value: {foundFlaggedMem} expected: {foundFlagged}");
+                    Assert.IsTrue(foundEntry == foundEntryMem, $"MemoryPool-based ReadAsync result does not match that of the byte array one. value: {foundEntryMem} expected: {foundEntry}");
+                    Assert.IsTrue(foundTotal == foundTotalMem, $"MemoryPool-based ReadAsync result does not match that of the byte array one. value: {foundTotalMem} expected: {foundTotal}");
 
                     break;
                 default:


### PR DESCRIPTION
returns an IMemoryOwner<byte> rented from a memorypool rather than a byte array.