### PR TITLE
[C#] FasterLog v2 Add ability to explicitly terminate a log

### DIFF
--- a/cs/samples/FasterLogSample/Program.cs
+++ b/cs/samples/FasterLogSample/Program.cs
@@ -156,8 +156,7 @@ namespace FasterLogSample
             {
                 while (!iter.GetNext(out result, out _, out _))
                 {
-                    // For finite end address, check if iteration ended
-                    // if (currentAddress >= endAddress) return; 
+                    if (iter.Ended) return;
                     iter.WaitAsync().AsTask().GetAwaiter().GetResult();
                 }
 

--- a/cs/src/core/FasterLog/FasterLog.cs
+++ b/cs/src/core/FasterLog/FasterLog.cs
@@ -133,7 +133,7 @@ namespace FASTER.core
                     new DefaultCheckpointNamingScheme(
                         logSettings.LogCommitDir ??
                         new FileInfo(logSettings.LogDevice.FileName).Directory.FullName),
-                    logSettings.ReadOnlyMode ? false : logSettings.RemoveOutdatedCommits);
+                    !logSettings.ReadOnlyMode && logSettings.RemoveOutdatedCommits);
 
             if (logSettings.LogCommitManager == null)
                 disposeLogCommitManager = true;

--- a/cs/src/core/FasterLog/FasterLogIterator.cs
+++ b/cs/src/core/FasterLog/FasterLogIterator.cs
@@ -32,6 +32,13 @@ namespace FASTER.core
         /// </summary>
         public long CompletedUntilAddress;
 
+
+        /// <summary>
+        /// Whether the underlying log is completed. A completed log will no longer allow enqueues, and there will be
+        /// no more entries if the iterator has exhausted current entries. 
+        /// </summary>
+        public bool LogCompleted => fasterLog.LogCompleted;
+
         /// <summary>
         /// Constructor
         /// </summary>

--- a/cs/src/core/FasterLog/FasterLogIterator.cs
+++ b/cs/src/core/FasterLog/FasterLogIterator.cs
@@ -190,7 +190,7 @@ namespace FASTER.core
         /// Get next record in iterator
         /// </summary>
         /// <param name="entry">Copy of entry, if found</param>
-        /// <param name="entryLength">Actual length of entry, or 0 for the last entry in a completed log</param>
+        /// <param name="entryLength">Actual length of entry</param>
         /// <param name="currentAddress">Logical address of entry</param>
         /// <returns></returns>
         public unsafe bool GetNext(out byte[] entry, out int entryLength, out long currentAddress)
@@ -202,7 +202,7 @@ namespace FASTER.core
         /// Get next record in iterator
         /// </summary>
         /// <param name="entry">Copy of entry, if found</param>
-        /// <param name="entryLength">Actual length of entry, or 0 for the last entry in a completed log</param>
+        /// <param name="entryLength">Actual length of entry</param>
         /// <param name="currentAddress">Logical address of entry</param>
         /// <param name="nextAddress">Logical address of next entry</param>
         /// <returns></returns>
@@ -283,7 +283,7 @@ namespace FASTER.core
         /// </summary>
         /// <param name="pool">Memory pool</param>
         /// <param name="entry">Copy of entry, if found</param>
-        /// <param name="entryLength">Actual length of entry, or 0 for the last entry in a completed log</param>
+        /// <param name="entryLength">Actual length of entry</param>
         /// <param name="currentAddress">Logical address of entry</param>
         /// <returns></returns>
         public unsafe bool GetNext(MemoryPool<byte> pool, out IMemoryOwner<byte> entry, out int entryLength, out long currentAddress)
@@ -296,7 +296,7 @@ namespace FASTER.core
         /// </summary>
         /// <param name="pool">Memory pool</param>
         /// <param name="entry">Copy of entry, if found</param>
-        /// <param name="entryLength">Actual length of entry, or 0 for the last entry in a completed log</param>
+        /// <param name="entryLength">Actual length of entry</param>
         /// <param name="currentAddress">Logical address of entry</param>
         /// <param name="nextAddress">Logical address of next entry</param>
         /// <returns></returns>
@@ -366,7 +366,7 @@ namespace FASTER.core
         /// Make sure to call UnsafeRelease when done processing the raw bytes (without delay).
         /// </summary>
         /// <param name="entry">Copy of entry, if found</param>
-        /// <param name="entryLength">Actual length of entry, or 0 for the last entry in a completed log</param>
+        /// <param name="entryLength">Actual length of entry</param>
         /// <param name="currentAddress">Logical address of entry</param>
         /// <param name="nextAddress">Logical address of next entry</param>
         /// <returns></returns>

--- a/cs/src/core/FasterLog/FasterLogIterator.cs
+++ b/cs/src/core/FasterLog/FasterLogIterator.cs
@@ -82,15 +82,15 @@ namespace FASTER.core
                 long nextAddress;
                 while (!GetNext(out result, out length, out currentAddress, out nextAddress))
                 {
-
                     if (currentAddress >= endAddress)
                         yield break;
                     if (!await WaitAsync(token).ConfigureAwait(false))
                         yield break;
+                    // EOF
+                    if (fasterLog.LogCompleted)
+                        yield break;
                 }
-                // EOF
-                if (fasterLog.LogCompleted)
-                    yield break;
+
                 yield return (result, length, currentAddress, nextAddress);
             }
         }
@@ -113,10 +113,10 @@ namespace FASTER.core
                         yield break;
                     if (!await WaitAsync(token).ConfigureAwait(false))
                         yield break;
+                    // EOF
+                    if (fasterLog.LogCompleted)
+                        yield break;
                 }
-                // EOF
-                if (fasterLog.LogCompleted)
-                    yield break;
                 yield return (result, length, currentAddress, nextAddress);
             }
         }

--- a/cs/src/core/FasterLog/FasterLogIterator.cs
+++ b/cs/src/core/FasterLog/FasterLogIterator.cs
@@ -82,7 +82,7 @@ namespace FASTER.core
                         yield break;
                 }
                 // EOF
-                if (length == 0)
+                if (fasterLog.LogCompleted)
                     yield break;
                 yield return (result, length, currentAddress, nextAddress);
             }
@@ -108,7 +108,7 @@ namespace FASTER.core
                         yield break;
                 }
                 // EOF
-                if (length == 0)
+                if (fasterLog.LogCompleted)
                     yield break;
                 yield return (result, length, currentAddress, nextAddress);
             }
@@ -240,11 +240,11 @@ namespace FASTER.core
                     info.Initialize(new BinaryReader(new UnmanagedMemoryStream((byte *)physicalAddress, entryLength)));
                     if (info.CommitNum != long.MaxValue) continue;
                     
-                    // Otherwise, set return entry length to be 0 to indicate eof
-                    entry = null;
-                    entryLength = 0;
+                    // Otherwise, no more entries
+                    entry = default;
+                    entryLength = default;
                     epoch.Suspend();
-                    return true;
+                    return false;
                 }
                 
                 if (getMemory != null)
@@ -337,11 +337,11 @@ namespace FASTER.core
                     info.Initialize(new BinaryReader(new UnmanagedMemoryStream((byte *)physicalAddress, entryLength)));
                     if (info.CommitNum != long.MaxValue) continue;
                     
-                    // Otherwise, set return entry length to be 0 to indicate eof
-                    entry = null;
-                    entryLength = 0;
+                    // Otherwise, no more entries
+                    entry = default;
+                    entryLength = default;
                     epoch.Suspend();
-                    return true;
+                    return false;
                 }
                 
                 entry = pool.Rent(entryLength);
@@ -404,10 +404,11 @@ namespace FASTER.core
                     info.Initialize(new BinaryReader(new UnmanagedMemoryStream((byte *)physicalAddress, entryLength)));
                     if (info.CommitNum != long.MaxValue) continue;
                     
-                    // Otherwise, set return entry length to be 0 to indicate eof
-                    entry = null;
-                    entryLength = 0;
-                    return true;
+                    // Otherwise, no more entries
+                    entry = default;
+                    entryLength = default;
+                    epoch.Suspend();
+                    return false;
                 }
                 
                 entry = (byte*)(headerSize + physicalAddress);

--- a/cs/src/core/FasterLog/FasterLogRecoveryInfo.cs
+++ b/cs/src/core/FasterLog/FasterLogRecoveryInfo.cs
@@ -20,6 +20,11 @@ namespace FASTER.core
         const int FasterLogRecoveryVersion = 1;
 
         /// <summary>
+        /// Whether this commit record is the last of ta log that will not longer be enqueued to
+        /// </summary>
+        public bool LogCompleted;
+
+        /// <summary>
         /// Begin address
         /// </summary>
         public long BeginAddress;
@@ -84,6 +89,7 @@ namespace FASTER.core
                     CommitNum = reader.ReadInt64();
                 else
                     CommitNum = -1;
+                LogCompleted = reader.ReadBoolean();
             }
             catch (Exception e)
             {
@@ -179,6 +185,7 @@ namespace FASTER.core
                 writer.Write(BeginAddress);
                 writer.Write(UntilAddress);
                 writer.Write(CommitNum);
+                writer.Write(LogCompleted);
 
                 writer.Write(iteratorCount);
                 if (iteratorCount > 0)
@@ -209,7 +216,7 @@ namespace FASTER.core
                     iteratorSize += kvp.Key.Length + sizeof(long);
             }
 
-            return sizeof(int) + 4 * sizeof(long) + iteratorSize + sizeof(int) + (Cookie?.Length ?? 0);
+            return sizeof(int) + 4 * sizeof(long) + iteratorSize + sizeof(int) + (Cookie?.Length ?? 0) + sizeof(bool);
         }
 
         /// <summary>

--- a/cs/test/DeviceFasterLogTests.cs
+++ b/cs/test/DeviceFasterLogTests.cs
@@ -135,9 +135,8 @@ namespace FASTER.test
                         }
                         break;
                     case FasterLogTestBase.IteratorType.Sync:
-                        while (iter.GetNext(out byte[] result, out var length, out _))
+                        while (iter.GetNext(out byte[] result, out _, out _))
                         {
-                            if (log.LogCompleted) break;
                             Assert.IsTrue(result.SequenceEqual(entry));
                             counter.IncrementAndMaybeTruncateUntil(iter.NextAddress);
                         }

--- a/cs/test/DeviceFasterLogTests.cs
+++ b/cs/test/DeviceFasterLogTests.cs
@@ -137,7 +137,7 @@ namespace FASTER.test
                     case FasterLogTestBase.IteratorType.Sync:
                         while (iter.GetNext(out byte[] result, out var length, out _))
                         {
-                            if (length == 0) break;
+                            if (log.LogCompleted) break;
                             Assert.IsTrue(result.SequenceEqual(entry));
                             counter.IncrementAndMaybeTruncateUntil(iter.NextAddress);
                         }

--- a/cs/test/FasterLogResumeTests.cs
+++ b/cs/test/FasterLogResumeTests.cs
@@ -112,7 +112,6 @@ namespace FASTER.test
 
             using (var logCommitManager = new DeviceLogCommitCheckpointManager(new LocalStorageNamedDeviceFactory(), new DefaultCheckpointNamingScheme(path), removeOutdated))
             {
-
                 long originalCompleted;
 
                 using (var l = new FasterLog(new FasterLogSettings { LogDevice = device, PageSizeBits = 16, MemorySizeBits = 16, LogChecksum = logChecksum, LogCommitManager = logCommitManager }))


### PR DESCRIPTION
Logs can be "completed" by enqueuing a special commit records that will interrupt async waiting on async iterators.

Completion persists across restarts and prevents future enqueues. 