### PR TITLE
fix BeginAddress and EndAddress in MemoryPageScanIterator

### DIFF
--- a/cs/src/core/Allocator/MemoryPageScanIterator.cs
+++ b/cs/src/core/Allocator/MemoryPageScanIterator.cs
@@ -37,9 +37,9 @@ namespace FASTER.core
 
         public long NextAddress => pageStartAddress + (offset + 1) * recordSize;
 
-        public long BeginAddress => start;
+        public long BeginAddress => pageStartAddress + start * recordSize;
 
-        public long EndAddress => end;
+        public long EndAddress => pageStartAddress + end * recordSize;
 
         public void Dispose()
         {


### PR DESCRIPTION
I noticed that the fix in #631 did not include the new properties `BeginAddress` and `EndAddress` that were added to MemoryPageScanIterator in v2. 

Since this is a semantic merge conflict it went undetected. This PR is the easy fix. 