### PR TITLE
[C#] Fix hanging reads

### DIFF
--- a/cs/src/core/Async/RMWAsync.cs
+++ b/cs/src/core/Async/RMWAsync.cs
@@ -62,7 +62,10 @@ namespace FASTER.core
             /// <inheritdoc/>
             public void DecrementPending(FasterExecutionContext<Input, Output, Context> currentCtx, ref PendingContext<Input, Output, Context> pendingContext)
             {
-                currentCtx.ioPendingRequests.Remove(pendingContext.id);
+                if (!this.diskRequest.IsDefault())
+                {
+                    currentCtx.ioPendingRequests.Remove(pendingContext.id);
+                }
                 currentCtx.asyncPendingCount--;
                 currentCtx.pendingReads.Remove();
             }


### PR DESCRIPTION
This PR is my attempt at fixing the hanging reads issue. It worked to fix my test, but please review and change if necessary, I am not all that familiar with how the code works.

--- 

Here is a description of the buggy behavior I tracked down:

The RMWAsync.CallInternalRMW executes this line:
                internalStatus = InternalRMW(ref key, ref input, ref output, ref context, ref pcontext, fasterSession, currentCtx, serialNo);

And for some reason this returns internalStatus == OperationStatus.ALLOCATE_FAILED. 

This it returns Status.PENDING without first calling HandleOperationStatus.

Because HandleOperationStatus is not called,  this line is not executed:

                pendingContext.id = opCtx.totalPending++;

which means that the id keeps its initial value of 0. This is perhaps not an immediate problem (?) because the RMWAsync appears to be proceeding on some alternate “slow” path.

But it becomes a problem at cleanup time when this code is called in RMWAsync.DecrementPending:

                currentCtx.ioPendingRequests.Remove(pendingContext.id);

since the id is 0, this removes the wrong request! In my case, some completely unrelated read that just happens to have id 0, and is then doomed to hang forever.

--- 

The proposed fix is to wrap a condition around the remove so it is not executed in cases where there is no pending request.
