### PR TITLE
[C#] Wait index checkpoint phase should behave similarly to wait flush

### DIFF
--- a/cs/src/core/Index/FASTER/FASTERImpl.cs
+++ b/cs/src/core/Index/FASTER/FASTERImpl.cs
@@ -688,6 +688,7 @@ namespace FASTER.core
                         }
                         break; // Normal Processing
                     }
+                case Phase.WAIT_INDEX_CHECKPOINT:
                 case Phase.WAIT_FLUSH:
                     {
                         if (!CheckEntryVersionNew(logicalAddress))
@@ -1233,6 +1234,7 @@ namespace FASTER.core
                         }
                         break; // Normal Processing
                     }
+                case Phase.WAIT_INDEX_CHECKPOINT:
                 case Phase.WAIT_FLUSH:
                     {
                         if (!CheckEntryVersionNew(logicalAddress))
@@ -1638,6 +1640,7 @@ namespace FASTER.core
                             }
                             break; // Normal Processing
                         }
+                    case Phase.WAIT_INDEX_CHECKPOINT:
                     case Phase.WAIT_FLUSH:
                         {
                             if (!CheckEntryVersionNew(logicalAddress))


### PR DESCRIPTION
Wait index checkpoint phase should behave similarly to wait flush - perform create-new-record during a checkpoint if record is not in the new version (during the snapshot).