### PR TITLE
various changes from indexing work

### DIFF
--- a/cs/src/core/Allocator/IFasterScanIterator.cs
+++ b/cs/src/core/Allocator/IFasterScanIterator.cs
@@ -70,5 +70,15 @@ namespace FASTER.core
         /// Next address
         /// </summary>
         long NextAddress { get; }
+
+        /// <summary>
+        /// The starting address of the scan
+        /// </summary>
+        long BeginAddress { get; }
+
+        /// <summary>
+        /// The ending address of the scan
+        /// </summary>
+        long EndAddress { get; }
     }
 }

--- a/cs/src/core/Allocator/MemoryPageScanIterator.cs
+++ b/cs/src/core/Allocator/MemoryPageScanIterator.cs
@@ -16,7 +16,7 @@ namespace FASTER.core
     class MemoryPageScanIterator<Key, Value> : IFasterScanIterator<Key, Value>
     {
         readonly Record<Key, Value>[] page;
-        readonly int end;
+        readonly int start, end;
         int offset;
         
 
@@ -25,12 +25,17 @@ namespace FASTER.core
             this.page = new Record<Key, Value>[page.Length];
             Array.Copy(page, start, this.page, start, end - start);
             offset = start - 1;
+            this.start = start;
             this.end = end;
         }
 
         public long CurrentAddress => offset;
 
         public long NextAddress => offset + 1;
+
+        public long BeginAddress => start;
+
+        public long EndAddress => end;
 
         public void Dispose()
         {

--- a/cs/src/core/Allocator/ScanIteratorBase.cs
+++ b/cs/src/core/Allocator/ScanIteratorBase.cs
@@ -53,6 +53,16 @@ namespace FASTER.core
         public long NextAddress => nextAddress;
 
         /// <summary>
+        /// The starting address of the scan
+        /// </summary>
+        public long BeginAddress => beginAddress;
+
+        /// <summary>
+        /// The ending address of the scan
+        /// </summary>
+        public long EndAddress => endAddress;
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="beginAddress"></param>

--- a/cs/src/core/Allocator/WorkQueueLIFO.cs
+++ b/cs/src/core/Allocator/WorkQueueLIFO.cs
@@ -54,7 +54,7 @@ namespace FASTER.core
 
         private void ProcessQueue()
         {
-            // Process items in qork queue
+            // Process items in work queue
             while (true)
             {
                 while (_queue.TryPop(out var workItem))

--- a/cs/src/core/Index/Common/CompletedOutput.cs
+++ b/cs/src/core/Index/Common/CompletedOutput.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Collections.Generic;
 
 namespace FASTER.core
 {
@@ -94,7 +93,7 @@ namespace FASTER.core
         public ref TInput Input => ref inputContainer.Get();
 
         /// <summary>
-        /// The output for this pending operation.
+        /// The output for this pending operation. It is the caller's responsibility to dispose this if necessary; <see cref="Dispose()"/> will not try to dispose this member.
         /// </summary>
         public TOutput Output;
 

--- a/cs/src/core/Index/Common/HeapContainer.cs
+++ b/cs/src/core/Index/Common/HeapContainer.cs
@@ -12,9 +12,8 @@ namespace FASTER.core
     public interface IHeapContainer<T> : IDisposable
     {
         /// <summary>
-        /// Get object
+        /// Get a reference to the contained object
         /// </summary>
-        /// <returns></returns>
         ref T Get();
     }
 

--- a/cs/src/core/Index/FASTER/FASTERIterator.cs
+++ b/cs/src/core/Index/FASTER/FASTERIterator.cs
@@ -85,6 +85,10 @@ namespace FASTER.core
 
         public long NextAddress => enumerationPhase == 0 ? iter1.NextAddress : iter2.NextAddress;
 
+        public long BeginAddress => enumerationPhase == 0 ? iter1.BeginAddress : iter2.BeginAddress;
+
+        public long EndAddress => enumerationPhase == 0 ? iter1.EndAddress : iter2.EndAddress;
+
         public void Dispose()
         {
             iter1?.Dispose();

--- a/cs/src/core/Index/Interfaces/IFasterSession.cs
+++ b/cs/src/core/Index/Interfaces/IFasterSession.cs
@@ -1,4 +1,7 @@
-﻿namespace FASTER.core
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace FASTER.core
 {
     /// <summary>
     /// Provides thread management and callback to checkpoint completion (called state machine).

--- a/cs/src/core/Index/Recovery/ICheckpointManager.cs
+++ b/cs/src/core/Index/Recovery/ICheckpointManager.cs
@@ -82,7 +82,7 @@ namespace FASTER.core
         /// <param name="scanDelta"> whether or not to scan through the delta log to acquire latest entry</param>
         /// <param name="recoverTo"> version upper bound to scan for in the delta log. Function will return the largest version metadata no greater than the given version.</param>
         /// <returns>Metadata, or null if invalid</returns>
-        byte[] GetLogCheckpointMetadata(Guid logToken, DeltaLog deltaLog, bool scanDelta, long recoverTo);
+        byte[] GetLogCheckpointMetadata(Guid logToken, DeltaLog deltaLog, bool scanDelta = false, long recoverTo = -1);
 
         /// <summary>
         /// Get list of index checkpoint tokens, in order of usage preference

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -304,6 +304,7 @@ namespace FASTER.core
             // Recover session information
             hlog.RecoveryReset(tailAddress, headAddress, recoveredHLCInfo.info.beginAddress, readOnlyAddress);
             _recoveredSessions = recoveredHLCInfo.info.continueTokens;
+
             checkpointManager.OnRecovery(recoveredICInfo.info.token, recoveredHLCInfo.info.guid);
             recoveredHLCInfo.Dispose();
         }
@@ -348,6 +349,7 @@ namespace FASTER.core
             hlog.RecoveryReset(tailAddress, headAddress, recoveredHLCInfo.info.beginAddress, readOnlyAddress);
             _recoveredSessions = recoveredHLCInfo.info.continueTokens;
 
+            checkpointManager.OnRecovery(recoveredICInfo.info.token, recoveredHLCInfo.info.guid);
             recoveredHLCInfo.Dispose();
         }
 

--- a/cs/test/LockTests.cs
+++ b/cs/test/LockTests.cs
@@ -15,11 +15,6 @@ namespace FASTER.test
     {
         internal class Functions : AdvancedSimpleFunctions<int, int>
         {
-            public override void ConcurrentReader(ref int key, ref int input, ref int value, ref int dst, ref RecordInfo recordInfo, long address)
-            {
-                dst = value;
-            }
-
             bool Increment(ref int dst)
             {
                 ++dst;

--- a/cs/test/ObjectTestTypes.cs
+++ b/cs/test/ObjectTestTypes.cs
@@ -230,7 +230,6 @@ namespace FASTER.test
         {
             if (dst == null)
                 dst = new MyOutput();
-
             dst.value = value;
         }
 
@@ -288,7 +287,6 @@ namespace FASTER.test
 
         public MyLargeValue()
         {
-
         }
 
         public MyLargeValue(int size)

--- a/cs/test/RecoveryTestTypes.cs
+++ b/cs/test/RecoveryTestTypes.cs
@@ -13,6 +13,8 @@ namespace FASTER.test.recovery.sumstore
         public long GetHashCode64(ref AdId key) => Utility.GetHashCode(key.adId);
 
         public bool Equals(ref AdId k1, ref AdId k2) => k1.adId == k2.adId;
+
+        public override string ToString() => adId.ToString();
     }
 
     public struct AdInput

--- a/cs/test/SimpleRecoveryTest.cs
+++ b/cs/test/SimpleRecoveryTest.cs
@@ -72,7 +72,7 @@ namespace FASTER.test.recovery.sumstore.simple
         {
             checkpointManager = new DeviceLogCommitCheckpointManager(
                 new LocalStorageNamedDeviceFactory(),
-                new DefaultCheckpointNamingScheme(TestUtils.MethodTestDir));
+                new DefaultCheckpointNamingScheme($"{TestUtils.MethodTestDir}/chkpt"));
             await SimpleRecoveryTest1_Worker(checkpointType, isAsync, testCommitCookie);
             checkpointManager.PurgeAll();
         }


### PR DESCRIPTION
- Add BeginAddress and EndAddress to scan iterators
- Allow null deltaFileDevice in HybridLogCheckpointInfo.Recover
- Rename FoldOverSnapshot to useFoldOverCheckpoint
- Make TakeHybridLogCheckpoint overload call through to overload to avoid duplication
- Add default values to new scanDelta and recoverTo arguments
- Add missing checkpointManager.OnRecovery call to IntenralRecoverAsync
- Shorten a test directory name
- Fix some comments