### PR TITLE
[C#]: Fix NullRef in RMWAsync in low-memory conditions

### DIFF
--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -828,6 +828,8 @@ namespace FASTER.core
                 epoch.Dispose();
             bufferPool.Free();
 
+            this.FlushEvent.Dispose();
+
             OnReadOnlyObserver?.OnCompleted();
             OnEvictionObserver?.OnCompleted();
         }

--- a/cs/src/core/Async/RMWAsync.cs
+++ b/cs/src/core/Async/RMWAsync.cs
@@ -55,6 +55,7 @@ namespace FASTER.core
                 fasterSession.CompletePendingWithOutputs(out var completedOutputs, wait: true, spinWaitForCommit: false);
                 var status = completedOutputs.Next() ? completedOutputs.Current.Status : Status.ERROR;
                 completedOutputs.Dispose();
+                this.diskRequest = default;
                 return status != Status.PENDING;
             }
 
@@ -167,8 +168,10 @@ namespace FASTER.core
             if (internalStatus == OperationStatus.ALLOCATE_FAILED)
                 return Status.PENDING;    // This plus diskRequest.IsDefault() means allocate failed
 
-            flushEvent = default;
-            return HandleOperationStatus(currentCtx, currentCtx, ref pcontext, fasterSession, internalStatus, asyncOp, out diskRequest);
+            var result = HandleOperationStatus(currentCtx, currentCtx, ref pcontext, fasterSession, internalStatus, asyncOp, out diskRequest);
+            if (!diskRequest.IsDefault())
+                flushEvent = default;
+            return result;
         }
 
         private static async ValueTask<RmwAsyncResult<Input, Output, Context>> SlowRmwAsync<Input, Output, Context>(

--- a/cs/src/core/ClientSession/AdvancedClientSession.cs
+++ b/cs/src/core/ClientSession/AdvancedClientSession.cs
@@ -1131,7 +1131,7 @@ namespace FASTER.core
             }
 
             public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
-                => throw new NotImplementedException();
+                => _clientSession.CompletePendingWithOutputs(out completedOutputs, wait, spinWaitForCommit);
         }
     }
 }

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -1208,7 +1208,7 @@ namespace FASTER.core
             }
 
             public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
-                => throw new NotImplementedException();
+                 => _clientSession.CompletePendingWithOutputs(out completedOutputs, wait, spinWaitForCommit);
         }
     }
 }

--- a/cs/src/core/Utilities/CompletionEvent.cs
+++ b/cs/src/core/Utilities/CompletionEvent.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace FASTER.core
 {
     // This structure uses a SemaphoreSlim as if it were a ManualResetEventSlim, because MRES does not support async waiting.
-    internal struct CompletionEvent
+    internal struct CompletionEvent : IDisposable
     {
         private SemaphoreSlim semaphore;
 
@@ -33,6 +34,13 @@ namespace FASTER.core
         internal void Wait(CancellationToken token = default) => this.semaphore.Wait(token);
 
         internal Task WaitAsync(CancellationToken token = default) => this.semaphore.WaitAsync(token);
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            this.semaphore?.Dispose();
+            this.semaphore = null;
+        }
     }
 }
 

--- a/cs/test/LowMemAsyncTests.cs
+++ b/cs/test/LowMemAsyncTests.cs
@@ -92,7 +92,7 @@ namespace FASTER.test.async
         [Test]
         [Category("FasterKV")]
         [Category("Stress")]
-        public async Task LowMemConcurrentUpsertRMWReadAsyncTest()
+        public async Task LowMemConcurrentUpsertRMWReadAsyncTest([Values]bool completeSync)
         {
             await Task.Yield();
             using var s1 = fht1.NewSession(new SimpleFunctions<long, long>((a, b) => a + b));
@@ -112,6 +112,11 @@ namespace FASTER.test.async
                     var result = await rmwtasks[key].ConfigureAwait(false);
                     if (result.Status == Status.PENDING)
                     {
+                        if (completeSync)
+                        {
+                            result.Complete();
+                            continue;
+                        }
                         done = false;
                         rmwtasks[key] = result.CompleteAsync();
                     }


### PR DESCRIPTION
Found by Netherite. Fixes:

- Remove 'readonly' from UpdateAsyncInternal._asyncOperation; this was causing the update to _asyncOperation._diskRequest to operate on a copy.
- Also fix call sequence to complete pending I/O in UpdateAsync.Complete()
- Fix the *ClientSession.CompletePendingWithOutput calls
- Make CompletionEvent implement IDisposable