### PR TITLE
[C#] Modify SubscribeKVProvider to support custom functions

### DIFF
--- a/cs/remote/src/FASTER.server/Providers/SpanByteFasterKVProvider.cs
+++ b/cs/remote/src/FASTER.server/Providers/SpanByteFasterKVProvider.cs
@@ -61,17 +61,26 @@ namespace FASTER.server
             this.maxSizeSettings = maxSizeSettings ?? new MaxSizeSettings();
         }
 
+        /// <summary>
+        /// GetFunctions() for custom functions provided by the client
+        /// </summary>
+        /// <returns></returns>
+        public virtual IAdvancedFunctions<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, long> GetFunctions()
+        {
+            return new SpanByteFunctionsForServer<long>();
+        }
+
         /// <inheritdoc />
         public virtual IServerSession GetSession(WireFormat wireFormat, Socket socket)
         {
             switch (wireFormat)
             {
                 case WireFormat.WebSocket:
-                    return new WebsocketServerSession<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, SpanByteFunctionsForServer<long>, SpanByteServerSerializer>
-                        (socket, store, new SpanByteFunctionsForServer<long>(), serializer, maxSizeSettings, kvBroker, broker);
+                    return new WebsocketServerSession<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, IAdvancedFunctions<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, long>, SpanByteServerSerializer>
+                        (socket, store, GetFunctions(), serializer, maxSizeSettings, kvBroker, broker);
                 default:
-                    return new BinaryServerSession<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, SpanByteFunctionsForServer<long>, SpanByteServerSerializer>
-                        (socket, store, new SpanByteFunctionsForServer<long>(), serializer, maxSizeSettings, kvBroker, broker);
+                    return new BinaryServerSession<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, IAdvancedFunctions<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, long>, SpanByteServerSerializer>
+                        (socket, store, GetFunctions(), serializer, maxSizeSettings, kvBroker, broker);
             }
         }
     }

--- a/cs/remote/src/FASTER.server/PubSub/SubscribeKVBroker.cs
+++ b/cs/remote/src/FASTER.server/PubSub/SubscribeKVBroker.cs
@@ -158,7 +158,7 @@ namespace FASTER.server
                                                 fixed (byte* inputPtr = &sub.Value.Item2[0])
                                                 {
                                                     byte* inputBytePtr = inputPtr;
-                                                    serverSession.Publish(ref keyBytePtr, keyBytes.Length, ref nullBytrPtr, 0, ref inputBytePtr, sub.Key);
+                                                    serverSession.PrefixPublish(subPrefixPtr, kvp.Key.Length, ref keyBytePtr, keyBytes.Length, ref nullBytrPtr, 0, ref inputBytePtr, sub.Key);
                                                 }
                                             }
                                         }


### PR DESCRIPTION
* Added a GetFunctions() method in SpanByteFasterKVProvider, to support custom functions with the SpanByte provider.
* Fixed a bug in SubscribeKVBroker, where it was calling Publish for normal subscriptions instead of prefix subscriptions.