### PR TITLE
[C++] Bugfix on cleaning hash index buckets

### DIFF
--- a/cc/src/core/faster.h
+++ b/cc/src/core/faster.h
@@ -2150,9 +2150,9 @@ bool FasterKv<K, V, D>::CleanHashTableBuckets() {
   uint8_t version = resize_info_.version;
   Address begin_address = hlog.begin_address.load();
   uint64_t upper_bound;
-  if(chunk + 1 < grow_.num_chunks) {
-    // All chunks but the last chunk contain kGrowHashTableChunkSize elements.
-    upper_bound = kGrowHashTableChunkSize;
+  if(chunk + 1 < gc_.num_chunks) {
+    // All chunks but the last chunk contain kGcHashTableChunkSize elements.
+    upper_bound = kGcHashTableChunkSize;
   } else {
     // Last chunk might contain more or fewer elements.
     upper_bound = state_[version].size() - (chunk * kGcHashTableChunkSize);


### PR DESCRIPTION
This bugfix is connected to some spurious assertion error messages that may occur during log compaction or log truncation (i.e. `ShiftBeginAddress`).  Example of such an error message is the following: 

```
Assertion `idx < size_' failed.
```

This error message is also mentioned in #582, where a partial solution is proposed, yet it does not fix the underlying issue.