### PR TITLE
Fixed the comparison in the assert statement

### DIFF
--- a/cc/src/core/guid.h
+++ b/cc/src/core/guid.h
@@ -66,7 +66,7 @@ class Guid {
     GUID guid;
     auto result = ::UuidFromString(reinterpret_cast<uint8_t*>(const_cast<char*>(str.c_str())),
                                    &guid);
-    assert(result = RPC_S_OK);
+    assert(result == RPC_S_OK);
     return guid;
 #else
     uuid_t uuid;


### PR DESCRIPTION
The line 69 in guid.h was an assignment statement and causing assert failure when running sum_store exe

PS C:\Workspace\FASTER\nbhargava2022\FASTER\cc\build\Debug> .\sum_store.exe single recover "2BACC136-B2CF-4EEA-A1A0-5FB73A14B4EE"
Assertion failed: result = RPC_S_OK, file C:\Workspace\FASTER\nbhargava2022\FASTER\cc\src\core\guid.h, line 69

After the fix, running the same command is successful

PS C:\Workspace\FASTER\nbhargava2022\FASTER\cc\build\Debug> .\sum_store.exe single recover "2BACC136-B2CF-4EEA-A1A0-5FB73A14B4EE"
Test successful

Ran all the unit tests successfully after making the change.
