### PR TITLE
Fix typo in 25-fasterkv-recovery.md.

### DIFF
--- a/docs/_docs/25-fasterkv-recovery.md
+++ b/docs/_docs/25-fasterkv-recovery.md
@@ -138,7 +138,7 @@ public class PersistenceExample
         long key = 1, input = 10;
         while (true)
         {
-            key = (seq % 1L << 20);
+            key = seq % (1L << 20);
             session.RMW(ref key, ref input, Empty.Default, seq++);
         }
     }
@@ -151,7 +151,7 @@ public class PersistenceExample
         long key = 1, input = 10;
         while (true)
         {
-            key = (seq % 1L << 20);
+            key = seq % (1L << 20);
             session.RMW(ref key, ref input, Empty.Default, seq++);
         }
     }


### PR DESCRIPTION
`(seq % 1L << 20)` = 0 for any `seq`, should be either `seq % (1L << 20)` or `seq % fht.IndexSize`.