### PR TITLE
[C#] Support int session ID for FasterKV

### DIFF
--- a/cs/benchmark/Functions.cs
+++ b/cs/benchmark/Functions.cs
@@ -25,9 +25,9 @@ namespace FASTER.benchmark
         {
         }
 
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
+        public void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
         {
-            Debug.WriteLine("Session {0} reports persistence until {1}", sessionId, commitPoint.UntilSerialNo);
+            Debug.WriteLine("Session {0} reports persistence until {1}", sessionID, commitPoint.UntilSerialNo);
         }
 
         // Read functions

--- a/cs/benchmark/Functions.cs
+++ b/cs/benchmark/Functions.cs
@@ -27,7 +27,7 @@ namespace FASTER.benchmark
 
         public void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
         {
-            Debug.WriteLine("Session {0} reports persistence until {1}", sessionID, commitPoint.UntilSerialNo);
+            Debug.WriteLine($"Session {sessionID} ({(sessionName ?? "null")}) reports persistence until {commitPoint.UntilSerialNo}");
         }
 
         // Read functions

--- a/cs/playground/SumStore/SumStoreTypes.cs
+++ b/cs/playground/SumStore/SumStoreTypes.cs
@@ -41,7 +41,7 @@ namespace SumStore
     {
         public override void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
         {
-            Console.WriteLine("Session {0} reports persistence until {1}", sessionID, commitPoint.UntilSerialNo);
+            Console.WriteLine($"Session {sessionID} ({(sessionName ?? "null")}) reports persistence until {commitPoint.UntilSerialNo}");
         }
 
         // Read functions

--- a/cs/playground/SumStore/SumStoreTypes.cs
+++ b/cs/playground/SumStore/SumStoreTypes.cs
@@ -39,9 +39,9 @@ namespace SumStore
 
     public sealed class Functions : FunctionsBase<AdId, NumClicks, Input, Output, Empty>
     {
-        public override void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
+        public override void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
         {
-            Console.WriteLine("Session {0} reports persistence until {1}", sessionId, commitPoint.UntilSerialNo);
+            Console.WriteLine("Session {0} reports persistence until {1}", sessionID, commitPoint.UntilSerialNo);
         }
 
         // Read functions

--- a/cs/remote/samples/FixedLenServer/Types.cs
+++ b/cs/remote/samples/FixedLenServer/Types.cs
@@ -64,8 +64,8 @@ namespace FasterFixedLenServer
 
         public void DeleteCompletionCallback(ref Key key, long ctx) { }
 
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-            => Debug.WriteLine("Session {0} reports persistence until {1}", sessionId, commitPoint.UntilSerialNo);
+        public void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
+            => Debug.WriteLine("Session {0} reports persistence until {1}", sessionID, commitPoint.UntilSerialNo);
 
         // Read functions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/cs/remote/src/FASTER.server/ServerKVFunctions.cs
+++ b/cs/remote/src/FASTER.server/ServerKVFunctions.cs
@@ -17,8 +17,8 @@ namespace FASTER.server
             this.serverNetworkSession = serverNetworkSession;
         }
 
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-            => functions.CheckpointCompletionCallback(sessionId, commitPoint);
+        public void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
+            => functions.CheckpointCompletionCallback(sessionID, sessionName, commitPoint);
 
         public void SingleDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, long address)
             => functions.SingleDeleter(ref key, ref value, ref recordInfo, address);

--- a/cs/samples/StoreAsyncApi/Types.cs
+++ b/cs/samples/StoreAsyncApi/Types.cs
@@ -93,11 +93,6 @@ namespace StoreAsyncApi
             return true;
         }
 
-        public override void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
-        {
-            // Console.WriteLine("Session {0} reports persistence until {1}", sessionId, commitPoint.UntilSerialNo);
-        }
-
         public override void ReadCompletionCallback(ref CacheKey key, ref CacheInput input, ref CacheOutput output, CacheContext ctx, Status status, RecordMetadata recordMetadata)
         {
             if (ctx.type == 0)

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -121,7 +121,12 @@ namespace FASTER.core
         /// <summary>
         /// Get session ID
         /// </summary>
-        public string ID { get { return ctx.guid; } }
+        public int ID { get { return ctx.sessionID; } }
+
+        /// <summary>
+        /// Get session name
+        /// </summary>
+        public string Name { get { return ctx.sessionName; } }
 
         /// <summary>
         /// Next sequential serial no for session (current serial no + 1)
@@ -145,7 +150,7 @@ namespace FASTER.core
         {
             this.completedOutputs?.Dispose();
             CompletePending(true);
-            fht.DisposeClientSession(ID);
+            fht.DisposeClientSession(ID, ctx.phase);
         }
 
         /// <summary>
@@ -1037,9 +1042,9 @@ namespace FASTER.core
             #endregion Key and Value management
 
             #region IFunctions - Checkpointing
-            public void CheckpointCompletionCallback(string guid, CommitPoint commitPoint)
+            public void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
             {
-                _clientSession.functions.CheckpointCompletionCallback(guid, commitPoint);
+                _clientSession.functions.CheckpointCompletionCallback(sessionID, sessionName, commitPoint);
                 _clientSession.LatestCommitPoint = commitPoint;
             }
             #endregion IFunctions - Checkpointing

--- a/cs/src/core/ClientSession/FASTERClientSession.cs
+++ b/cs/src/core/ClientSession/FASTERClientSession.cs
@@ -157,6 +157,9 @@ namespace FASTER.core
             if (functions == null)
                 throw new ArgumentNullException(nameof(functions));
 
+            if (sessionName == "")
+                throw new FasterException("Cannot use empty string as session name");
+
             if (sessionName != null && _recoveredSessionNameMap != null && _recoveredSessionNameMap.ContainsKey(sessionName))
                 throw new FasterException($"Session named {sessionName} already exists in recovery info, use RecoverSession to resume it");
 

--- a/cs/src/core/ClientSession/FASTERClientSession.cs
+++ b/cs/src/core/ClientSession/FASTERClientSession.cs
@@ -11,7 +11,7 @@ namespace FASTER.core
 {
     public unsafe partial class FasterKV<Key, Value> : FasterBase, IFasterKV<Key, Value>
     {
-        internal Dictionary<string, IClientSession> _activeSessions = new();
+        internal Dictionary<int, SessionInfo> _activeSessions = new();
 
         /// <summary>
         /// Client session type helper
@@ -34,63 +34,81 @@ namespace FASTER.core
             /// Start a new client session with FASTER.
             /// </summary>
             /// <param name="functions">Callback functions</param>
-            /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
+            /// <param name="sessionName">Name of session (optional)</param>
             /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(Functions functions, string sessionId = null,
+            public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(Functions functions, string sessionName = null,
                     SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
-                return _fasterKV.NewSession<Input, Output, Context, Functions>(functions, sessionId, sessionVariableLengthStructSettings);
+                return _fasterKV.NewSession<Input, Output, Context, Functions>(functions, sessionName, sessionVariableLengthStructSettings);
             }
 
             /// <summary>
             /// Resume (continue) prior client session with FASTER; used during recovery from failure.
             /// </summary>
             /// <param name="functions">Callback functions</param>
-            /// <param name="sessionId">ID/name of previous session to resume</param>
+            /// <param name="sessionName">Name of previous session to resume</param>
             /// <param name="commitPoint">Prior commit point of durability for session</param>
             /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(Functions functions, string sessionId, out CommitPoint commitPoint,
+            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(Functions functions, string sessionName, out CommitPoint commitPoint,
                     SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
-                return _fasterKV.ResumeSession<Input, Output, Context, Functions>(functions, sessionId, out commitPoint, sessionVariableLengthStructSettings);
+                return _fasterKV.ResumeSession<Input, Output, Context, Functions>(functions, sessionName, out commitPoint, sessionVariableLengthStructSettings);
             }
 
             /// <summary>
             /// Start a new client session with FASTER.
             /// </summary>
-            /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
+            /// <param name="sessionName">Name of session (optional)</param>
             /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(string sessionId = null, 
+            public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(string sessionName = null, 
                     SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
                 if (_functions == null)
                     throw new FasterException("Functions not provided for session");
 
-                return _fasterKV.NewSession<Input, Output, Context, Functions>((Functions)_functions, sessionId, sessionVariableLengthStructSettings);
+                return _fasterKV.NewSession<Input, Output, Context, Functions>((Functions)_functions, sessionName, sessionVariableLengthStructSettings);
             }
 
             /// <summary>
             /// Resume (continue) prior client session with FASTER, used during
             /// recovery from failure.
             /// </summary>
-            /// <param name="sessionId">ID/name of previous session to resume</param>
+            /// <param name="sessionName">Name of previous session to resume</param>
             /// <param name="commitPoint">Prior commit point of durability for session</param>
             /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(string sessionId, out CommitPoint commitPoint,
+            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(string sessionName, out CommitPoint commitPoint,
                     SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
                 if (_functions == null)
                     throw new FasterException("Functions not provided for session");
 
-                return _fasterKV.ResumeSession<Input, Output, Context, Functions>((Functions)_functions, sessionId, out commitPoint, sessionVariableLengthStructSettings);
+                return _fasterKV.ResumeSession<Input, Output, Context, Functions>((Functions)_functions, sessionName, out commitPoint, sessionVariableLengthStructSettings);
+            }
+
+            /// <summary>
+            /// Resume (continue) prior client session with FASTER, used during
+            /// recovery from failure.
+            /// </summary>
+            /// <param name="sessionID">ID of previous session to resume</param>
+            /// <param name="commitPoint">Prior commit point of durability for session</param>
+            /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
+            /// <returns>Session instance</returns>
+            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(int sessionID, out CommitPoint commitPoint,
+                    SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
+                where Functions : IFunctions<Key, Value, Input, Output, Context>
+            {
+                if (_functions == null)
+                    throw new FasterException("Functions not provided for session");
+
+                return _fasterKV.ResumeSession<Input, Output, Context, Functions>((Functions)_functions, sessionID, out commitPoint, sessionVariableLengthStructSettings);
             }
         }
 
@@ -111,50 +129,52 @@ namespace FASTER.core
         /// For performance reasons, please use <see cref="FasterKV{Key, Value}.For{Input, Output, Context}(IFunctions{Key, Value, Input, Output, Context})"/> instead of this overload.
         /// </summary>
         /// <param name="functions">Callback functions</param>
-        /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
+        /// <param name="sessionName">Name of session (auto-generated if not provided)</param>
         /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
-        public ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> NewSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions, string sessionId = null,
+        public ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> NewSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions, string sessionName = null,
                 SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
         {
-            return NewSession<Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>>(functions, sessionId, sessionVariableLengthStructSettings);
+            return NewSession<Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>>(functions, sessionName, sessionVariableLengthStructSettings);
         }
 
         /// <summary>
         /// Start a new client session with FASTER.
         /// </summary>
         /// <param name="functions">Callback functions</param>
-        /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
+        /// <param name="sessionName">Name of session (optional)</param>
         /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
-        internal ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Input, Output, Context, Functions>(Functions functions, string sessionId = null,
+        internal ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Input, Output, Context, Functions>(Functions functions, string sessionName = null,
                 SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
             where Functions : IFunctions<Key, Value, Input, Output, Context>
-            => InternalNewSession<Input, Output, Context, Functions, ClientSession<Key, Value, Input, Output, Context, Functions>>(functions, sessionId,
+            => InternalNewSession<Input, Output, Context, Functions, ClientSession<Key, Value, Input, Output, Context, Functions>>(functions, sessionName,
                             ctx => new ClientSession<Key, Value, Input, Output, Context, Functions>(this, ctx, functions, sessionVariableLengthStructSettings));
 
-        private TSession InternalNewSession<Input, Output, Context, Functions, TSession>(Functions functions, string sessionId, Func<FasterExecutionContext<Input, Output, Context>, TSession> sessionCreator)
+        private TSession InternalNewSession<Input, Output, Context, Functions, TSession>(Functions functions, string sessionName, Func<FasterExecutionContext<Input, Output, Context>, TSession> sessionCreator)
             where TSession : IClientSession
         {
             if (functions == null)
                 throw new ArgumentNullException(nameof(functions));
 
-            if (sessionId == null)
-                sessionId = Guid.NewGuid().ToString();
+            if (sessionName != null && _recoveredSessionNameMap != null && _recoveredSessionNameMap.ContainsKey(sessionName))
+                throw new FasterException($"Session named {sessionName} already exists in recovery info, use RecoverSession to resume it");
+
+            int sessionId = Interlocked.Increment(ref maxSessionId);
             var ctx = new FasterExecutionContext<Input, Output, Context>();
-            InitContext(ctx, sessionId);
+            InitContext(ctx, sessionId, sessionName);
             var prevCtx = new FasterExecutionContext<Input, Output, Context>();
-            InitContext(prevCtx, sessionId);
+            InitContext(prevCtx, sessionId, sessionName);
             prevCtx.version--;
 
             ctx.prevCtx = prevCtx;
 
             if (_activeSessions == null)
-                Interlocked.CompareExchange(ref _activeSessions, new Dictionary<string, IClientSession>(), null);
+                Interlocked.CompareExchange(ref _activeSessions, new Dictionary<int, SessionInfo>(), null);
 
             var session = sessionCreator(ctx);
             lock (_activeSessions)
-                _activeSessions.Add(sessionId, session);
+                _activeSessions.Add(sessionId, new SessionInfo { sessionName = sessionName, session = session, isActive = true });
             return session;
         }
 
@@ -163,14 +183,14 @@ namespace FASTER.core
         /// For performance reasons this overload is not recommended if functions is value type (struct).
         /// </summary>
         /// <param name="functions">Callback functions</param>
-        /// <param name="sessionId">ID/name of previous session to resume</param>
+        /// <param name="sessionName">Name of previous session to resume</param>
         /// <param name="commitPoint">Prior commit point of durability for session</param>
         /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
-        public ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> ResumeSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions, string sessionId,
+        public ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> ResumeSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions, string sessionName,
                 out CommitPoint commitPoint, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
         {
-            return ResumeSession<Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>>(functions, sessionId, out commitPoint, sessionVariableLengthStructSettings);
+            return ResumeSession<Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>>(functions, sessionName, out commitPoint, sessionVariableLengthStructSettings);
         }
 
         /// <summary>
@@ -178,48 +198,91 @@ namespace FASTER.core
         /// recovery from failure.
         /// </summary>
         /// <param name="functions">Callback functions</param>
-        /// <param name="sessionId">ID/name of previous session to resume</param>
+        /// <param name="sessionName">Name of previous session to resume</param>
         /// <param name="commitPoint">Prior commit point of durability for session</param>
         /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
-
-        internal ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Input, Output, Context, Functions>(Functions functions, string sessionId, out CommitPoint commitPoint,
+        internal ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Input, Output, Context, Functions>(Functions functions, string sessionName, out CommitPoint commitPoint,
                 SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
             where Functions : IFunctions<Key, Value, Input, Output, Context>
         {
+            if (_recoveredSessionNameMap == null || !_recoveredSessionNameMap.TryRemove(sessionName, out int sessionId))
+                throw new FasterException($"Unable to find session named {sessionName} to recover");
+
             return InternalResumeSession<Input, Output, Context, Functions, ClientSession<Key, Value, Input, Output, Context, Functions>>(functions, sessionId, out commitPoint,
                         ctx => new ClientSession<Key, Value, Input, Output, Context, Functions>(this, ctx, functions, sessionVariableLengthStructSettings));
         }
 
-        private TSession InternalResumeSession<Input, Output, Context, Functions, TSession>(Functions functions, string sessionId, out CommitPoint commitPoint,
+        /// <summary>
+        /// Resume (continue) prior client session with FASTER; used during recovery from failure.
+        /// For performance reasons this overload is not recommended if functions is value type (struct).
+        /// </summary>
+        /// <param name="functions">Callback functions</param>
+        /// <param name="sessionID">ID of previous session to resume</param>
+        /// <param name="commitPoint">Prior commit point of durability for session</param>
+        /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
+        /// <returns>Session instance</returns>
+        public ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> ResumeSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions, int sessionID,
+                out CommitPoint commitPoint, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
+        {
+            return ResumeSession<Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>>(functions, sessionID, out commitPoint, sessionVariableLengthStructSettings);
+        }
+
+        /// <summary>
+        /// Resume (continue) prior client session with FASTER, used during
+        /// recovery from failure.
+        /// </summary>
+        /// <param name="functions">Callback functions</param>
+        /// <param name="sessionID">ID of previous session to resume</param>
+        /// <param name="commitPoint">Prior commit point of durability for session</param>
+        /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
+        /// <returns>Session instance</returns>
+        internal ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Input, Output, Context, Functions>(Functions functions, int sessionID, out CommitPoint commitPoint,
+                SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null)
+            where Functions : IFunctions<Key, Value, Input, Output, Context>
+        {
+            return InternalResumeSession<Input, Output, Context, Functions, ClientSession<Key, Value, Input, Output, Context, Functions>>(functions, sessionID, out commitPoint,
+                        ctx => new ClientSession<Key, Value, Input, Output, Context, Functions>(this, ctx, functions, sessionVariableLengthStructSettings));
+        }
+
+        private TSession InternalResumeSession<Input, Output, Context, Functions, TSession>(Functions functions, int sessionID, out CommitPoint commitPoint,
                                                                                             Func<FasterExecutionContext<Input, Output, Context>, TSession> sessionCreator)
              where TSession : IClientSession
         {
             if (functions == null)
                 throw new ArgumentNullException(nameof(functions));
 
-            commitPoint = InternalContinue<Input, Output, Context>(sessionId, out var ctx);
+            string sessionName;
+            (sessionName, commitPoint) = InternalContinue<Input, Output, Context>(sessionID, out var ctx);
             if (commitPoint.UntilSerialNo == -1)
-                throw new Exception($"Unable to find session {sessionId} to recover");
+                throw new Exception($"Unable to find session {sessionID} to recover");
 
             var session = sessionCreator(ctx);
 
             if (_activeSessions == null)
-                Interlocked.CompareExchange(ref _activeSessions, new Dictionary<string, IClientSession>(), null);
+                Interlocked.CompareExchange(ref _activeSessions, new Dictionary<int, SessionInfo>(), null);
             lock (_activeSessions)
-                _activeSessions.Add(sessionId, session);
+                _activeSessions.Add(sessionID, new SessionInfo { sessionName = sessionName, session = session, isActive = true });
             return session;
         }
 
         /// <summary>
         /// Dispose session with FASTER
         /// </summary>
-        /// <param name="guid"></param>
+        /// <param name="sessionId"></param>
+        /// <param name="sessionPhase"></param>
         /// <returns></returns>
-        internal void DisposeClientSession(string guid)
+        internal void DisposeClientSession(int sessionId, Phase sessionPhase)
         {
+            // If a session is disposed during a checkpoint cycle, we mark the session
+            // as inactive, but wait until the end of checkpoint before disposing it
             lock (_activeSessions)
-                _activeSessions.Remove(guid);
+            {
+                if (sessionPhase == Phase.REST || sessionPhase == Phase.PREPARE_GROW || sessionPhase == Phase.IN_PROGRESS_GROW)
+                    _activeSessions.Remove(sessionId);
+                else
+                    _activeSessions[sessionId].isActive = false;
+            }
         }
     }
 }

--- a/cs/src/core/ClientSession/IClientSession.cs
+++ b/cs/src/core/ClientSession/IClientSession.cs
@@ -3,6 +3,13 @@
 
 namespace FASTER.core
 {
+    class SessionInfo
+    {
+        public string sessionName;
+        public bool isActive;
+        public IClientSession session;
+    }
+
     internal interface IClientSession
     {
         void AtomicSwitch(long version);

--- a/cs/src/core/ClientSession/LockableUnsafeContext.cs
+++ b/cs/src/core/ClientSession/LockableUnsafeContext.cs
@@ -605,9 +605,9 @@ namespace FASTER.core
             #endregion Key and Value management
 
             #region IFunctions - Checkpointing
-            public void CheckpointCompletionCallback(string guid, CommitPoint commitPoint)
+            public void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
             {
-                _clientSession.functions.CheckpointCompletionCallback(guid, commitPoint);
+                _clientSession.functions.CheckpointCompletionCallback(sessionID, sessionName, commitPoint);
                 _clientSession.LatestCommitPoint = commitPoint;
             }
 #endregion IFunctions - Checkpointing

--- a/cs/src/core/ClientSession/UnsafeContext.cs
+++ b/cs/src/core/ClientSession/UnsafeContext.cs
@@ -611,9 +611,9 @@ namespace FASTER.core
             #endregion Key and Value management
 
             #region IFunctions - Checkpointing
-            public void CheckpointCompletionCallback(string guid, CommitPoint commitPoint)
+            public void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
             {
-                _clientSession.functions.CheckpointCompletionCallback(guid, commitPoint);
+                _clientSession.functions.CheckpointCompletionCallback(sessionID, sessionName, commitPoint);
                 _clientSession.LatestCommitPoint = commitPoint;
             }
             #endregion IFunctions - Checkpointing

--- a/cs/src/core/Compaction/LogCompactionFunctions.cs
+++ b/cs/src/core/Compaction/LogCompactionFunctions.cs
@@ -14,7 +14,7 @@ namespace FASTER.core
             _functions = functions;
         }
 
-        public void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint) { }
+        public void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint) { }
 
         /// <summary>
         /// No reads during compaction

--- a/cs/src/core/FasterLog/FasterLog.cs
+++ b/cs/src/core/FasterLog/FasterLog.cs
@@ -382,8 +382,8 @@ namespace FASTER.core
         }
 
         /// <summary>
-        /// Try to append a user-defined header byte and three SpanByte entries entries atomically to the log. If it returns true, we are
-        /// done. If it returns false, we need to retry.
+        /// Try to append a user-defined blittable struct header and three SpanByte entries entries atomically to the log.
+        /// If it returns true, we are done. If it returns false, we need to retry.
         /// </summary>
         /// <param name="userHeader"></param>
         /// <param name="item1"></param>
@@ -391,10 +391,11 @@ namespace FASTER.core
         /// <param name="item3"></param>
         /// <param name="logicalAddress">Logical address of added entry</param>
         /// <returns>Whether the append succeeded</returns>
-        public unsafe bool TryEnqueue(byte userHeader, ref SpanByte item1, ref SpanByte item2, ref SpanByte item3, out long logicalAddress)
+        public unsafe bool TryEnqueue<THeader>(THeader userHeader, ref SpanByte item1, ref SpanByte item2, ref SpanByte item3, out long logicalAddress)
+            where THeader : unmanaged
         {
             logicalAddress = 0;
-            var length = sizeof(byte) + item1.TotalSize + item2.TotalSize + item3.TotalSize;
+            var length = sizeof(THeader) + item1.TotalSize + item2.TotalSize + item3.TotalSize;
             int allocatedLength = headerSize + Align(length);
             ValidateAllocatedLength(allocatedLength);
 
@@ -409,83 +410,14 @@ namespace FASTER.core
             }
 
             var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
-            *physicalAddress = userHeader;
-            item1.CopyTo(physicalAddress + sizeof(byte));
-            item2.CopyTo(physicalAddress + sizeof(byte) + item1.TotalSize);
-            item3.CopyTo(physicalAddress + sizeof(byte) + item1.TotalSize + item2.TotalSize);
+            *(THeader*)physicalAddress = userHeader;
+            item1.CopyTo(physicalAddress + sizeof(THeader));
+            item2.CopyTo(physicalAddress + sizeof(THeader) + item1.TotalSize);
+            item3.CopyTo(physicalAddress + sizeof(THeader) + item1.TotalSize + item2.TotalSize);
             SetHeader(length, physicalAddress);
             epoch.Suspend();
             return true;
         }
-
-        /// <summary>
-        /// Try to append a user-defined header byte and two SpanByte entries entries atomically to the log. If it returns true, we are
-        /// done. If it returns false, we need to retry.
-        /// </summary>
-        /// <param name="userHeader"></param>
-        /// <param name="item1"></param>
-        /// <param name="item2"></param>
-        /// <param name="logicalAddress">Logical address of added entry</param>
-        /// <returns>Whether the append succeeded</returns>
-        public unsafe bool TryEnqueue(byte userHeader, ref SpanByte item1, ref SpanByte item2, out long logicalAddress)
-        {
-            logicalAddress = 0;
-            var length = sizeof(byte) + item1.TotalSize + item2.TotalSize;
-            int allocatedLength = headerSize + Align(length);
-            ValidateAllocatedLength(allocatedLength);
-
-            epoch.Resume();
-
-            logicalAddress = allocator.TryAllocateRetryNow(allocatedLength);
-            if (logicalAddress == 0)
-            {
-                epoch.Suspend();
-                if (cannedException != null) throw cannedException;
-                return false;
-            }
-
-            var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
-            *physicalAddress = userHeader;
-            item1.CopyTo(physicalAddress + sizeof(byte));
-            item2.CopyTo(physicalAddress + sizeof(byte) + item1.TotalSize);
-            SetHeader(length, physicalAddress);
-            epoch.Suspend();
-            return true;
-        }
-
-        /// <summary>
-        /// Try to append a user-defined header byte and a SpanByte entry atomically to the log. If it returns true, we are
-        /// done. If it returns false, we need to retry.
-        /// </summary>
-        /// <param name="userHeader"></param>
-        /// <param name="item"></param>
-        /// <param name="logicalAddress">Logical address of added entry</param>
-        /// <returns>Whether the append succeeded</returns>
-        public unsafe bool TryEnqueue(byte userHeader, ref SpanByte item, out long logicalAddress)
-        {
-            logicalAddress = 0;
-            var length = sizeof(byte) + item.TotalSize;
-            int allocatedLength = headerSize + Align(length);
-            ValidateAllocatedLength(allocatedLength);
-
-            epoch.Resume();
-
-            logicalAddress = allocator.TryAllocateRetryNow(allocatedLength);
-            if (logicalAddress == 0)
-            {
-                epoch.Suspend();
-                if (cannedException != null) throw cannedException;
-                return false;
-            }
-
-            var physicalAddress = (byte*)allocator.GetPhysicalAddress(logicalAddress);
-            *physicalAddress = userHeader;
-            item.CopyTo(physicalAddress + sizeof(byte));
-            SetHeader(length, physicalAddress);
-            epoch.Suspend();
-            return true;
-        }
-
 
         /// <summary>
         /// Try to enqueue batch of entries as a single atomic unit (to memory). Entire 

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -34,36 +34,6 @@ namespace FASTER.core
         ALLOCATE_FAILED
     }
 
-    internal class SerializedFasterExecutionContext
-    {
-        internal long version;
-        internal long serialNum;
-        internal int sessionID;
-        internal string sessionName;
-
-        /// <summary>
-        /// </summary>
-        /// <param name="writer"></param>
-        public void Write(StreamWriter writer)
-        {
-            writer.WriteLine(version);
-            writer.WriteLine(sessionName);
-            writer.WriteLine(sessionID);
-            writer.WriteLine(serialNum);
-        }
-
-        /// <summary>
-        /// </summary>
-        /// <param name="reader"></param>
-        public void Load(StreamReader reader)
-        {
-            version = long.Parse(reader.ReadLine());
-            sessionName = reader.ReadLine();
-            sessionID = int.Parse(reader.ReadLine());
-            serialNum = long.Parse(reader.ReadLine());
-        }
-    }
-
     public partial class FasterKV<Key, Value> : FasterBase, IFasterKV<Key, Value>
     {
         internal struct PendingContext<Input, Output, Context>
@@ -190,9 +160,15 @@ namespace FASTER.core
             }
         }
 
-        internal sealed class FasterExecutionContext<Input, Output, Context> : SerializedFasterExecutionContext
+        internal sealed class FasterExecutionContext<Input, Output, Context>
         {
+            internal int sessionID;
+            internal string sessionName;
+
+            internal long version;
+            internal long serialNum;
             public Phase phase;
+
             public bool[] markers;
             public long totalPending;
             public Queue<PendingContext<Input, Output, Context>> retryRequests;
@@ -423,6 +399,7 @@ namespace FASTER.core
             {
                 var sessionID = int.Parse(reader.ReadLine());
                 var sessionName = reader.ReadLine();
+                if (sessionName == "") sessionName = null;
                 var serialno = long.Parse(reader.ReadLine());
 
                 var exclusions = new List<long>();

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -331,7 +331,7 @@ namespace FASTER.core
         /// <summary>
         /// Max session ID
         /// </summary>
-        public int maxSessionId;
+        public int maxSessionID;
 
         /// <summary>
         /// Object log segment offsets
@@ -421,7 +421,7 @@ namespace FASTER.core
 
             for (int i = 0; i < numSessions; i++)
             {
-                var sessionId = int.Parse(reader.ReadLine());
+                var sessionID = int.Parse(reader.ReadLine());
                 var sessionName = reader.ReadLine();
                 var serialno = long.Parse(reader.ReadLine());
 
@@ -430,7 +430,7 @@ namespace FASTER.core
                 for (int j = 0; j < exclusionCount; j++)
                     exclusions.Add(long.Parse(reader.ReadLine()));
 
-                continueTokens.TryAdd(sessionId, (sessionName, new CommitPoint
+                continueTokens.TryAdd(sessionID, (sessionName, new CommitPoint
                 {
                     UntilSerialNo = serialno,
                     ExcludedSerialNos = exclusions
@@ -438,9 +438,9 @@ namespace FASTER.core
                 if (sessionName != null)
                 {
                     sessionNameMap ??= new();
-                    sessionNameMap.TryAdd(sessionName, sessionId);
+                    sessionNameMap.TryAdd(sessionName, sessionID);
                 }
-                if (sessionId > maxSessionId) maxSessionId = sessionId;
+                if (sessionID > maxSessionID) maxSessionID = sessionID;
             }
 
             // Read object log segment offsets

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -59,7 +59,9 @@ namespace FASTER.core
         /// </summary>
         public LogAccessor<Key, Value> ReadCache { get; }
 
-        internal ConcurrentDictionary<string, CommitPoint> _recoveredSessions;
+        ConcurrentDictionary<int, (string, CommitPoint)> _recoveredSessions;
+        ConcurrentDictionary<string, int> _recoveredSessionNameMap;
+        int maxSessionId;
 
         internal readonly bool DisableLocking;
         internal readonly LockTable<Key> LockTable;
@@ -78,8 +80,8 @@ namespace FASTER.core
         /// <param name="fasterKVConfig">Config settings</param>
         public FasterKV(FasterKVSettings<Key, Value> fasterKVConfig) :
             this(
-                fasterKVConfig.GetIndexSizeCacheLines(), fasterKVConfig.GetLogSettings(), 
-                fasterKVConfig.GetCheckpointSettings(), fasterKVConfig.GetSerializerSettings(), 
+                fasterKVConfig.GetIndexSizeCacheLines(), fasterKVConfig.GetLogSettings(),
+                fasterKVConfig.GetCheckpointSettings(), fasterKVConfig.GetSerializerSettings(),
                 fasterKVConfig.EqualityComparer, fasterKVConfig.GetVariableLengthStructSettings(),
                 fasterKVConfig.TryRecoverLatest, fasterKVConfig.DisableLocking)
         { }
@@ -438,7 +440,7 @@ namespace FASTER.core
         /// <param name="numPagesToPreload">Number of pages to preload into memory after recovery</param>
         /// <param name="undoNextVersion">Whether records with versions beyond checkpoint version need to be undone (and invalidated on log)</param>
         /// <param name="cancellationToken">Cancellation token</param>
-        public ValueTask RecoverAsync(Guid fullCheckpointToken, int numPagesToPreload = -1, bool undoNextVersion = true, CancellationToken cancellationToken = default) 
+        public ValueTask RecoverAsync(Guid fullCheckpointToken, int numPagesToPreload = -1, bool undoNextVersion = true, CancellationToken cancellationToken = default)
             => InternalRecoverAsync(fullCheckpointToken, fullCheckpointToken, numPagesToPreload, undoNextVersion, -1, cancellationToken);
 
         /// <summary>
@@ -451,6 +453,45 @@ namespace FASTER.core
         public void Recover(Guid indexCheckpointToken, Guid hybridLogCheckpointToken, int numPagesToPreload = -1, bool undoNextVersion = true)
         {
             InternalRecover(indexCheckpointToken, hybridLogCheckpointToken, numPagesToPreload, undoNextVersion, -1);
+        }
+
+        /// <summary>
+        /// Enumerate all currently recoverable sessions
+        /// </summary>
+        public IEnumerable<(int, string, CommitPoint)> RecoverableSessions
+        {
+            get
+            {
+                if (_recoveredSessions != null)
+                {
+                    foreach (var kvp in _recoveredSessions)
+                    {
+                        yield return (kvp.Key, kvp.Value.Item1, kvp.Value.Item2);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Dispose recoverable session with given ID, use RecoverableSessions to get recoverable session details
+        /// </summary>
+        /// <param name="sessionID"></param>
+        public void DisposeRecoverableSession(int sessionID)
+        {
+            if (_recoveredSessions != null && _recoveredSessions.TryRemove(sessionID, out var entry))
+            {
+                if (entry.Item1 != null)
+                    _recoveredSessionNameMap.TryRemove(entry.Item1, out _);
+            }
+        }
+
+        /// <summary>
+        /// Dispose (all) recoverable sessions
+        /// </summary>
+        public void DisposeRecoverableSessions()
+        {
+            _recoveredSessions = null;
+            _recoveredSessionNameMap = null;
         }
 
         /// <summary>

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -61,7 +61,7 @@ namespace FASTER.core
 
         ConcurrentDictionary<int, (string, CommitPoint)> _recoveredSessions;
         ConcurrentDictionary<string, int> _recoveredSessionNameMap;
-        int maxSessionId;
+        int maxSessionID;
 
         internal readonly bool DisableLocking;
         internal readonly LockTable<Key> LockTable;

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -78,7 +78,7 @@ namespace FASTER.core
             ThreadStateMachineStep(ctx, fasterSession, default);
         }
 
-        internal void InitContext<Input, Output, Context>(FasterExecutionContext<Input, Output, Context> ctx, int sessionId, string sessionName, long lsn = -1)
+        internal void InitContext<Input, Output, Context>(FasterExecutionContext<Input, Output, Context> ctx, int sessionID, string sessionName, long lsn = -1)
         {
             ctx.phase = Phase.REST;
             // The system version starts at 1. Because we do not know what the current state machine state is,
@@ -87,7 +87,7 @@ namespace FASTER.core
             ctx.version = 1;
             ctx.markers = new bool[8];
             ctx.serialNum = lsn;
-            ctx.sessionID = sessionId;
+            ctx.sessionID = sessionID;
             ctx.sessionName = sessionName;
 
             if (ctx.retryRequests == null)

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -12,13 +12,13 @@ namespace FASTER.core
 {
     public partial class FasterKV<Key, Value> : FasterBase, IFasterKV<Key, Value>
     {
-        internal CommitPoint InternalContinue<Input, Output, Context>(string guid, out FasterExecutionContext<Input, Output, Context> ctx)
+        internal (string, CommitPoint) InternalContinue<Input, Output, Context>(int sessionID, out FasterExecutionContext<Input, Output, Context> ctx)
         {
             ctx = null;
 
             if (_recoveredSessions != null)
             {
-                if (_recoveredSessions.TryGetValue(guid, out _))
+                if (_recoveredSessions.TryGetValue(sessionID, out _))
                 {
                     // We have recovered the corresponding session. 
                     // Now obtain the session by first locking the rest phase
@@ -29,21 +29,21 @@ namespace FASTER.core
                         if (MakeTransition(currentState, intermediateState))
                         {
                             // No one can change from REST phase
-                            if (_recoveredSessions.TryRemove(guid, out CommitPoint cp))
+                            if (_recoveredSessions.TryRemove(sessionID, out var cp))
                             {
                                 // We have atomically removed session details. 
                                 // No one else can continue this session
                                 ctx = new FasterExecutionContext<Input, Output, Context>();
-                                InitContext(ctx, guid);
+                                InitContext(ctx, sessionID, cp.Item1);
                                 ctx.prevCtx = new FasterExecutionContext<Input, Output, Context>();
-                                InitContext(ctx.prevCtx, guid);
+                                InitContext(ctx.prevCtx, sessionID, cp.Item1);
                                 ctx.prevCtx.version--;
-                                ctx.serialNum = cp.UntilSerialNo;
+                                ctx.serialNum = cp.Item2.UntilSerialNo;
                             }
                             else
                             {
                                 // Someone else continued this session
-                                cp = new CommitPoint { UntilSerialNo = -1 };
+                                cp = ((string)null, new CommitPoint { UntilSerialNo = -1 });
                                 Debug.WriteLine("Session already continued by another thread!");
                             }
 
@@ -54,12 +54,12 @@ namespace FASTER.core
 
                     // Need to try again when in REST
                     Debug.WriteLine("Can continue only in REST phase");
-                    return new CommitPoint { UntilSerialNo = -1 };
+                    return (null, new CommitPoint { UntilSerialNo = -1 });
                 }
             }
 
             Debug.WriteLine("No recovered sessions!");
-            return new CommitPoint { UntilSerialNo = -1 };
+            return (null, new CommitPoint { UntilSerialNo = -1 });
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -78,7 +78,7 @@ namespace FASTER.core
             ThreadStateMachineStep(ctx, fasterSession, default);
         }
 
-        internal void InitContext<Input, Output, Context>(FasterExecutionContext<Input, Output, Context> ctx, string token, long lsn = -1)
+        internal void InitContext<Input, Output, Context>(FasterExecutionContext<Input, Output, Context> ctx, int sessionId, string sessionName, long lsn = -1)
         {
             ctx.phase = Phase.REST;
             // The system version starts at 1. Because we do not know what the current state machine state is,
@@ -87,7 +87,8 @@ namespace FASTER.core
             ctx.version = 1;
             ctx.markers = new bool[8];
             ctx.serialNum = lsn;
-            ctx.guid = token;
+            ctx.sessionID = sessionId;
+            ctx.sessionName = sessionName;
 
             if (ctx.retryRequests == null)
             {
@@ -105,7 +106,7 @@ namespace FASTER.core
             dst.threadStateMachine = src.threadStateMachine;
             dst.markers = src.markers;
             dst.serialNum = src.serialNum;
-            dst.guid = src.guid;
+            dst.sessionName = src.sessionName;
             dst.excludedSerialNos = new List<long>();
 
             foreach (var v in src.ioPendingRequests.Values)

--- a/cs/src/core/Index/Interfaces/FunctionsBase.cs
+++ b/cs/src/core/Index/Interfaces/FunctionsBase.cs
@@ -61,7 +61,7 @@ namespace FASTER.core
         /// <inheritdoc/>
         public virtual void DeleteCompletionCallback(ref Key key, Context ctx) { }
         /// <inheritdoc/>
-        public virtual void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint) { }
+        public virtual void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint) { }
     }
 
     /// <summary>
@@ -91,28 +91,11 @@ namespace FASTER.core
         }
 
         /// <inheritdoc/>
-        public override bool ConcurrentWriter(ref Key key, ref Value input, ref Value src, ref Value dst, ref Value output, ref RecordInfo recordInfo, long address) { dst = src; return true; }
-        /// <inheritdoc/>
-        public override void SingleWriter(ref Key key, ref Value input, ref Value src, ref Value dst, ref Value output, ref RecordInfo recordInfo, long address, WriteReason reason) => dst = src;
-
-        /// <inheritdoc/>
         public override void InitialUpdater(ref Key key, ref Value input, ref Value value, ref Value output, ref RecordInfo recordInfo, long address) => value = input;
         /// <inheritdoc/>
         public override void CopyUpdater(ref Key key, ref Value input, ref Value oldValue, ref Value newValue, ref Value output, ref RecordInfo recordInfo, long address) => newValue = merger(input, oldValue);
-
         /// <inheritdoc/>
         public override bool InPlaceUpdater(ref Key key, ref Value input, ref Value value, ref Value output, ref RecordInfo recordInfo, long address) { value = merger(input, value); return true; }
-
-        /// <inheritdoc/>
-        public override void ReadCompletionCallback(ref Key key, ref Value input, ref Value output, Context ctx, Status status, RecordMetadata recordMetadata) { }
-        /// <inheritdoc/>
-        public override void RMWCompletionCallback(ref Key key, ref Value input, ref Value output, Context ctx, Status status, RecordMetadata recordMetadata) { }
-        /// <inheritdoc/>
-        public override void UpsertCompletionCallback(ref Key key, ref Value input, ref Value value, Context ctx) { }
-        /// <inheritdoc/>
-        public override void DeleteCompletionCallback(ref Key key, Context ctx) { }
-        /// <inheritdoc/>
-        public override void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint) { }
     }
 
     public class SimpleFunctions<Key, Value> : SimpleFunctions<Key, Value, Empty>

--- a/cs/src/core/Index/Interfaces/IFasterKV.cs
+++ b/cs/src/core/Index/Interfaces/IFasterKV.cs
@@ -19,24 +19,33 @@ namespace FASTER.core
         /// For performance reasons, please use FasterKV&lt;Key, Value&gt;.For(functions).NewSession&lt;Functions&gt;(...) instead of this overload.
         /// </summary>
         /// <param name="functions">Callback functions.</param>
-        /// <param name="sessionId">ID/name of session (auto-generated if not provided)</param>
+        /// <param name="sessionName">Name of session (optional)</param>
         /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
         ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> NewSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions,
-                string sessionId = null, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null);
+                string sessionName = null, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null);
 
         /// <summary>
-        /// Resume (continue) prior client session with FASTER, used during
-        /// recovery from failure.
+        /// Resume (continue) prior client session with FASTER, used during recovery from failure.
         /// </summary>
         /// <param name="functions">Callback functions.</param>
-        /// <param name="sessionId">ID/name of previous session to resume</param>
+        /// <param name="sessionName">Name of previous session to resume</param>
         /// <param name="commitPoint">Prior commit point of durability for session</param>
         /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
         /// <returns>Session instance</returns>
         ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> ResumeSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions,
-                string sessionId, out CommitPoint commitPoint, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null);
+                string sessionName, out CommitPoint commitPoint, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null);
 
+        /// <summary>
+        /// Resume (continue) prior client session with FASTER; used during recovery from failure.
+        /// </summary>
+        /// <param name="functions">Callback functions</param>
+        /// <param name="sessionID">ID of previous session to resume</param>
+        /// <param name="commitPoint">Prior commit point of durability for session</param>
+        /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
+        /// <returns>Session instance</returns>
+        public ClientSession<Key, Value, Input, Output, Context, IFunctions<Key, Value, Input, Output, Context>> ResumeSession<Input, Output, Context>(IFunctions<Key, Value, Input, Output, Context> functions, int sessionID,
+                out CommitPoint commitPoint, SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null);
         #endregion
 
         #region Growth and Recovery

--- a/cs/src/core/Index/Interfaces/IFasterSession.cs
+++ b/cs/src/core/Index/Interfaces/IFasterSession.cs
@@ -11,7 +11,7 @@ namespace FASTER.core
     {
         void UnsafeResumeThread();
         void UnsafeSuspendThread();
-        void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint);
+        void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint);
     }
 
     /// <summary>

--- a/cs/src/core/Index/Interfaces/IFunctions.cs
+++ b/cs/src/core/Index/Interfaces/IFunctions.cs
@@ -254,9 +254,10 @@ namespace FASTER.core
         /// <summary>
         /// Checkpoint completion callback (called per client session)
         /// </summary>
-        /// <param name="sessionId">Session ID reporting persistence</param>
+        /// <param name="sessionID">ID of session reporting persistence</param>
+        /// <param name="sessionName">Name of session reporting persistence</param>
         /// <param name="commitPoint">Commit point descriptor</param>
-        void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint);
+        void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint);
         #endregion Checkpointing
     }
 

--- a/cs/src/core/Index/Interfaces/NullFasterSession.cs
+++ b/cs/src/core/Index/Interfaces/NullFasterSession.cs
@@ -4,7 +4,7 @@
     {
         public static readonly NullFasterSession Instance = new();
 
-        public void CheckpointCompletionCallback(string guid, CommitPoint commitPoint)
+        public void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
         {
         }
 

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -359,7 +359,8 @@ namespace FASTER.core
             // Recover session information
             hlog.RecoveryReset(tailAddress, headAddress, recoveredHLCInfo.info.beginAddress, readOnlyAddress);
             _recoveredSessions = recoveredHLCInfo.info.continueTokens;
-
+            _recoveredSessionNameMap = recoveredHLCInfo.info.sessionNameMap;
+            maxSessionId = recoveredHLCInfo.info.maxSessionId;
             checkpointManager.OnRecovery(recoveredICInfo.info.token, recoveredHLCInfo.info.guid);
             recoveredHLCInfo.Dispose();
         }
@@ -873,7 +874,7 @@ namespace FASTER.core
             }
         }
 
-        internal bool AtomicSwitch<Input, Output, Context>(FasterExecutionContext<Input, Output, Context> fromCtx, FasterExecutionContext<Input, Output, Context> toCtx, long version, ConcurrentDictionary<string, CommitPoint> tokens)
+        internal bool AtomicSwitch<Input, Output, Context>(FasterExecutionContext<Input, Output, Context> fromCtx, FasterExecutionContext<Input, Output, Context> toCtx, long version, ConcurrentDictionary<int, (string, CommitPoint)> tokens)
         {
             lock (toCtx)
             {
@@ -882,12 +883,12 @@ namespace FASTER.core
                     CopyContext(fromCtx, toCtx);
                     if (toCtx.serialNum != -1)
                     {
-                        tokens.TryAdd(toCtx.guid,
+                        tokens.TryAdd(toCtx.sessionID, (toCtx.sessionName,
                             new CommitPoint
                             {
                                 UntilSerialNo = toCtx.serialNum,
                                 ExcludedSerialNos = toCtx.excludedSerialNos
-                            });
+                            }));
                     }
                     return true;
                 }

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -360,7 +360,7 @@ namespace FASTER.core
             hlog.RecoveryReset(tailAddress, headAddress, recoveredHLCInfo.info.beginAddress, readOnlyAddress);
             _recoveredSessions = recoveredHLCInfo.info.continueTokens;
             _recoveredSessionNameMap = recoveredHLCInfo.info.sessionNameMap;
-            maxSessionId = recoveredHLCInfo.info.maxSessionId;
+            maxSessionID = recoveredHLCInfo.info.maxSessionID;
             checkpointManager.OnRecovery(recoveredICInfo.info.token, recoveredHLCInfo.info.guid);
             recoveredHLCInfo.Dispose();
         }

--- a/cs/src/core/Index/Synchronization/FasterStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/FasterStateMachine.cs
@@ -216,7 +216,7 @@ namespace FASTER.core
                         };
 
                         // Thread local action
-                        fasterSession?.CheckpointCompletionCallback(ctx.guid, commitPoint);
+                        fasterSession?.CheckpointCompletionCallback(ctx.sessionID, ctx.sessionName, commitPoint);
                     }
                 }
                 if ((ctx.version == targetStartState.Version) && (ctx.phase < Phase.REST) && !(ctx.threadStateMachine is IndexSnapshotStateMachine))
@@ -314,7 +314,7 @@ namespace FASTER.core
                     }
                 }
                 if (commitPoint.ExcludedSerialNos != null)
-                    fasterSession?.CheckpointCompletionCallback(ctx.guid, commitPoint);
+                    fasterSession?.CheckpointCompletionCallback(ctx.sessionID, ctx.sessionName, commitPoint);
             }
 
         }

--- a/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
@@ -65,7 +65,7 @@ namespace FASTER.core
                         if (!_ctx.markers[EpochPhaseIdx.InProgress])
                         {
                             faster.AtomicSwitch(ctx, ctx.prevCtx, _ctx.version, tokens);
-                            faster.InitContext(ctx, ctx.prevCtx.guid, ctx.prevCtx.serialNum);
+                            faster.InitContext(ctx, ctx.prevCtx.sessionID, ctx.prevCtx.sessionName, ctx.prevCtx.serialNum);
 
                             // Has to be prevCtx, not ctx
                             ctx.prevCtx.markers[EpochPhaseIdx.InProgress] = true;

--- a/cs/test/AsyncTests.cs
+++ b/cs/test/AsyncTests.cs
@@ -88,8 +88,7 @@ namespace FASTER.test.async
 
             fht2.Recover(token); // sync, does not require session
 
-            var guid = s1.ID;
-            using (var s3 = fht2.For(functions).ResumeSession<AdSimpleFunctions>(guid, out CommitPoint lsn))
+            using (var s3 = fht2.For(functions).ResumeSession<AdSimpleFunctions>(s1.ID, out CommitPoint lsn))
             {
                 Assert.AreEqual(numOps - 1, lsn.UntilSerialNo);
 

--- a/cs/test/ObjectRecoveryTest.cs
+++ b/cs/test/ObjectRecoveryTest.cs
@@ -179,7 +179,7 @@ namespace FASTER.test.recovery.objectstore
             long[] expected = new long[numUniqueKeys];
             foreach (var guid in checkpointInfo.continueTokens.Keys)
             {
-                var cp = checkpointInfo.continueTokens[guid];
+                var cp = checkpointInfo.continueTokens[guid].Item2;
                 for (long i = 0; i <= cp.UntilSerialNo; i++)
                 {
                     var id = i % numUniqueKeys;

--- a/cs/test/RecoveryTests.cs
+++ b/cs/test/RecoveryTests.cs
@@ -210,7 +210,7 @@ namespace FASTER.test.recovery.sumstore
             long[] expected = new long[numUniqueKeys];
             foreach (var guid in checkpointInfo.continueTokens.Keys)
             {
-                var cp = checkpointInfo.continueTokens[guid];
+                var cp = checkpointInfo.continueTokens[guid].Item2;
                 for (long i = 0; i <= cp.UntilSerialNo; i++)
                 {
                     var id = i % numUniqueKeys;

--- a/cs/test/SharedDirectoryTests.cs
+++ b/cs/test/SharedDirectoryTests.cs
@@ -221,7 +221,7 @@ namespace FASTER.test.recovery.sumstore
             long[] expected = new long[numUniqueKeys];
             foreach (var guid in checkpointInfo.continueTokens.Keys)
             {
-                var sno = checkpointInfo.continueTokens[guid].UntilSerialNo;
+                var sno = checkpointInfo.continueTokens[guid].Item2.UntilSerialNo;
                 for (long i = 0; i <= sno; i++)
                 {
                     var id = i % numUniqueKeys;

--- a/cs/test/SimpleRecoveryTest.cs
+++ b/cs/test/SimpleRecoveryTest.cs
@@ -135,6 +135,8 @@ namespace FASTER.test.recovery.sumstore.simple
                 Assert.Null(fht2.RecoveredCommitCookie);
             
             var session2 = fht2.NewSession(new AdSimpleFunctions());
+            Assert.AreEqual(2, session2.ID);
+
             for (int key = 0; key < numOps; key++)
             {
                 var status = session2.Read(ref inputArray[key], ref inputArg, ref output, Empty.Default, 0);

--- a/cs/test/StateMachineTests.cs
+++ b/cs/test/StateMachineTests.cs
@@ -561,7 +561,7 @@ namespace FASTER.test.statemachine
     {
         public int checkpointCallbackExpectation = 0;
 
-        public override void CheckpointCompletionCallback(string sessionId, CommitPoint commitPoint)
+        public override void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
         {
             switch (checkpointCallbackExpectation)
             {


### PR DESCRIPTION
* Session ID (int) and optional session name (string) are supported
* Ensure that checkpoints write out recoverable sessions (i.e., sessions that were restored from the previous checkpoint, but not yet explicitly resumed) to the commit info, even if these sessions were not explicitly resumed after recovery.
* Add APIs to iterate as well as dispose recoverable sessions in store, after calling `Recover`
* Correctly handle active sessions that are disposed during a checkpoint (by waiting until the checkpoint completes before removing them)