### PR TITLE
[C#] SingleDeleter should not set value = default for SpanByte

### DIFF
--- a/cs/src/core/ClientSession/LockableUnsafeContext.cs
+++ b/cs/src/core/ClientSession/LockableUnsafeContext.cs
@@ -583,10 +583,7 @@ namespace FASTER.core
             #region IFunctions - Deletes
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public bool SingleDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, ref DeleteInfo deleteInfo)
-            {
-                value = default;
-                return true;
-            }
+                => _clientSession.functions.SingleDeleter(ref key, ref value, ref deleteInfo);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void PostSingleDeleter(ref Key key, ref RecordInfo recordInfo, ref DeleteInfo deleteInfo)

--- a/cs/src/core/ClientSession/UnsafeContext.cs
+++ b/cs/src/core/ClientSession/UnsafeContext.cs
@@ -570,10 +570,7 @@ namespace FASTER.core
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public bool SingleDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, ref DeleteInfo deleteInfo)
-            {
-                value = default;
-                return true;
-            }
+                => _clientSession.functions.SingleDeleter(ref key, ref value, ref deleteInfo);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public bool ConcurrentDeleter(ref Key key, ref Value value, ref RecordInfo recordInfo, ref DeleteInfo deleteInfo, out bool lockFailed)

--- a/cs/src/core/Compaction/LogCompactionFunctions.cs
+++ b/cs/src/core/Compaction/LogCompactionFunctions.cs
@@ -21,7 +21,7 @@ namespace FASTER.core
         /// </summary>
         public bool ConcurrentReader(ref Key key, ref Input input, ref Value value, ref Output dst, ref ReadInfo readInfo) => true;
 
-        public bool SingleDeleter(ref Key key, ref Value value, ref DeleteInfo deleteInfo) { value = default; return true; }
+        public bool SingleDeleter(ref Key key, ref Value value, ref DeleteInfo deleteInfo) => true;
 
         public void PostSingleDeleter(ref Key key, ref DeleteInfo deleteInfo) { }
 

--- a/cs/src/core/VarLen/SpanByte.cs
+++ b/cs/src/core/VarLen/SpanByte.cs
@@ -15,7 +15,7 @@ namespace FASTER.core
     /// Format: [4-byte (int) length of payload][[optional 8-byte metadata] payload bytes...]
     /// First 2 bits of length are used as a mask for properties, so max payload length is 1GB
     /// </summary>
-    [StructLayout(LayoutKind.Explicit)]
+    [StructLayout(LayoutKind.Explicit, Pack = 4)]
     public unsafe struct SpanByte
     {
         // Byte #31 is used to denote unserialized (1) or serialized (0) data 

--- a/cs/src/core/VarLen/SpanByteFunctions.cs
+++ b/cs/src/core/VarLen/SpanByteFunctions.cs
@@ -58,6 +58,10 @@ namespace FASTER.core
             UpsertInfo upsertInfo = new(ref rmwInfo);
             return ConcurrentWriter(ref key, ref input, ref input, ref value, ref output, ref upsertInfo);
         }
+
+        /// <inheritdoc/>
+        /// <remarks>Avoids the "value = default" for added tombstone record, which do not have space for the payload</remarks>
+        public override bool SingleDeleter(ref Key key, ref SpanByte value, ref DeleteInfo deleteInfo) => true;
     }
 
     /// <summary>


### PR DESCRIPTION
SingleDeleter does not need to set value = default, and for SpanByte this is bad because it zeroes the size of the full SpanByte struct, but we only allocate 4 bytes on the log for the tombstoned record. SpanByteFunctions now overrides FunctionsBase.SingleDeleter to not do this. Also:
- Added pack = 4 to SpanByte so the struct size is the expected 12, not 16
- Made sure temporarily-sealed records are unsealed on readcache skip failure, and fixed one cancellation exit to be before .Sealing the record