### PR TITLE
Use older version of Microsoft.Extensions.Logging for compatibility

### DIFF
--- a/cs/src/core/FASTER.core.csproj
+++ b/cs/src/core/FASTER.core.csproj
@@ -41,7 +41,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
 	<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
@@ -52,4 +51,18 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
   </ItemGroup>
+
+  <Choose>
+	<When Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'">
+      <ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.26" />
+	  </ItemGroup>
+	</When>
+    <Otherwise>
+	  <ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+	  </ItemGroup>
+	</Otherwise>
+  </Choose>
+
 </Project>

--- a/cs/src/core/FASTER.core.nuspec
+++ b/cs/src/core/FASTER.core.nuspec
@@ -22,12 +22,12 @@
         <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" />
         <dependency id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" />
         <dependency id="System.Interactive.Async" version="6.0.1" />
-		<dependency id="Microsoft.Extensions.Logging" version="6.0.0" />
+		<dependency id="Microsoft.Extensions.Logging" version="3.1.26" />
 	  </group>
       <group targetFramework="netstandard2.1">
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" />
         <dependency id="System.Interactive.Async" version="6.0.1" />
-		<dependency id="Microsoft.Extensions.Logging" version="6.0.0" />
+		<dependency id="Microsoft.Extensions.Logging" version="3.1.26" />
 	  </group>
       <group targetFramework="net5.0">
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" />


### PR DESCRIPTION
When using FASTER and Netherite on a Durable Functions host, the it is not possible to load version 6.0.0 of Microsoft.Extensions.Logging.

This appears to be an instance of a well known problem with the functions host not being able to load the latest versions of some dependencies (https://stackoverflow.com/questions/64809716/could-not-load-file-or-assembly-microsoft-extensions-configuration-abstractions).

Since there is no other workaround for this problem at the moment, we are reverting the versions used by the netstandard2.0 and netstandard 2.1 to Microsoft.Extensions.Logging version 3.1.26 which is the newest one that works.
