### PR TITLE
[C#] Checkpoint, Recovery, RecordInfo updates

### DIFF
--- a/cs/benchmark/FasterSpanByteYcsbBenchmark.cs
+++ b/cs/benchmark/FasterSpanByteYcsbBenchmark.cs
@@ -71,7 +71,7 @@ namespace FASTER.benchmark
             for (int i = 0; i < 8; i++)
                 input_[i].value = i;
 
-            device = Devices.CreateLogDevice(TestLoader.DevicePath, preallocateFile: true, deleteOnClose: !testLoader.CheckpointRecoverStore, useIoCompletionPort: true);
+            device = Devices.CreateLogDevice(TestLoader.DevicePath, preallocateFile: true, deleteOnClose: !testLoader.RecoverMode, useIoCompletionPort: true);
 
             if (testLoader.Options.UseSmallMemoryLog)
                 store = new FasterKV<SpanByte, SpanByte>

--- a/cs/benchmark/FasterSpanByteYcsbBenchmark.cs
+++ b/cs/benchmark/FasterSpanByteYcsbBenchmark.cs
@@ -71,7 +71,7 @@ namespace FASTER.benchmark
             for (int i = 0; i < 8; i++)
                 input_[i].value = i;
 
-            device = Devices.CreateLogDevice(TestLoader.DevicePath, preallocateFile: true, deleteOnClose: true);
+            device = Devices.CreateLogDevice(TestLoader.DevicePath, preallocateFile: true, deleteOnClose: !testLoader.CheckpointRecoverStore, useIoCompletionPort: true);
 
             if (testLoader.Options.UseSmallMemoryLog)
                 store = new FasterKV<SpanByte, SpanByte>

--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -68,7 +68,7 @@ namespace FASTER.benchmark
             for (int i = 0; i < 8; i++)
                 input_[i].value = i;
 
-            device = Devices.CreateLogDevice(TestLoader.DevicePath, preallocateFile: true, deleteOnClose: !testLoader.CheckpointRecoverStore, useIoCompletionPort: true);
+            device = Devices.CreateLogDevice(TestLoader.DevicePath, preallocateFile: true, deleteOnClose: !testLoader.RecoverMode, useIoCompletionPort: true);
 
             if (testLoader.Options.ThreadCount >= 16)
                 device.ThrottleLimit = testLoader.Options.ThreadCount * 12;

--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -68,7 +68,7 @@ namespace FASTER.benchmark
             for (int i = 0; i < 8; i++)
                 input_[i].value = i;
 
-            device = Devices.CreateLogDevice(TestLoader.DevicePath, preallocateFile: true, deleteOnClose: true, useIoCompletionPort: true);
+            device = Devices.CreateLogDevice(TestLoader.DevicePath, preallocateFile: true, deleteOnClose: !testLoader.CheckpointRecoverStore, useIoCompletionPort: true);
 
             if (testLoader.Options.ThreadCount >= 16)
                 device.ThrottleLimit = testLoader.Options.ThreadCount * 12;

--- a/cs/benchmark/Program.cs
+++ b/cs/benchmark/Program.cs
@@ -12,8 +12,8 @@ namespace FASTER.benchmark
 
         public static void Main(string[] args)
         {
-            TestLoader testLoader = new();
-            if (!testLoader.Parse(args))
+            TestLoader testLoader = new(args);
+            if (testLoader.error)
                 return;
 
             TestStats testStats = new(testLoader.Options);

--- a/cs/benchmark/TestLoader.cs
+++ b/cs/benchmark/TestLoader.cs
@@ -19,27 +19,29 @@ namespace FASTER.benchmark
 
     class TestLoader
     {
-        internal Options Options;
-
-        internal BenchmarkType BenchmarkType;
-        internal LockImpl LockImpl;
-        internal string Distribution;
-
+        internal readonly Options Options;
+        internal readonly string Distribution;
         internal Key[] init_keys = default;
         internal Key[] txn_keys = default;
         internal KeySpanByte[] init_span_keys = default;
         internal KeySpanByte[] txn_span_keys = default;
 
-        internal long InitCount;
-        internal long TxnCount;
-        internal int MaxKey;
+        internal readonly BenchmarkType BenchmarkType;
+        internal readonly LockImpl LockImpl;
+        internal readonly long InitCount;
+        internal readonly long TxnCount;
+        internal readonly int MaxKey;
+        internal readonly bool RecoverMode;
+        internal readonly bool error;
 
-        internal bool Parse(string[] args)
+
+        internal TestLoader(string[] args)
         {
+            error = true;
             ParserResult<Options> result = Parser.Default.ParseArguments<Options>(args);
             if (result.Tag == ParserResultType.NotParsed)
             {
-                return false;
+                return;
             }
             Options = result.MapResult(o => o, xs => new Options());
 
@@ -52,33 +54,34 @@ namespace FASTER.benchmark
 
             this.BenchmarkType = (BenchmarkType)Options.Benchmark;
             if (!verifyOption(Enum.IsDefined(typeof(BenchmarkType), this.BenchmarkType), "Benchmark"))
-                return false;
+                return;
 
             if (!verifyOption(Options.NumaStyle >= 0 && Options.NumaStyle <= 1, "NumaStyle"))
-                return false;
+                return;
 
             this.LockImpl = (LockImpl)Options.LockImpl;
             if (!verifyOption(Enum.IsDefined(typeof(LockImpl), this.LockImpl), "Lock Implementation"))
-                return false;
+                return;
 
             if (!verifyOption(Options.IterationCount > 0, "Iteration Count"))
-                return false;
+                return;
 
             if (!verifyOption(Options.ReadPercent >= -1 && Options.ReadPercent <= 100, "Read Percent"))
-                return false;
+                return;
 
             this.Distribution = Options.DistributionName.ToLower();
             if (!verifyOption(this.Distribution == YcsbConstants.UniformDist || this.Distribution == YcsbConstants.ZipfDist, "Distribution"))
-                return false;
+                return;
 
             if (!verifyOption(this.Options.RunSeconds >= 0, "RunSeconds"))
-                return false;
+                return;
 
             this.InitCount = this.Options.UseSmallData ? 2500480 : 250000000;
             this.TxnCount = this.Options.UseSmallData ? 10000000 : 1000000000;
             this.MaxKey = this.Options.UseSmallData ? 1 << 22 : 1 << 28;
+            this.RecoverMode = Options.BackupAndRestore && Options.PeriodicCheckpointMilliseconds <= 0;
 
-            return true;
+            error = false;
         }
 
         internal void LoadData()
@@ -330,14 +333,10 @@ namespace FASTER.benchmark
 
         internal string BackupPath => $"{DataPath}/{this.Distribution}_{(this.Options.UseSyntheticData ? "synthetic" : "ycsb")}_{(this.Options.UseSmallData ? "2.5M_10M" : "250M_1000M")}";
 
-
-        internal bool CheckpointRecoverStore
-            => Options.BackupAndRestore && Options.PeriodicCheckpointMilliseconds <= 0;
-
         internal bool MaybeRecoverStore<K, V>(FasterKV<K, V> store)
         {
             // Recover database for fast benchmark repeat runs.
-            if (CheckpointRecoverStore)
+            if (RecoverMode)
             {
                 if (this.Options.UseSmallData)
                 {
@@ -366,7 +365,7 @@ namespace FASTER.benchmark
         internal void MaybeCheckpointStore<K, V>(FasterKV<K, V> store)
         {
             // Checkpoint database for fast benchmark repeat runs.
-            if (CheckpointRecoverStore)
+            if (RecoverMode)
             {
                 Console.WriteLine($"Checkpointing FasterKV to {this.BackupPath} for fast restart");
                 var sw = Stopwatch.StartNew();

--- a/cs/benchmark/TestLoader.cs
+++ b/cs/benchmark/TestLoader.cs
@@ -10,8 +10,6 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 
-#pragma warning disable CS0162 // Unreachable code detected -- when switching on YcsbConstants 
-
 namespace FASTER.benchmark
 {
     internal interface IKeySetter<TKey>
@@ -373,7 +371,7 @@ namespace FASTER.benchmark
                 Console.WriteLine($"Checkpointing FasterKV to {this.BackupPath} for fast restart");
                 var sw = Stopwatch.StartNew();
                 store.TakeFullCheckpoint(out _, CheckpointType.Snapshot);
-                store.CompleteCheckpointAsync().GetAwaiter().GetResult();
+                store.CompleteCheckpointAsync().AsTask().GetAwaiter().GetResult();
                 sw.Stop();
                 Console.WriteLine($"  Completed checkpoint in {(double)sw.ElapsedMilliseconds / 1000:N3} seconds");
             }

--- a/cs/benchmark/TestLoader.cs
+++ b/cs/benchmark/TestLoader.cs
@@ -332,10 +332,14 @@ namespace FASTER.benchmark
 
         internal string BackupPath => $"{DataPath}/{this.Distribution}_{(this.Options.UseSyntheticData ? "synthetic" : "ycsb")}_{(this.Options.UseSmallData ? "2.5M_10M" : "250M_1000M")}";
 
+
+        internal bool CheckpointRecoverStore
+            => Options.BackupAndRestore && Options.PeriodicCheckpointMilliseconds <= 0;
+
         internal bool MaybeRecoverStore<K, V>(FasterKV<K, V> store)
         {
             // Recover database for fast benchmark repeat runs.
-            if (this.Options.BackupAndRestore && this.Options.PeriodicCheckpointMilliseconds <= 0)
+            if (CheckpointRecoverStore)
             {
                 if (this.Options.UseSmallData)
                 {
@@ -364,7 +368,7 @@ namespace FASTER.benchmark
         internal void MaybeCheckpointStore<K, V>(FasterKV<K, V> store)
         {
             // Checkpoint database for fast benchmark repeat runs.
-            if (this.Options.BackupAndRestore && this.Options.PeriodicCheckpointMilliseconds <= 0)
+            if (CheckpointRecoverStore)
             {
                 Console.WriteLine($"Checkpointing FasterKV to {this.BackupPath} for fast restart");
                 var sw = Stopwatch.StartNew();

--- a/cs/benchmark/YcsbConstants.cs
+++ b/cs/benchmark/YcsbConstants.cs
@@ -5,14 +5,14 @@ using FASTER.core;
 
 namespace FASTER.benchmark
 {
-    enum BenchmarkType : int
+    enum BenchmarkType : byte
     {
         Ycsb,
         SpanByte,
         ConcurrentDictionaryYcsb
     };
 
-    enum LockImpl : int
+    enum LockImpl : byte
     {
         None,
         RecordInfo

--- a/cs/samples/ReadAddress/VersionedReadApp.cs
+++ b/cs/samples/ReadAddress/VersionedReadApp.cs
@@ -152,7 +152,6 @@ namespace ReadAddress
             var input = default(Value);
             var key = new Key(keyValue);
             RecordMetadata recordMetadata = default;
-            int version = int.MaxValue;
             for (int lap = 9; /* tested in loop */; --lap)
             {
                 var status = session.Read(ref key, ref input, ref output, ref recordMetadata, serialNo: maxLap + 1);
@@ -169,7 +168,7 @@ namespace ReadAddress
                     }
                 }
 
-                if (!ProcessRecord(store, status, recordMetadata.RecordInfo, lap, ref output, ref version))
+                if (!ProcessRecord(store, status, recordMetadata.RecordInfo, lap, ref output))
                     break;
             }
         }
@@ -184,27 +183,24 @@ namespace ReadAddress
             var input = default(Value);
             var key = new Key(keyValue);
             RecordMetadata recordMetadata = default;
-            int version = int.MaxValue;
             for (int lap = 9; /* tested in loop */; --lap)
             {
                 var readAsyncResult = await session.ReadAsync(ref key, ref input, recordMetadata.RecordInfo.PreviousAddress, default, serialNo: maxLap + 1, cancellationToken: cancellationToken);
                 cancellationToken.ThrowIfCancellationRequested();
                 var (status, output) = readAsyncResult.Complete(out recordMetadata);
-                if (!ProcessRecord(store, status, recordMetadata.RecordInfo, lap, ref output, ref version))
+                if (!ProcessRecord(store, status, recordMetadata.RecordInfo, lap, ref output))
                     break;
             }
         }
 
-        private static bool ProcessRecord(FasterKV<Key, Value> store, Status status, RecordInfo recordInfo, int lap, ref Value output, ref int previousVersion)
+        private static bool ProcessRecord(FasterKV<Key, Value> store, Status status, RecordInfo recordInfo, int lap, ref Value output)
         {
             Debug.Assert((status == Status.NOTFOUND) == recordInfo.Tombstone);
             Debug.Assert((lap == deleteLap) == recordInfo.Tombstone);
             var value = recordInfo.Tombstone ? "<deleted>" : output.value.ToString();
-            Debug.Assert(previousVersion >= recordInfo.Version);
-            Console.WriteLine($"  {value}; Version = {recordInfo.Version}; PrevAddress: {recordInfo.PreviousAddress}");
+            Console.WriteLine($"  {value}; PrevAddress: {recordInfo.PreviousAddress}");
 
             // Check for end of loop
-            previousVersion = recordInfo.Version;
             return recordInfo.PreviousAddress >= store.Log.BeginAddress;
         }
     }

--- a/cs/samples/ReadAddress/VersionedReadApp.cs
+++ b/cs/samples/ReadAddress/VersionedReadApp.cs
@@ -110,7 +110,7 @@ namespace ReadAddress
             using var s = store.For(new Functions()).NewSession<Functions>();
             Console.WriteLine($"Writing {numKeys} keys to FASTER", numKeys);
 
-            Stopwatch sw = new Stopwatch();
+            Stopwatch sw = new();
             sw.Start();
             var prevLap = 0;
             for (int ii = 0; ii < numKeys; ii++)

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -23,7 +23,7 @@ namespace FASTER.core
         [FieldOffset(8)]
         public long LastClosedUntilAddress;
         [FieldOffset(16)]
-        public int Dirty;
+        public long Dirty;
     }
 
     [StructLayout(LayoutKind.Explicit)]
@@ -413,7 +413,7 @@ namespace FASTER.core
         /// <param name="prevEndAddress"></param>
         /// <param name="version"></param>
         /// <param name="deltaLog"></param>
-        internal unsafe virtual void AsyncFlushDeltaToDevice(long startAddress, long endAddress, long prevEndAddress, int version, DeltaLog deltaLog)
+        internal unsafe virtual void AsyncFlushDeltaToDevice(long startAddress, long endAddress, long prevEndAddress, long version, DeltaLog deltaLog)
         {
             long startPage = GetPage(startAddress);
             long endPage = GetPage(endAddress);
@@ -530,7 +530,7 @@ namespace FASTER.core
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void MarkPage(long logicalAddress, int version)
+        internal void MarkPage(long logicalAddress, long version)
         {
             var offset = (logicalAddress >> LogPageSizeBits) % BufferSize;
             if (PageStatusIndicator[offset].Dirty < version)
@@ -538,7 +538,7 @@ namespace FASTER.core
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void MarkPageAtomic(long logicalAddress, int version)
+        internal void MarkPageAtomic(long logicalAddress, long version)
         {
             var offset = (logicalAddress >> LogPageSizeBits) % BufferSize;
             Utility.MonotonicUpdate(ref PageStatusIndicator[offset].Dirty, version, out _);

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -1052,7 +1052,7 @@ namespace FASTER.core
             }
         }
 
-        internal override void AsyncFlushDeltaToDevice(long startAddress, long endAddress, long prevEndAddress, int version, DeltaLog deltaLog)
+        internal override void AsyncFlushDeltaToDevice(long startAddress, long endAddress, long prevEndAddress, long version, DeltaLog deltaLog)
         {
             throw new FasterException("Incremental snapshots not supported with generic allocator");
         }

--- a/cs/src/core/Async/CompletePendingAsync.cs
+++ b/cs/src/core/Async/CompletePendingAsync.cs
@@ -24,7 +24,7 @@ namespace FASTER.core
             #region Previous pending requests
             if (!RelaxedCPR)
             {
-                if (currentCtx.phase == Phase.IN_PROGRESS || currentCtx.phase == Phase.WAIT_PENDING)
+                if (currentCtx.phase == Phase.IN_PROGRESS)
                 {
                     if (currentCtx.prevCtx.SyncIoPendingCount != 0)
                         await currentCtx.prevCtx.readyResponses.WaitForEntryAsync(token).ConfigureAwait(false);
@@ -52,7 +52,7 @@ namespace FASTER.core
                 #region Previous pending requests
                 if (!RelaxedCPR)
                 {
-                    if (currentCtx.phase == Phase.IN_PROGRESS || currentCtx.phase == Phase.WAIT_PENDING)
+                    if (currentCtx.phase == Phase.IN_PROGRESS)
                     {
                         fasterSession.UnsafeResumeThread();
                         try

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -1108,7 +1108,7 @@ namespace FASTER.core
             fht.epoch.Suspend();
         }
 
-        void IClientSession.AtomicSwitch(int version)
+        void IClientSession.AtomicSwitch(long version)
         {
             fht.AtomicSwitch(ctx, ctx.prevCtx, version, fht._hybridLogCheckpoint.info.checkpointTokens);
         }

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -1198,7 +1198,6 @@ namespace FASTER.core
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private void PostSingleWriterNoLock(ref Key key, ref Input input, ref Value src, ref Value dst, ref Output output, ref RecordInfo recordInfo, long address)
             {
-                recordInfo.Version = _clientSession.ctx.version;
                 _clientSession.functions.PostSingleWriter(ref key, ref input, ref src, ref dst, ref output, ref recordInfo, address);
             }
 
@@ -1225,7 +1224,7 @@ namespace FASTER.core
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private bool ConcurrentWriterNoLock(ref Key key, ref Input input, ref Value src, ref Value dst, ref Output output, ref RecordInfo recordInfo, long address)
             {
-                recordInfo.Version = _clientSession.ctx.version;
+                recordInfo.SetDirty();
                 // Note: KeyIndexes do not need notification of in-place updates because the key does not change.
                 return _clientSession.functions.ConcurrentWriter(ref key, ref input, ref src, ref dst, ref output, ref recordInfo, address);
             }
@@ -1287,7 +1286,6 @@ namespace FASTER.core
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private void PostInitialUpdaterNoLock(ref Key key, ref Input input, ref Value value, ref Output output, ref RecordInfo recordInfo, long address)
             {
-                recordInfo.Version = _clientSession.ctx.version;
                 _clientSession.functions.PostInitialUpdater(ref key, ref input, ref value, ref output, ref recordInfo, address);
             }
 
@@ -1343,7 +1341,6 @@ namespace FASTER.core
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private bool PostCopyUpdaterNoLock(ref Key key, ref Input input, ref Output output, ref Value oldValue, ref Value newValue, ref RecordInfo recordInfo, long address)
             {
-                recordInfo.Version = _clientSession.ctx.version;
                 return _clientSession.functions.PostCopyUpdater(ref key, ref input, ref oldValue, ref newValue, ref output, ref recordInfo, address);
             }
 
@@ -1373,7 +1370,7 @@ namespace FASTER.core
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private bool InPlaceUpdaterNoLock(ref Key key, ref Input input, ref Output output, ref Value value, ref RecordInfo recordInfo, long address)
             {
-                recordInfo.Version = _clientSession.ctx.version;
+                recordInfo.SetDirty();
                 // Note: KeyIndexes do not need notification of in-place updates because the key does not change.
                 return _clientSession.functions.InPlaceUpdater(ref key, ref input, ref value, ref output, ref recordInfo, address);
             }
@@ -1406,7 +1403,6 @@ namespace FASTER.core
                     return;
 
                 // There is no value to lock here, so we take a RecordInfo lock in InternalDelete and release it here.
-                recordInfo.Version = _clientSession.ctx.version;
                 _clientSession.functions.PostSingleDeleter(ref key, ref recordInfo, address);
                 if (this.SupportsLocking)
                     recordInfo.UnlockExclusive();
@@ -1421,8 +1417,8 @@ namespace FASTER.core
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private bool ConcurrentDeleterNoLock(ref Key key, ref Value value, ref RecordInfo recordInfo, long address)
             {
-                recordInfo.Version = _clientSession.ctx.version;
-                recordInfo.Tombstone = true;
+                recordInfo.SetDirty();
+                recordInfo.SetTombstone();
                 return _clientSession.functions.ConcurrentDeleter(ref key, ref value, ref recordInfo, address);
             }
 

--- a/cs/src/core/ClientSession/IClientSession.cs
+++ b/cs/src/core/ClientSession/IClientSession.cs
@@ -5,7 +5,7 @@ namespace FASTER.core
 {
     internal interface IClientSession
     {
-        void AtomicSwitch(int version);
+        void AtomicSwitch(long version);
     }
 }
 

--- a/cs/src/core/Epochs/LightEpoch.cs
+++ b/cs/src/core/Epochs/LightEpoch.cs
@@ -474,9 +474,9 @@ namespace FASTER.core
         /// <param name="version">Version</param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Mark(int markerIdx, int version)
+        public void Mark(int markerIdx, long version)
         {
-            (*(tableAligned + threadEntryIndex)).markers[markerIdx] = version;
+            (*(tableAligned + threadEntryIndex)).markers[markerIdx] = (int)version;
         }
 
         /// <summary>
@@ -487,7 +487,7 @@ namespace FASTER.core
         /// <param name="version">Version</param>
         /// <returns>Whether complete</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool CheckIsComplete(int markerIdx, int version)
+        public bool CheckIsComplete(int markerIdx, long version)
         {
             // check if all threads have reported complete
             for (int index = 1; index <= kTableSize; ++index)
@@ -496,7 +496,7 @@ namespace FASTER.core
                 int fc_version = (*(tableAligned + index)).markers[markerIdx];
                 if (0 != entry_epoch)
                 {
-                    if (fc_version != version && entry_epoch < int.MaxValue)
+                    if ((fc_version != (int)version) && (entry_epoch < int.MaxValue))
                     {
                         return false;
                     }

--- a/cs/src/core/Index/CheckpointManagement/DeviceLogCommitCheckpointManager.cs
+++ b/cs/src/core/Index/CheckpointManagement/DeviceLogCommitCheckpointManager.cs
@@ -272,7 +272,7 @@ namespace FASTER.core
         }
 
         /// <inheritdoc />
-        public unsafe void CommitLogIncrementalCheckpoint(Guid logToken, int version, byte[] commitMetadata, DeltaLog deltaLog)
+        public unsafe void CommitLogIncrementalCheckpoint(Guid logToken, long version, byte[] commitMetadata, DeltaLog deltaLog)
         {
             deltaLog.Allocate(out int length, out long physicalAddress);
             if (length < commitMetadata.Length)

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -36,7 +36,7 @@ namespace FASTER.core
 
     internal class SerializedFasterExecutionContext
     {
-        internal int version;
+        internal long version;
         internal long serialNum;
         internal string guid;
 
@@ -56,7 +56,7 @@ namespace FASTER.core
         public void Load(StreamReader reader)
         {
             string value = reader.ReadLine();
-            version = int.Parse(value);
+            version = long.Parse(value);
 
             guid = reader.ReadLine();
             value = reader.ReadLine();
@@ -78,7 +78,7 @@ namespace FASTER.core
 
             // Some additional information about the previous attempt
             internal long id;
-            internal int version;
+            internal long version;
             internal long logicalAddress;
             internal long serialNum;
             internal HashBucketEntry entry;
@@ -248,7 +248,7 @@ namespace FASTER.core
     /// </summary>
     public struct HybridLogRecoveryInfo
     {
-        const int CheckpointVersion = 2;
+        const int CheckpointVersion = 3;
 
         /// <summary>
         /// Guid
@@ -261,11 +261,11 @@ namespace FASTER.core
         /// <summary>
         /// Version
         /// </summary>
-        public int version;
+        public long version;
         /// <summary>
         /// Next Version
         /// </summary>
-        public int nextVersion;
+        public long nextVersion;
         /// <summary>
         /// Flushed logical address; indicates the latest immutable address on the main FASTER log at recovery time.
         /// </summary>
@@ -318,7 +318,7 @@ namespace FASTER.core
         /// </summary>
         /// <param name="token"></param>
         /// <param name="_version"></param>
-        public void Initialize(Guid token, int _version)
+        public void Initialize(Guid token, long _version)
         {
             guid = token;
             useSnapshotFile = 0;
@@ -356,10 +356,10 @@ namespace FASTER.core
             useSnapshotFile = int.Parse(value);
 
             value = reader.ReadLine();
-            version = int.Parse(value);
+            version = long.Parse(value);
 
             value = reader.ReadLine();
-            nextVersion = int.Parse(value);
+            nextVersion = long.Parse(value);
 
             value = reader.ReadLine();
             flushedLogicalAddress = long.Parse(value);
@@ -560,9 +560,9 @@ namespace FASTER.core
         public IDevice deltaFileDevice;
         public DeltaLog deltaLog;
         public SemaphoreSlim flushedSemaphore;
-        public int prevVersion;
+        public long prevVersion;
 
-        public void Initialize(Guid token, int _version, ICheckpointManager checkpointManager)
+        public void Initialize(Guid token, long _version, ICheckpointManager checkpointManager)
         {
             info.Initialize(token, _version);
             checkpointManager.InitializeLogCheckpoint(token);

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -221,6 +221,8 @@ namespace FASTER.core
                     await readyResponses.WaitForEntryAsync(token).ConfigureAwait(false);
             }
 
+            public bool NewVersion => phase < Phase.REST;
+
             public FasterExecutionContext<Input, Output, Context> prevCtx;
         }
     }

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -221,7 +221,7 @@ namespace FASTER.core
                     await readyResponses.WaitForEntryAsync(token).ConfigureAwait(false);
             }
 
-            public bool NewVersion => phase < Phase.REST;
+            public bool InNewVersion => phase < Phase.REST;
 
             public FasterExecutionContext<Input, Output, Context> prevCtx;
         }

--- a/cs/src/core/Index/Common/RecordInfo.cs
+++ b/cs/src/core/Index/Common/RecordInfo.cs
@@ -10,7 +10,7 @@ using System.Threading;
 namespace FASTER.core
 {
     // RecordInfo layout (64 bits total):
-    // [--][NewVersion][Filler][Dirty][Stub][Sealed] [Valid][Tombstone][X][SSSSSS] [RAAAAAAA] [AAAAAAAA] [AAAAAAAA] [AAAAAAAA] [AAAAAAAA] [AAAAAAAA]
+    // [--][InNewVersion][Filler][Dirty][Stub][Sealed] [Valid][Tombstone][X][SSSSSS] [RAAAAAAA] [AAAAAAAA] [AAAAAAAA] [AAAAAAAA] [AAAAAAAA] [AAAAAAAA]
     //     where X = exclusive lock, S = shared lock, R = readcache, A = address, - = unused
     [StructLayout(LayoutKind.Explicit, Size = 8)]
     public struct RecordInfo
@@ -44,7 +44,7 @@ namespace FASTER.core
         const int kSealedBitOffset = kStubBitOffset + 1;
         const int kDirtyBitOffset = kSealedBitOffset + 1;
         const int kFillerBitOffset = kDirtyBitOffset + 1;
-        const int kNewVersionBitOffset = kFillerBitOffset + 1;
+        const int kInNewVersionBitOffset = kFillerBitOffset + 1;
 
         const long kTombstoneBitMask = 1L << kTombstoneBitOffset;
         const long kValidBitMask = 1L << kValidBitOffset;
@@ -52,19 +52,19 @@ namespace FASTER.core
         const long kSealedBitMask = 1L << kSealedBitOffset;
         const long kDirtyBitMask = 1L << kDirtyBitOffset;
         const long kFillerBitMask = 1L << kFillerBitOffset;
-        const long kNewVersionBitMask = 1L << kNewVersionBitOffset;
+        const long kInNewVersionBitMask = 1L << kInNewVersionBitOffset;
 
         [FieldOffset(0)]
         private long word;
 
-        public static void WriteInfo(ref RecordInfo info, bool newVersion, bool tombstone, bool dirty, long previousAddress)
+        public static void WriteInfo(ref RecordInfo info, bool inNewVersion, bool tombstone, bool dirty, long previousAddress)
         {
             info.word = default;
             info.Tombstone = tombstone;
             info.SetValid();
             info.Dirty = dirty;
             info.PreviousAddress = previousAddress;
-            info.NewVersion = newVersion;
+            info.InNewVersion = inNewVersion;
         }
 
         /// <summary>
@@ -248,13 +248,13 @@ namespace FASTER.core
             }
         }
 
-        public bool NewVersion
+        public bool InNewVersion
         {
-            get => (word & kNewVersionBitMask) > 0;
+            get => (word & kInNewVersionBitMask) > 0;
             set
             {
-                if (value) word |= kNewVersionBitMask;
-                else word &= ~kNewVersionBitMask;
+                if (value) word |= kInNewVersionBitMask;
+                else word &= ~kInNewVersionBitMask;
             }
         }
 

--- a/cs/src/core/Index/Common/RecordInfo.cs
+++ b/cs/src/core/Index/Common/RecordInfo.cs
@@ -10,8 +10,8 @@ using System.Threading;
 namespace FASTER.core
 {
     // RecordInfo layout (64 bits total):
-    // [--][CPR][Filler][Dirty][Stub][Sealed] [Valid][Tombstone][X][SSSSSS] [RAAAAAAA] [AAAAAAAA] [AAAAAAAA] [AAAAAAAA] [AAAAAAAA] [AAAAAAAA]
-    //     where V = version, X = exclusive lock, S = shared lock, A = address, R = readcache, - = unused
+    // [--][NewVersion][Filler][Dirty][Stub][Sealed] [Valid][Tombstone][X][SSSSSS] [RAAAAAAA] [AAAAAAAA] [AAAAAAAA] [AAAAAAAA] [AAAAAAAA] [AAAAAAAA]
+    //     where X = exclusive lock, S = shared lock, R = readcache, A = address, - = unused
     [StructLayout(LayoutKind.Explicit, Size = 8)]
     public struct RecordInfo
     {

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -228,9 +228,7 @@ namespace FASTER.core
             sectorSize = (int)logSettings.LogDevice.SectorSize;
             Initialize(size, sectorSize);
 
-            systemState = default;
-            systemState.Phase = Phase.REST;
-            systemState.Version = 1;
+            systemState = SystemState.Make(Phase.REST, 1);
         }
 
         /// <summary>

--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -529,22 +529,6 @@ namespace FASTER.core
                         }
                         break; // Normal Processing
                     }
-                case Phase.WAIT_PENDING:
-                    {
-                        if (!CheckEntryVersionNew(logicalAddress, sessionCtx))
-                        {
-                            if (HashBucket.NoSharedLatches(bucket))
-                            {
-                                return LatchDestination.CreateNewRecord; // Create a (v+1) record
-                            }
-                            else
-                            {
-                                status = OperationStatus.RETRY_LATER;
-                                return LatchDestination.CreatePendingContext; // Go Pending
-                            }
-                        }
-                        break; // Normal Processing
-                    }
                 case Phase.WAIT_FLUSH:
                     {
                         if (!CheckEntryVersionNew(logicalAddress, sessionCtx))
@@ -895,23 +879,6 @@ namespace FASTER.core
                         }
                         break; // Normal Processing
                     }
-                case Phase.WAIT_PENDING:
-                    {
-                        if (!CheckEntryVersionNew(logicalAddress, sessionCtx))
-                        {
-                            if (HashBucket.NoSharedLatches(bucket))
-                            {
-                                if (logicalAddress >= hlog.HeadAddress)
-                                    return LatchDestination.CreateNewRecord; // Create a (v+1) record
-                            }
-                            else
-                            {
-                                status = OperationStatus.RETRY_LATER;
-                                return LatchDestination.CreatePendingContext; // Go Pending
-                            }
-                        }
-                        break; // Normal Processing
-                    }
                 case Phase.WAIT_FLUSH:
                     {
                         if (!CheckEntryVersionNew(logicalAddress, sessionCtx))
@@ -1148,22 +1115,6 @@ namespace FASTER.core
                                 {
                                     // Set to release exclusive latch (default)
                                     latchOperation = LatchOperation.Exclusive;
-                                    goto CreateNewRecord; // Create a (v+1) record
-                                }
-                                else
-                                {
-                                    status = OperationStatus.RETRY_LATER;
-                                    goto CreatePendingContext; // Go Pending
-                                }
-                            }
-                            break; // Normal Processing
-                        }
-                    case Phase.WAIT_PENDING:
-                        {
-                            if (!CheckEntryVersionNew(logicalAddress, sessionCtx))
-                            {
-                                if (HashBucket.NoSharedLatches(bucket))
-                                {
                                     goto CreateNewRecord; // Create a (v+1) record
                                 }
                                 else

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -153,7 +153,7 @@ namespace FASTER.core
                 #region Previous pending requests
                 if (!RelaxedCPR)
                 {
-                    if (ctx.phase == Phase.IN_PROGRESS || ctx.phase == Phase.WAIT_PENDING)
+                    if (ctx.phase == Phase.IN_PROGRESS)
                     {
                         InternalCompletePendingRequests(ctx.prevCtx, ctx, fasterSession, completedOutputs);
                         InternalCompleteRetryRequests(ctx.prevCtx, ctx, fasterSession);

--- a/cs/src/core/Index/Recovery/Checkpoint.cs
+++ b/cs/src/core/Index/Recovery/Checkpoint.cs
@@ -92,7 +92,7 @@ namespace FASTER.core
             _indexCheckpoint.Initialize(indexToken, state[resizeInfo.version].size, checkpointManager);
         }
 
-        internal void InitializeHybridLogCheckpoint(Guid hybridLogToken, int version)
+        internal void InitializeHybridLogCheckpoint(Guid hybridLogToken, long version)
         {
             _hybridLogCheckpoint.Initialize(hybridLogToken, version, checkpointManager);
         }

--- a/cs/src/core/Index/Recovery/Checkpoint.cs
+++ b/cs/src/core/Index/Recovery/Checkpoint.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-#pragma warning disable 0162
-
-//#define WAIT_FOR_INDEX_CHECKPOINT
-
 using System;
 using System.Linq;
 using System.Text;
@@ -36,8 +32,7 @@ namespace FASTER.core
     public partial class FasterKV<Key, Value>
     {
         
-        internal TaskCompletionSource<LinkedCheckpointInfo> checkpointTcs
-            = new TaskCompletionSource<LinkedCheckpointInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal TaskCompletionSource<LinkedCheckpointInfo> checkpointTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
             
         internal Guid _indexCheckpointToken;
         internal Guid _hybridLogCheckpointToken;

--- a/cs/src/core/Index/Recovery/ICheckpointManager.cs
+++ b/cs/src/core/Index/Recovery/ICheckpointManager.cs
@@ -65,7 +65,7 @@ namespace FASTER.core
         /// <param name="version"></param>
         /// <param name="commitMetadata"></param>
         /// <param name="deltaLog"></param>
-        void CommitLogIncrementalCheckpoint(Guid logToken, int version, byte[] commitMetadata, DeltaLog deltaLog);
+        void CommitLogIncrementalCheckpoint(Guid logToken, long version, byte[] commitMetadata, DeltaLog deltaLog);
 
         /// <summary>
         /// Retrieve commit metadata for specified index checkpoint

--- a/cs/src/core/Index/Recovery/LocalCheckpointManager.cs
+++ b/cs/src/core/Index/Recovery/LocalCheckpointManager.cs
@@ -277,7 +277,7 @@ namespace FASTER.core
         }
 
         /// <inheritdoc />
-        public unsafe void CommitLogIncrementalCheckpoint(Guid logToken, int version, byte[] commitMetadata, DeltaLog deltaLog)
+        public unsafe void CommitLogIncrementalCheckpoint(Guid logToken, long version, byte[] commitMetadata, DeltaLog deltaLog)
         {
             deltaLog.Allocate(out int length, out long physicalAddress);
             if (length < commitMetadata.Length)

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -784,7 +784,7 @@ namespace FASTER.core
                     entry = default;
                     FindOrCreateTag(hash, tag, ref bucket, ref slot, ref entry, hlog.BeginAddress);
 
-                    if (!info.NewVersion || !undoNextVersion)
+                    if (!info.InNewVersion || !undoNextVersion)
                     {
                         entry.Address = pageLogicalAddress + pointer;
                         entry.Tag = tag;

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-#pragma warning disable 0162
-
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -204,7 +201,7 @@ namespace FASTER.core
             }
         }
 
-        private bool IsCompatible(in IndexRecoveryInfo indexInfo, in HybridLogRecoveryInfo recoveryInfo)
+        private static bool IsCompatible(in IndexRecoveryInfo indexInfo, in HybridLogRecoveryInfo recoveryInfo)
         {
             var l1 = indexInfo.finalLogicalAddress;
             var l2 = recoveryInfo.finalLogicalAddress;

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -788,7 +788,7 @@ namespace FASTER.core
                     entry = default;
                     FindOrCreateTag(hash, tag, ref bucket, ref slot, ref entry, hlog.BeginAddress);
 
-                    if (info.Version != RecordInfo.GetShortVersion(nextVersion) || !undoNextVersion)
+                    if (!info.NewVersion || !undoNextVersion)
                     {
                         entry.Address = pageLogicalAddress + pointer;
                         entry.Tag = tag;
@@ -799,7 +799,7 @@ namespace FASTER.core
                     else
                     {
                         touched = true;
-                        info.Invalid = true;
+                        info.SetInvalid();
                         if (info.PreviousAddress < startRecoveryAddress)
                         {
                             entry.Address = info.PreviousAddress;

--- a/cs/src/core/Index/Synchronization/FullCheckpointStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/FullCheckpointStateMachine.cs
@@ -87,7 +87,7 @@ namespace FASTER.core
                 case Phase.PREP_INDEX_CHECKPOINT:
                     result.Phase = Phase.PREPARE;
                     break;
-                case Phase.WAIT_PENDING:
+                case Phase.IN_PROGRESS:
                     result.Phase = Phase.WAIT_INDEX_CHECKPOINT;
                     break;
                 case Phase.WAIT_INDEX_CHECKPOINT:

--- a/cs/src/core/Index/Synchronization/HybridLogCheckpointTask.cs
+++ b/cs/src/core/Index/Synchronization/HybridLogCheckpointTask.cs
@@ -48,7 +48,7 @@ namespace FASTER.core
             }
         }
 
-        protected void CollectMetadata<Key, Value>(SystemState next, FasterKV<Key, Value> faster)
+        protected static void CollectMetadata<Key, Value>(SystemState next, FasterKV<Key, Value> faster)
         {
             // Collect object log offsets only after flushes
             // are completed

--- a/cs/src/core/Index/Synchronization/HybridLogCheckpointTask.cs
+++ b/cs/src/core/Index/Synchronization/HybridLogCheckpointTask.cs
@@ -384,7 +384,7 @@ namespace FASTER.core
             var result = SystemState.Copy(ref start);
             switch (start.Phase)
             {
-                case Phase.WAIT_PENDING:
+                case Phase.IN_PROGRESS:
                     result.Phase = Phase.WAIT_FLUSH;
                     break;
                 case Phase.WAIT_FLUSH:

--- a/cs/src/core/Index/Synchronization/StateTransitions.cs
+++ b/cs/src/core/Index/Synchronization/StateTransitions.cs
@@ -28,9 +28,6 @@ namespace FASTER.core
         /// <summary>In-progress phase, entering (v+1) version</summary>
         IN_PROGRESS,
 
-        /// <summary>Wait-pending phase, waiting for pending (v) operations to complete</summary>
-        WAIT_PENDING,
-
         /// <summary>Wait for an index checkpoint to finish</summary>
         WAIT_INDEX_CHECKPOINT,
 

--- a/cs/src/core/Index/Synchronization/StateTransitions.cs
+++ b/cs/src/core/Index/Synchronization/StateTransitions.cs
@@ -65,23 +65,57 @@ namespace FASTER.core
     [StructLayout(LayoutKind.Explicit, Size = 8)]
     public struct SystemState
     {
-        /// <summary>
-        /// The current <see cref="Phase"/> of the operation
-        /// </summary>
-        [FieldOffset(0)]
-        public Phase Phase;
+        const int kTotalSizeInBytes = 8;
+        const int kTotalBits = kTotalSizeInBytes * 8;
 
-        /// <summary>
-        /// The version of the database when this operation is complete
-        /// </summary>
-        [FieldOffset(4)]
-        public int Version;
-        
+        // Phase
+        const int kPhaseBits = 8;
+        const int kPhaseShiftInWord = kTotalBits - kPhaseBits;
+        const long kPhaseMaskInWord = ((1L << kPhaseBits) - 1) << kPhaseShiftInWord;
+        const long kPhaseMaskInInteger = (1L << kPhaseBits) - 1;
+
+        // Version
+        const int kVersionBits = kPhaseShiftInWord;
+        const long kVersionMaskInWord = (1L << kVersionBits) - 1;
+
         /// <summary>
         /// The word containing information in bitfields
         /// </summary>
         [FieldOffset(0)]
         internal long Word;
+
+
+        /// <summary>
+        /// The current <see cref="Phase"/> of the operation
+        /// </summary>
+        public Phase Phase
+        {
+            get
+            {
+                return (Phase)((Word >> kPhaseShiftInWord) & kPhaseMaskInInteger);
+            }
+            set
+            {
+                Word &= ~kPhaseMaskInWord;
+                Word |= (((long)value) & kPhaseMaskInInteger) << kPhaseShiftInWord;
+            }
+        }
+
+        /// <summary>
+        /// The version of the database when this operation is complete
+        /// </summary>
+        public long Version
+        {
+            get
+            {
+                return Word & kVersionMaskInWord;
+            }
+            set
+            {
+                Word &= ~kVersionMaskInWord;
+                Word |= value & kVersionMaskInWord;
+            }
+        }
 
         /// <summary>
         /// Copy the <paramref name="other"/> <see cref="SystemState"/> into this <see cref="SystemState"/>
@@ -98,7 +132,7 @@ namespace FASTER.core
         /// Create a <see cref="SystemState"/> with the specified values
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static SystemState Make(Phase status, int version)
+        internal static SystemState Make(Phase status, long version)
         {
             var info = default(SystemState);
             info.Phase = status;

--- a/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
@@ -156,12 +156,6 @@ namespace FASTER.core
                     break;
                 case Phase.PREPARE:
                     nextState.Phase = Phase.IN_PROGRESS;
-                    // FASTER records only store a few bits of version number, and we need to ensure that
-                    // the next version is distinguishable from the last in those bits.
-                    // If they are not distinguishable, simply increment target version to resolve this
-                    if (((targetVersion - start.Version) & RecordInfo.kVersionMaskInInteger) == 0)
-                        targetVersion++;
-
                     // TODO: Move to long for system state as well. 
                     SetToVersion(targetVersion == -1 ? start.Version + 1 : targetVersion);
                     nextState.Version = (int) ToVersion();

--- a/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
@@ -80,23 +80,6 @@ namespace FASTER.core
                     if (faster.epoch.CheckIsComplete(EpochPhaseIdx.InProgress, current.Version))
                         faster.GlobalStateMachineStep(current);
                     break;
-                case Phase.WAIT_PENDING:
-                    if (ctx != null)
-                    {
-                        if (!faster.RelaxedCPR && !ctx.prevCtx.markers[EpochPhaseIdx.WaitPending])
-                        {
-                            if (ctx.prevCtx.HasNoPendingRequests)
-                                ctx.prevCtx.markers[EpochPhaseIdx.WaitPending] = true;
-                            else
-                                break;
-                        }
-
-                        faster.epoch.Mark(EpochPhaseIdx.WaitPending, current.Version);
-                    }
-
-                    if (faster.epoch.CheckIsComplete(EpochPhaseIdx.WaitPending, current.Version))
-                        faster.GlobalStateMachineStep(current);
-                    break;
                 case Phase.REST:
                     break;
             }
@@ -184,10 +167,6 @@ namespace FASTER.core
                     nextState.Version = (int) ToVersion();
                     break;
                 case Phase.IN_PROGRESS:
-                    // This phase has no effect if using relaxed CPR model
-                    nextState.Phase = Phase.WAIT_PENDING;
-                    break;
-                case Phase.WAIT_PENDING:
                     nextState.Phase = Phase.REST;
                     break;
                 default:

--- a/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
@@ -127,7 +127,7 @@ namespace FASTER.core
     /// </summary>
     internal class VersionChangeStateMachine : SynchronizationStateMachineBase
     {
-        private long targetVersion;
+        private readonly long targetVersion;
 
         /// <summary>
         /// Construct a new VersionChangeStateMachine with the given tasks. Does not load any tasks by default.

--- a/cs/src/core/Utilities/PageAsyncResultTypes.cs
+++ b/cs/src/core/Utilities/PageAsyncResultTypes.cs
@@ -50,6 +50,22 @@ namespace FASTER.core
     }
 
     /// <summary>
+    /// Shared flush completion tracker, when bulk-flushing many pages
+    /// </summary>
+    public class FlushCompletionTracker
+    {
+        /// <summary>
+        /// Semaphore to set on flush completion
+        /// </summary>
+        public SemaphoreSlim completedSemaphore;
+
+        /// <summary>
+        /// Number of pages being flushed
+        /// </summary>
+        public int count;
+    }
+
+    /// <summary>
     /// Page async flush result
     /// </summary>
     /// <typeparam name="TContext"></typeparam>
@@ -75,6 +91,7 @@ namespace FASTER.core
         internal SectorAlignedMemory freeBuffer2;
         internal AutoResetEvent done;
         internal SemaphoreSlim completedSemaphore;
+        internal FlushCompletionTracker flushCompletionTracker;
 
         /// <summary>
         /// Free
@@ -93,6 +110,7 @@ namespace FASTER.core
             }
 
             completedSemaphore?.Release();
+            flushCompletionTracker?.completedSemaphore?.Release();
         }
     }
 }

--- a/cs/test/GenericByteArrayTests.cs
+++ b/cs/test/GenericByteArrayTests.cs
@@ -47,7 +47,7 @@ namespace FASTER.test
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
         }
 
-        private byte[] GetByteArray(int i)
+        private static byte[] GetByteArray(int i)
         {
             return BitConverter.GetBytes(i);
         }

--- a/cs/test/ReadAddressTests.cs
+++ b/cs/test/ReadAddressTests.cs
@@ -197,7 +197,7 @@ namespace FASTER.test.readaddress
                 await Flush();
             }
 
-            internal bool ProcessChainRecord(Status status, RecordMetadata recordMetadata, int lap, ref Output actualOutput, ref int previousVersion)
+            internal bool ProcessChainRecord(Status status, RecordMetadata recordMetadata, int lap, ref Output actualOutput)
             {
                 var recordInfo = recordMetadata.RecordInfo;
                 Assert.GreaterOrEqual(lap, 0);
@@ -205,13 +205,11 @@ namespace FASTER.test.readaddress
 
                 Assert.AreEqual(status == Status.NOTFOUND, recordInfo.Tombstone, $"status({status}) == NOTFOUND != Tombstone ({recordInfo.Tombstone})");
                 Assert.AreEqual(lap == deleteLap, recordInfo.Tombstone, $"lap({lap}) == deleteLap({deleteLap}) != Tombstone ({recordInfo.Tombstone})");
-                Assert.GreaterOrEqual(previousVersion, recordInfo.Version);
                 if (!recordInfo.Tombstone)
                     Assert.AreEqual(expectedValue, actualOutput.value);
 
                 // Check for end of loop
-                previousVersion = recordInfo.Version;
-                return recordInfo.PreviousAddress >= this.fkv.Log.BeginAddress;
+                return recordInfo.PreviousAddress >= fkv.Log.BeginAddress;
             }
 
             internal static void ProcessNoKeyRecord(Status status, ref Output actualOutput, int keyOrdinal)
@@ -253,7 +251,6 @@ namespace FASTER.test.readaddress
                 var input = default(Value);
                 var key = new Key(defaultKeyToScan);
                 RecordMetadata recordMetadata = default;
-                int version = int.MaxValue;
 
                 for (int lap = maxLap - 1; /* tested in loop */; --lap)
                 {
@@ -264,7 +261,7 @@ namespace FASTER.test.readaddress
                         session.CompletePendingWithOutputs(out var completedOutputs, wait: true);
                         (status, output) = TestUtils.GetSinglePendingResult(completedOutputs, out recordMetadata);
                     }
-                    if (!testStore.ProcessChainRecord(status, recordMetadata, lap, ref output, ref version))
+                    if (!testStore.ProcessChainRecord(status, recordMetadata, lap, ref output))
                         break;
                 }
             }
@@ -287,13 +284,12 @@ namespace FASTER.test.readaddress
                 var input = default(Value);
                 var key = new Key(defaultKeyToScan);
                 RecordMetadata recordMetadata = default;
-                int version = int.MaxValue;
 
                 for (int lap = maxLap - 1; /* tested in loop */; --lap)
                 {
                     var readAsyncResult = await session.ReadAsync(ref key, ref input, recordMetadata.RecordInfo.PreviousAddress, default, serialNo: maxLap + 1);
                     var (status, output) = readAsyncResult.Complete(out recordMetadata);
-                    if (!testStore.ProcessChainRecord(status, recordMetadata, lap, ref output, ref version))
+                    if (!testStore.ProcessChainRecord(status, recordMetadata, lap, ref output))
                         break;
                 }
             }
@@ -317,7 +313,6 @@ namespace FASTER.test.readaddress
                 var input = default(Value);
                 var key = new Key(defaultKeyToScan);
                 RecordMetadata recordMetadata = default;
-                int version = int.MaxValue;
 
                 for (int lap = maxLap - 1; /* tested in loop */; --lap)
                 {
@@ -330,7 +325,7 @@ namespace FASTER.test.readaddress
                         session.CompletePendingWithOutputs(out var completedOutputs, wait: true);
                         (status, output) = TestUtils.GetSinglePendingResult(completedOutputs, out recordMetadata);
                     }
-                    if (!testStore.ProcessChainRecord(status, recordMetadata, lap, ref output, ref version))
+                    if (!testStore.ProcessChainRecord(status, recordMetadata, lap, ref output))
                         break;
 
                     if (readAtAddress >= testStore.fkv.Log.BeginAddress)
@@ -370,7 +365,6 @@ namespace FASTER.test.readaddress
                 var input = default(Value);
                 var key = new Key(defaultKeyToScan);
                 RecordMetadata recordMetadata = default;
-                int version = int.MaxValue;
 
                 for (int lap = maxLap - 1; /* tested in loop */; --lap)
                 {
@@ -378,7 +372,7 @@ namespace FASTER.test.readaddress
 
                     var readAsyncResult = await session.ReadAsync(ref key, ref input, recordMetadata.RecordInfo.PreviousAddress, default, serialNo: maxLap + 1);
                     var (status, output) = readAsyncResult.Complete(out recordMetadata);
-                    if (!testStore.ProcessChainRecord(status, recordMetadata, lap, ref output, ref version))
+                    if (!testStore.ProcessChainRecord(status, recordMetadata, lap, ref output))
                         break;
 
                     if (readAtAddress >= testStore.fkv.Log.BeginAddress)
@@ -413,7 +407,6 @@ namespace FASTER.test.readaddress
                 var input = default(Value);
                 var key = new Key(defaultKeyToScan);
                 RecordMetadata recordMetadata = default;
-                int version = int.MaxValue;
 
                 for (int lap = maxLap - 1; /* tested in loop */; --lap)
                 {
@@ -421,7 +414,7 @@ namespace FASTER.test.readaddress
 
                     var readAsyncResult = await session.ReadAsync(ref key, ref input, recordMetadata.RecordInfo.PreviousAddress, default, serialNo: maxLap + 1);
                     var (status, output) = readAsyncResult.Complete(out recordMetadata);
-                    if (!testStore.ProcessChainRecord(status, recordMetadata, lap, ref output, ref version))
+                    if (!testStore.ProcessChainRecord(status, recordMetadata, lap, ref output))
                         break;
 
                     if (readAtAddress >= testStore.fkv.Log.BeginAddress)
@@ -456,7 +449,6 @@ namespace FASTER.test.readaddress
                 var input = default(Value);
                 var key = new Key(defaultKeyToScan);
                 RecordMetadata recordMetadata = default;
-                int version = int.MaxValue;
 
                 for (int lap = maxLap - 1; /* tested in loop */; --lap)
                 {
@@ -464,7 +456,7 @@ namespace FASTER.test.readaddress
 
                     var readAsyncResult = await session.ReadAsync(ref key, ref input, recordMetadata.RecordInfo.PreviousAddress, default, serialNo: maxLap + 1);
                     var (status, output) = readAsyncResult.Complete(out recordMetadata);
-                    if (!testStore.ProcessChainRecord(status, recordMetadata, lap, ref output, ref version))
+                    if (!testStore.ProcessChainRecord(status, recordMetadata, lap, ref output))
                         break;
 
                     if (readAtAddress >= testStore.fkv.Log.BeginAddress)

--- a/cs/test/StateMachineTests.cs
+++ b/cs/test/StateMachineTests.cs
@@ -399,7 +399,7 @@ namespace FASTER.test.statemachine
         [TestCase]
         [Category("FasterKV")]
         [Category("CheckpointRestore")]
-        public void VersionChangeRollOverTest()
+        public void VersionChangeTest()
         {
             var toVersion = 1 + (1 << 14);
             Prepare(out var f, out var s1, out var s2, toVersion);
@@ -411,13 +411,13 @@ namespace FASTER.test.statemachine
             s2.Refresh();
             s1.Refresh();
 
-            // We should now be in IN_PROGRESS, toVersion + 1 (because of rollover of 13 bit short version)
-            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.IN_PROGRESS, toVersion + 1), fht1.SystemState));
+            // We should now be in IN_PROGRESS, toVersion
+            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.IN_PROGRESS, toVersion), fht1.SystemState));
 
             s2.Refresh();
 
             // We should be in WAIT_FLUSH, 2
-            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.WAIT_FLUSH, toVersion + 1), fht1.SystemState));
+            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.WAIT_FLUSH, toVersion), fht1.SystemState));
 
             // Expect checkpoint completion callback
             f.checkpointCallbackExpectation = 1;
@@ -428,11 +428,11 @@ namespace FASTER.test.statemachine
             Assert.IsTrue(f.checkpointCallbackExpectation == 0);
 
             // We should be in PERSISTENCE_CALLBACK, 2
-            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.PERSISTENCE_CALLBACK, toVersion + 1), fht1.SystemState));
+            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.PERSISTENCE_CALLBACK, toVersion), fht1.SystemState));
 
             s2.Refresh();
 
-            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.REST, toVersion + 1), fht1.SystemState));
+            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.REST, toVersion), fht1.SystemState));
 
 
             // Dispose session s2; does not move state machine forward

--- a/cs/test/StateMachineTests.cs
+++ b/cs/test/StateMachineTests.cs
@@ -73,19 +73,8 @@ namespace FASTER.test.statemachine
 
             s2.Refresh();
 
-            // We should be in WAIT_PENDING, 2
-            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.WAIT_PENDING, 2), fht1.SystemState));
-
-            s1.Refresh();
-
             // We should be in WAIT_FLUSH, 2
             Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.WAIT_FLUSH, 2), fht1.SystemState));
-
-            s2.Refresh();
-
-
-            // We should be in PERSISTENCE_CALLBACK, 2
-            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.PERSISTENCE_CALLBACK, 2), fht1.SystemState));
 
             // Expect checkpoint completion callback
             f.checkpointCallbackExpectation = 1;
@@ -94,6 +83,12 @@ namespace FASTER.test.statemachine
 
             // Completion callback should have been called once
             Assert.AreEqual(0, f.checkpointCallbackExpectation);
+
+
+            // We should be in PERSISTENCE_CALLBACK, 2
+            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.PERSISTENCE_CALLBACK, 2), fht1.SystemState));
+
+            s2.Refresh();
 
             // We should be in REST, 2
             Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.REST, 2), fht1.SystemState));
@@ -256,13 +251,14 @@ namespace FASTER.test.statemachine
 
             s1.Refresh();
 
-            // We should be in WAIT_PENDING, 2
-            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.WAIT_PENDING, 2), fht1.SystemState));
+            // We should be in WAIT_FLUSH, 2
+            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.WAIT_FLUSH, 2), fht1.SystemState));
+
 
             s2.Refresh();
 
-            // We should be in WAIT_FLUSH, 2
-            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.WAIT_FLUSH, 2), fht1.SystemState));
+            // We should be in PERSISTENCE_CALLBACK, 2
+            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.PERSISTENCE_CALLBACK, 2), fht1.SystemState));
 
             // Expect checkpoint completion callback
             f.checkpointCallbackExpectation = 1;
@@ -272,8 +268,8 @@ namespace FASTER.test.statemachine
             // Completion callback should have been called once
             Assert.AreEqual(0, f.checkpointCallbackExpectation);
 
-            // We should be in PERSISTENCE_CALLBACK, 2
-            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.PERSISTENCE_CALLBACK, 2), fht1.SystemState));
+            // We should be in REST, 2
+            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.REST, 2), fht1.SystemState));
 
             // No callback here since already done
             s1.Refresh();
@@ -370,20 +366,8 @@ namespace FASTER.test.statemachine
 
             s2.Refresh();
 
-            // We should be in WAIT_PENDING, 2
-            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.WAIT_PENDING, 2), fht1.SystemState));
-            callback.CheckInvoked(fht1.SystemState);
-
-            s1.Refresh();
-
             // We should be in WAIT_FLUSH, 2
             Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.WAIT_FLUSH, 2), fht1.SystemState));
-            callback.CheckInvoked(fht1.SystemState);
-
-            s2.Refresh();
-
-            // We should be in PERSISTENCE_CALLBACK, 2
-            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.PERSISTENCE_CALLBACK, 2), fht1.SystemState));
             callback.CheckInvoked(fht1.SystemState);
 
             // Expect checkpoint completion callback
@@ -393,6 +377,12 @@ namespace FASTER.test.statemachine
 
             // Completion callback should have been called once
             Assert.IsTrue(f.checkpointCallbackExpectation == 0);
+
+            // We should be in PERSISTENCE_CALLBACK, 2
+            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.PERSISTENCE_CALLBACK, 2), fht1.SystemState));
+            callback.CheckInvoked(fht1.SystemState);
+
+            s2.Refresh();
 
             // We should be in REST, 2
             Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.REST, 2), fht1.SystemState));
@@ -426,23 +416,21 @@ namespace FASTER.test.statemachine
 
             s2.Refresh();
 
-            // We should be in WAIT_PENDING, 2
-            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.WAIT_PENDING, toVersion + 1), fht1.SystemState));
-
-            s1.Refresh();
-
             // We should be in WAIT_FLUSH, 2
             Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.WAIT_FLUSH, toVersion + 1), fht1.SystemState));
-
-            s2.Refresh();
-
-            // We should be in PERSISTENCE_CALLBACK, 2
-            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.PERSISTENCE_CALLBACK, toVersion + 1), fht1.SystemState));
 
             // Expect checkpoint completion callback
             f.checkpointCallbackExpectation = 1;
 
             s1.Refresh();
+
+            // Completion callback should have been called once
+            Assert.IsTrue(f.checkpointCallbackExpectation == 0);
+
+            // We should be in PERSISTENCE_CALLBACK, 2
+            Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.PERSISTENCE_CALLBACK, toVersion + 1), fht1.SystemState));
+
+            s2.Refresh();
 
             Assert.IsTrue(SystemState.Equal(SystemState.Make(Phase.REST, toVersion + 1), fht1.SystemState));
 


### PR DESCRIPTION
* Use only 1 bit for newVersion in RecordInfo, for CPR. Semantics are that sessions in v+1 will create records in fuzzy region with this bit set. Recovery only scans fuzzy region to elide such records.
* Add 1 Filler bit for future use with fillers in records
* Increase read lock bits to 6 (64 parallel readers)
* Use dirty bit for incremental checkpoints