### PR TITLE
[C#] Do not auto-acquire lockable context

### DIFF
--- a/cs/src/core/ClientSession/BasicContext.cs
+++ b/cs/src/core/ClientSession/BasicContext.cs
@@ -1,0 +1,228 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FASTER.core
+{
+    /// <summary>
+    /// Basic Faster Context implementation.
+    /// </summary>
+    public readonly struct BasicContext<Key, Value, Input, Output, Context, Functions> : IFasterContext<Key, Value, Input, Output, Context>
+        where Functions : IFunctions<Key, Value, Input, Output, Context>
+    {
+        readonly ClientSession<Key, Value, Input, Output, Context, Functions> clientSession;
+
+        internal BasicContext(ClientSession<Key, Value, Input, Output, Context, Functions> clientSession)
+        {
+            this.clientSession = clientSession;
+        }
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void UnsafeResumeThread()
+            => clientSession.UnsafeResumeThread();
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void UnsafeResumeThread(out int resumeEpoch)
+            => clientSession.UnsafeResumeThread(out resumeEpoch);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void UnsafeSuspendThread()
+            => clientSession.UnsafeSuspendThread();
+
+        #region IFasterContext
+
+        /// <inheritdoc/>
+        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false)
+            => clientSession.CompletePending(wait, spinWaitForCommit);
+
+        /// <inheritdoc/>
+        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
+            => clientSession.CompletePendingWithOutputs(out completedOutputs, wait, spinWaitForCommit);
+
+        /// <inheritdoc/>
+        public ValueTask CompletePendingAsync(bool waitForCommit = false, CancellationToken token = default)
+            => clientSession.CompletePendingAsync(waitForCommit, token);
+
+        /// <inheritdoc/>
+        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, CancellationToken token = default)
+            => clientSession.CompletePendingWithOutputsAsync(waitForCommit, token);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status Read(ref Key key, ref Input input, ref Output output, Context userContext = default, long serialNo = 0)
+            => clientSession.Read(ref key, ref input, ref output, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status Read(Key key, Input input, out Output output, Context userContext = default, long serialNo = 0)
+            => clientSession.Read(key, input, out output, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status Read(ref Key key, ref Output output, Context userContext = default, long serialNo = 0)
+            => clientSession.Read(ref key, ref output, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status Read(Key key, out Output output, Context userContext = default, long serialNo = 0)
+            => clientSession.Read(key, out output, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public (Status status, Output output) Read(Key key, Context userContext = default, long serialNo = 0)
+            => clientSession.Read(key, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status Read(ref Key key, ref Input input, ref Output output, ref ReadOptions readOptions, out RecordMetadata recordMetadata, Context userContext = default, long serialNo = 0)
+            => clientSession.Read(ref key, ref input, ref output, ref readOptions, out recordMetadata, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status ReadAtAddress(ref Input input, ref Output output, ref ReadOptions readOptions, Context userContext = default, long serialNo = 0)
+            => clientSession.ReadAtAddress(ref input, ref output, ref readOptions, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask<FasterKV<Key, Value>.ReadAsyncResult<Input, Output, Context>> ReadAsync(ref Key key, ref Input input, Context userContext = default, long serialNo = 0, CancellationToken cancellationToken = default)
+            => clientSession.ReadAsync(ref key, ref input, userContext, serialNo, cancellationToken);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask<FasterKV<Key, Value>.ReadAsyncResult<Input, Output, Context>> ReadAsync(Key key, Input input, Context context = default, long serialNo = 0, CancellationToken token = default)
+            => clientSession.ReadAsync(key, input, context, serialNo, token);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask<FasterKV<Key, Value>.ReadAsyncResult<Input, Output, Context>> ReadAsync(ref Key key, Context userContext = default, long serialNo = 0, CancellationToken token = default)
+            => clientSession.ReadAsync(ref key, userContext, serialNo, token);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask<FasterKV<Key, Value>.ReadAsyncResult<Input, Output, Context>> ReadAsync(Key key, Context context = default, long serialNo = 0, CancellationToken token = default)
+            => clientSession.ReadAsync(key, context, serialNo, token);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask<FasterKV<Key, Value>.ReadAsyncResult<Input, Output, Context>> ReadAsync(ref Key key, ref Input input, ref ReadOptions readOptions, Context userContext = default, long serialNo = 0, CancellationToken cancellationToken = default)
+            => clientSession.ReadAsync(ref key, ref input, ref readOptions, userContext, serialNo, cancellationToken);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask<FasterKV<Key, Value>.ReadAsyncResult<Input, Output, Context>> ReadAtAddressAsync(ref Input input, ref ReadOptions readOptions, Context userContext = default, long serialNo = 0, CancellationToken cancellationToken = default)
+            => clientSession.ReadAtAddressAsync(ref input, ref readOptions, userContext, serialNo, cancellationToken);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status Upsert(ref Key key, ref Value desiredValue, Context userContext = default, long serialNo = 0)
+            => clientSession.Upsert(ref key, ref desiredValue, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status Upsert(ref Key key, ref Input input, ref Value desiredValue, ref Output output, Context userContext = default, long serialNo = 0)
+            => clientSession.Upsert(ref key, ref input, ref desiredValue, ref output, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status Upsert(ref Key key, ref Input input, ref Value desiredValue, ref Output output, out RecordMetadata recordMetadata, Context userContext = default, long serialNo = 0)
+            => clientSession.Upsert(ref key, ref input, ref desiredValue, ref output, out recordMetadata, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status Upsert(Key key, Value desiredValue, Context userContext = default, long serialNo = 0)
+            => clientSession.Upsert(key, desiredValue, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status Upsert(Key key, Input input, Value desiredValue, ref Output output, Context userContext = default, long serialNo = 0)
+            => clientSession.Upsert(key, input, desiredValue, ref output, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask<FasterKV<Key, Value>.UpsertAsyncResult<Input, Output, Context>> UpsertAsync(ref Key key, ref Value desiredValue, Context userContext = default, long serialNo = 0, CancellationToken token = default)
+            => clientSession.UpsertAsync(ref key, ref desiredValue, userContext, serialNo, token);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask<FasterKV<Key, Value>.UpsertAsyncResult<Input, Output, Context>> UpsertAsync(ref Key key, ref Input input, ref Value desiredValue, Context userContext = default, long serialNo = 0, CancellationToken token = default)
+            => clientSession.UpsertAsync(ref key, ref input, ref desiredValue, userContext, serialNo, token);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask<FasterKV<Key, Value>.UpsertAsyncResult<Input, Output, Context>> UpsertAsync(Key key, Value desiredValue, Context userContext = default, long serialNo = 0, CancellationToken token = default)
+            => clientSession.UpsertAsync(key, desiredValue, userContext, serialNo, token);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask<FasterKV<Key, Value>.UpsertAsyncResult<Input, Output, Context>> UpsertAsync(Key key, Input input, Value desiredValue, Context userContext = default, long serialNo = 0, CancellationToken token = default)
+            => clientSession.UpsertAsync(key, input, desiredValue, userContext, serialNo, token);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status RMW(ref Key key, ref Input input, ref Output output, Context userContext = default, long serialNo = 0)
+            => clientSession.RMW(ref key, ref input, ref output, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status RMW(ref Key key, ref Input input, ref Output output, out RecordMetadata recordMetadata, Context userContext = default, long serialNo = 0)
+            => clientSession.RMW(ref key, ref input, ref output, out recordMetadata, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status RMW(Key key, Input input, out Output output, Context userContext = default, long serialNo = 0)
+            => clientSession.RMW(key, input, out output, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status RMW(ref Key key, ref Input input, Context userContext = default, long serialNo = 0)
+            => clientSession.RMW(ref key, ref input, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status RMW(Key key, Input input, Context userContext = default, long serialNo = 0)
+            => clientSession.RMW(key, input, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask<FasterKV<Key, Value>.RmwAsyncResult<Input, Output, Context>> RMWAsync(ref Key key, ref Input input, Context context = default, long serialNo = 0, CancellationToken token = default)
+            => clientSession.RMWAsync(ref key, ref input, context, serialNo, token);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask<FasterKV<Key, Value>.RmwAsyncResult<Input, Output, Context>> RMWAsync(Key key, Input input, Context context = default, long serialNo = 0, CancellationToken token = default)
+            => clientSession.RMWAsync(key, input, context, serialNo, token);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status Delete(ref Key key, Context userContext = default, long serialNo = 0)
+            => clientSession.Delete(ref key, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Status Delete(Key key, Context userContext = default, long serialNo = 0)
+            => clientSession.Delete(key, userContext, serialNo);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask<FasterKV<Key, Value>.DeleteAsyncResult<Input, Output, Context>> DeleteAsync(ref Key key, Context userContext = default, long serialNo = 0, CancellationToken token = default)
+            => clientSession.DeleteAsync(ref key, userContext, serialNo, token);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTask<FasterKV<Key, Value>.DeleteAsyncResult<Input, Output, Context>> DeleteAsync(Key key, Context userContext = default, long serialNo = 0, CancellationToken token = default)
+            => clientSession.DeleteAsync(key, userContext, serialNo, token);
+
+        /// <inheritdoc/>
+        public void Refresh()
+            => clientSession.Refresh();
+
+        #endregion IFasterContext
+    }
+}

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -44,6 +44,15 @@ namespace FASTER.core
         readonly ILoggerFactory loggerFactory;
         readonly ILogger logger;
 
+        internal ulong TotalLockCount => sharedLockCount + exclusiveLockCount;
+        internal ulong sharedLockCount;
+        internal ulong exclusiveLockCount;
+
+        /// <summary>
+        /// Local current epoch
+        /// </summary>
+        public int LocalCurrentEpoch => fht.epoch.LocalCurrentEpoch;
+
         internal ClientSession(
             FasterKV<Key, Value> fht,
             FasterKV<Key, Value>.FasterExecutionContext<Input, Output, Context> ctx,
@@ -51,6 +60,7 @@ namespace FASTER.core
             SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings,
             ILoggerFactory loggerFactory = null)
         {
+            this.lContext = new(this);
             this.loggerFactory = loggerFactory;
             this.logger = loggerFactory?.CreateLogger($"ClientSession-{GetHashCode().ToString("X8")}");
             this.fht = fht;
@@ -185,7 +195,6 @@ namespace FASTER.core
         /// </summary>
         public LockableContext<Key, Value, Input, Output, Context, Functions> GetLockableContext()
         {
-            this.lContext ??= new(this);
             return this.lContext;
         }
 

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -38,6 +38,7 @@ namespace FASTER.core
         UnsafeContext<Key, Value, Input, Output, Context, Functions> uContext;
         LockableUnsafeContext<Key, Value, Input, Output, Context, Functions> luContext;
         LockableContext<Key, Value, Input, Output, Context, Functions> lContext;
+        BasicContext<Key, Value, Input, Output, Context, Functions> bContext;
 
         internal const string NotAsyncSessionErr = "Session does not support async operations";
 
@@ -61,6 +62,8 @@ namespace FASTER.core
             ILoggerFactory loggerFactory = null)
         {
             this.lContext = new(this);
+            this.bContext = new(this);
+
             this.loggerFactory = loggerFactory;
             this.logger = loggerFactory?.CreateLogger($"ClientSession-{GetHashCode().ToString("X8")}");
             this.fht = fht;
@@ -191,12 +194,14 @@ namespace FASTER.core
         }
 
         /// <summary>
-        /// Return a new interface to Faster operations that supports manual locking.
+        /// Return a session wrapper that supports manual locking.
         /// </summary>
-        public LockableContext<Key, Value, Input, Output, Context, Functions> GetLockableContext()
-        {
-            return this.lContext;
-        }
+        public LockableContext<Key, Value, Input, Output, Context, Functions> LockableContext => lContext;
+
+        /// <summary>
+        /// Return a session wrapper struct that passes through to client session
+        /// </summary>
+        public BasicContext<Key, Value, Input, Output, Context, Functions> BasicContext => bContext;
 
         #region IFasterContext
         /// <inheritdoc/>

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -186,7 +186,6 @@ namespace FASTER.core
         public LockableContext<Key, Value, Input, Output, Context, Functions> GetLockableContext()
         {
             this.lContext ??= new(this);
-            this.lContext.Acquire();
             return this.lContext;
         }
 

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -37,8 +37,8 @@ namespace FASTER.core
 
         UnsafeContext<Key, Value, Input, Output, Context, Functions> uContext;
         LockableUnsafeContext<Key, Value, Input, Output, Context, Functions> luContext;
-        LockableContext<Key, Value, Input, Output, Context, Functions> lContext;
-        BasicContext<Key, Value, Input, Output, Context, Functions> bContext;
+        readonly LockableContext<Key, Value, Input, Output, Context, Functions> lContext;
+        readonly BasicContext<Key, Value, Input, Output, Context, Functions> bContext;
 
         internal const string NotAsyncSessionErr = "Session does not support async operations";
 

--- a/cs/src/core/ClientSession/LockableContext.cs
+++ b/cs/src/core/ClientSession/LockableContext.cs
@@ -27,6 +27,7 @@ namespace FASTER.core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void UnsafeResumeThread()
         {
+            clientSession.CheckAcquired();
             Debug.Assert(!clientSession.fht.epoch.ThisInstanceProtected());
             clientSession.UnsafeResumeThread();
         }
@@ -35,6 +36,7 @@ namespace FASTER.core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void UnsafeResumeThread(out int resumeEpoch)
         {
+            clientSession.CheckAcquired();
             Debug.Assert(!clientSession.fht.epoch.ThisInstanceProtected());
             clientSession.UnsafeResumeThread(out resumeEpoch);
         }
@@ -43,6 +45,7 @@ namespace FASTER.core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void UnsafeSuspendThread()
         {
+            clientSession.CheckAcquired();
             Debug.Assert(clientSession.fht.epoch.ThisInstanceProtected());
             clientSession.UnsafeSuspendThread();
         }
@@ -57,7 +60,7 @@ namespace FASTER.core
         /// </summary>
         public void Acquire()
         {
-            this.clientSession.fht.IncrementNumLockingSessions();
+            clientSession.Acquire();
         }
 
         /// <summary>
@@ -69,7 +72,7 @@ namespace FASTER.core
                 throw new FasterException("Releasing LockableContext with a protected epoch; must call UnsafeSuspendThread");
             if (clientSession.TotalLockCount > 0)
                 throw new FasterException($"Releasing LockableContext with locks held: {clientSession.sharedLockCount} shared locks, {clientSession.exclusiveLockCount} exclusive locks");
-            this.clientSession.fht.DecrementNumLockingSessions();
+            clientSession.Release();
         }
         #endregion Acquire and Dispose
 
@@ -78,6 +81,7 @@ namespace FASTER.core
         /// <inheritdoc/>
         public unsafe void Lock(ref Key key, LockType lockType)
         {
+            clientSession.CheckAcquired();
             Debug.Assert(!clientSession.fht.epoch.ThisInstanceProtected());
             clientSession.UnsafeResumeThread();
             try
@@ -108,6 +112,7 @@ namespace FASTER.core
         /// <inheritdoc/>
         public void Unlock(ref Key key, LockType lockType)
         {
+            clientSession.CheckAcquired();
             Debug.Assert(!clientSession.fht.epoch.ThisInstanceProtected());
             clientSession.UnsafeResumeThread();
             try
@@ -138,6 +143,7 @@ namespace FASTER.core
         /// <inheritdoc/>
         public (bool exclusive, byte shared) IsLocked(ref Key key)
         {
+            clientSession.CheckAcquired();
             Debug.Assert(!clientSession.fht.epoch.ThisInstanceProtected());
             clientSession.UnsafeResumeThread();
             try
@@ -165,7 +171,7 @@ namespace FASTER.core
         /// <summary>
         /// The session id of FasterSession
         /// </summary>
-        public int sessionID { get { return clientSession.ctx.sessionID; } }
+        public int SessionID { get { return clientSession.ctx.sessionID; } }
 
         #endregion Key Locking
 

--- a/cs/src/core/ClientSession/LockableUnsafeContext.cs
+++ b/cs/src/core/ClientSession/LockableUnsafeContext.cs
@@ -20,10 +20,6 @@ namespace FASTER.core
         internal readonly InternalFasterSession FasterSession;
         bool isAcquired;
 
-        ulong TotalLockCount => sharedLockCount + exclusiveLockCount;
-        internal ulong sharedLockCount;
-        internal ulong exclusiveLockCount;
-
         void CheckAcquired()
         {
             if (!isAcquired)
@@ -79,8 +75,8 @@ namespace FASTER.core
         {
             if (clientSession.fht.epoch.ThisInstanceProtected())
                 throw new FasterException("Disposing LockableUnsafeContext with a protected epoch; must call UnsafeSuspendThread");
-            if (TotalLockCount > 0)
-                throw new FasterException($"Disposing LockableUnsafeContext with locks held: {sharedLockCount} shared locks, {exclusiveLockCount} exclusive locks");
+            if (clientSession.TotalLockCount > 0)
+                throw new FasterException($"Disposing LockableUnsafeContext with locks held: {clientSession.sharedLockCount} shared locks, {clientSession.exclusiveLockCount} exclusive locks");
             this.isAcquired = false;
             this.clientSession.fht.DecrementNumLockingSessions();
         }
@@ -104,9 +100,9 @@ namespace FASTER.core
             Debug.Assert(status == OperationStatus.SUCCESS);
 
             if (lockType == LockType.Exclusive)
-                ++this.exclusiveLockCount;
+                ++clientSession.exclusiveLockCount;
             else
-                ++this.sharedLockCount;
+                ++clientSession.sharedLockCount;
         }
 
         /// <inheritdoc/>
@@ -128,9 +124,9 @@ namespace FASTER.core
             Debug.Assert(status == OperationStatus.SUCCESS);
 
             if (lockType == LockType.Exclusive)
-                --this.exclusiveLockCount;
+                --clientSession.exclusiveLockCount;
             else
-                --this.sharedLockCount;
+                --clientSession.sharedLockCount;
         }
 
         /// <inheritdoc/>

--- a/cs/src/core/FasterLog/FasterLogIterator.cs
+++ b/cs/src/core/FasterLog/FasterLogIterator.cs
@@ -551,10 +551,11 @@ namespace FASTER.core
                 if (name != null)
                     fasterLog.PersistedIterators.TryRemove(name, out _);
 
+                if (Interlocked.Decrement(ref fasterLog.logRefCount) == 0)
+                    fasterLog.TrueDispose();
+
                 disposed = true;
             }
-            if (Interlocked.Decrement(ref fasterLog.logRefCount) == 0)
-                fasterLog.TrueDispose();
         }
 
         internal override void AsyncReadPagesFromDeviceToFrame<TContext>(long readPageStart, int numPages, long untilAddress, TContext context, out CountdownEvent completed, long devicePageOffset = 0, IDevice device = null, IDevice objectLogDevice = null, CancellationTokenSource cts = null)

--- a/cs/test/LockableUnsafeContextTests.cs
+++ b/cs/test/LockableUnsafeContextTests.cs
@@ -145,21 +145,21 @@ namespace FASTER.test.LockableUnsafeContext
                 this.fht.Log.FlushAndEvict(wait: true);
         }
 
-        static void ClearCountsOnError(LockableUnsafeContext<int, int, int, int, Empty, LockableUnsafeFunctions> luContext)
+        static void ClearCountsOnError(ClientSession<int, int, int, int, Empty, LockableUnsafeFunctions> luContext)
         {
             // If we already have an exception, clear these counts so "Run" will not report them spuriously.
             luContext.sharedLockCount = 0;
             luContext.exclusiveLockCount = 0;
         }
 
-        static void ClearCountsOnError(LockableUnsafeContext<int, int, int, int, Empty, IFunctions<int, int, int, int, Empty>> luContext)
+        static void ClearCountsOnError(ClientSession<int, int, int, int, Empty, IFunctions<int, int, int, int, Empty>> luContext)
         {
             // If we already have an exception, clear these counts so "Run" will not report them spuriously.
             luContext.sharedLockCount = 0;
             luContext.exclusiveLockCount = 0;
         }
 
-        static void ClearCountsOnError(LockableUnsafeContext<long, long, long, long, Empty, IFunctions<long, long, long, long, Empty>> luContext)
+        static void ClearCountsOnError(ClientSession<long, long, long, long, Empty, IFunctions<long, long, long, long, Empty>> luContext)
         {
             // If we already have an exception, clear these counts so "Run" will not report them spuriously.
             luContext.sharedLockCount = 0;
@@ -409,7 +409,7 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 catch (Exception)
                 {
-                    ClearCountsOnError(luContext);
+                    ClearCountsOnError(session);
                     throw;
                 }
                 finally
@@ -496,7 +496,7 @@ namespace FASTER.test.LockableUnsafeContext
             }
             catch (Exception)
             {
-                ClearCountsOnError(luContext);
+                ClearCountsOnError(session);
                 throw;
             }
             finally
@@ -554,7 +554,7 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 catch (Exception)
                 {
-                    ClearCountsOnError(luContext);
+                    ClearCountsOnError(session);
                     throw;
                 }
                 finally
@@ -705,7 +705,7 @@ namespace FASTER.test.LockableUnsafeContext
             }
             catch (Exception)
             {
-                ClearCountsOnError(luContext);
+                ClearCountsOnError(session);
                 throw;
             }
             finally
@@ -757,7 +757,7 @@ namespace FASTER.test.LockableUnsafeContext
             }
             catch (Exception)
             {
-                ClearCountsOnError(luContext);
+                ClearCountsOnError(session);
                 throw;
             }
             finally
@@ -799,7 +799,7 @@ namespace FASTER.test.LockableUnsafeContext
             }
             catch (Exception)
             {
-                ClearCountsOnError(luContext);
+                ClearCountsOnError(session);
                 throw;
             }
             finally
@@ -846,7 +846,7 @@ namespace FASTER.test.LockableUnsafeContext
             }
             catch (Exception)
             {
-                ClearCountsOnError(luContext);
+                ClearCountsOnError(session);
                 throw;
             }
             finally
@@ -894,7 +894,7 @@ namespace FASTER.test.LockableUnsafeContext
             }
             catch (Exception)
             {
-                ClearCountsOnError(luContext);
+                ClearCountsOnError(session);
                 throw;
             }
             finally
@@ -947,7 +947,7 @@ namespace FASTER.test.LockableUnsafeContext
             }
             catch (Exception)
             {
-                ClearCountsOnError(luContext);
+                ClearCountsOnError(session);
                 throw;
             }
             finally
@@ -1036,7 +1036,7 @@ namespace FASTER.test.LockableUnsafeContext
             }
             catch (Exception)
             {
-                ClearCountsOnError(lockLuContext);
+                ClearCountsOnError(lockSession);
                 throw;
             }
             finally
@@ -1056,7 +1056,7 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 catch (Exception)
                 {
-                    ClearCountsOnError(lockLuContext);
+                    ClearCountsOnError(lockSession);
                     throw;
                 }
                 finally
@@ -1086,7 +1086,7 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 catch (Exception)
                 {
-                    ClearCountsOnError(updateLuContext);
+                    ClearCountsOnError(updateSession);
                     throw;
                 }
                 finally
@@ -1131,7 +1131,7 @@ namespace FASTER.test.LockableUnsafeContext
             }
             catch (Exception)
             {
-                ClearCountsOnError(luContext);
+                ClearCountsOnError(session);
                 throw;
             }
             finally
@@ -1202,7 +1202,7 @@ namespace FASTER.test.LockableUnsafeContext
             }
             catch (Exception)
             {
-                ClearCountsOnError(luContext);
+                ClearCountsOnError(session);
                 throw;
             }
             finally
@@ -1243,7 +1243,7 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 catch (Exception)
                 {
-                    ClearCountsOnError(luContext);
+                    ClearCountsOnError(session);
                     throw;
                 }
                 finally
@@ -1270,7 +1270,7 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 catch (Exception)
                 {
-                    ClearCountsOnError(luContext);
+                    ClearCountsOnError(session);
                     throw;
                 }
                 finally
@@ -1302,7 +1302,7 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 catch (Exception)
                 {
-                    ClearCountsOnError(luContext);
+                    ClearCountsOnError(session);
                     throw;
                 }
                 finally
@@ -1382,7 +1382,7 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 catch (Exception)
                 {
-                    ClearCountsOnError(luc1);
+                    ClearCountsOnError(s1);
                     throw;
                 }
                 finally
@@ -1406,7 +1406,7 @@ namespace FASTER.test.LockableUnsafeContext
             }
             catch (Exception)
             {
-                ClearCountsOnError(luc1);
+                ClearCountsOnError(s1);
                 throw;
             }
             finally
@@ -1462,7 +1462,7 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 catch (Exception)
                 {
-                    ClearCountsOnError(luc1);
+                    ClearCountsOnError(s1);
                     throw;
                 }
                 finally

--- a/cs/test/ReadCacheChainTests.cs
+++ b/cs/test/ReadCacheChainTests.cs
@@ -227,7 +227,7 @@ namespace FASTER.test.ReadCacheTests
             Assert.AreEqual(expectedKey, storedKey);
         }
 
-        static void ClearCountsOnError(LockableUnsafeContext<int, int, int, int, Empty, IFunctions<int, int, int, int, Empty>> luContext)
+        static void ClearCountsOnError(ClientSession<int, int, int, int, Empty, IFunctions<int, int, int, int, Empty>> luContext)
         {
             // If we already have an exception, clear these counts so "Run" will not report them spuriously.
             luContext.sharedLockCount = 0;
@@ -531,7 +531,7 @@ namespace FASTER.test.ReadCacheTests
             }
             catch (Exception)
             {
-                ClearCountsOnError(luContext);
+                ClearCountsOnError(session);
                 throw;
             }
             finally
@@ -607,7 +607,7 @@ namespace FASTER.test.ReadCacheTests
             }
             catch (Exception)
             {
-                ClearCountsOnError(luContext);
+                ClearCountsOnError(session);
                 throw;
             }
             finally
@@ -718,7 +718,7 @@ namespace FASTER.test.ReadCacheTests
             fht.Log.FlushAndEvict(true);
         }
 
-        static void ClearCountsOnError(LockableUnsafeContext<long, long, long, long, Empty, IFunctions<long, long, long, long, Empty>> luContext)
+        static void ClearCountsOnError(ClientSession<long, long, long, long, Empty, IFunctions<long, long, long, long, Empty>> luContext)
         {
             // If we already have an exception, clear these counts so "Run" will not report them spuriously.
             luContext.sharedLockCount = 0;
@@ -903,7 +903,7 @@ namespace FASTER.test.ReadCacheTests
             fht.Log.FlushAndEvict(true);
         }
 
-        static void ClearCountsOnError(LockableUnsafeContext<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, Empty, IFunctions<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, Empty>> luContext)
+        static void ClearCountsOnError(ClientSession<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, Empty, IFunctions<SpanByte, SpanByte, SpanByte, SpanByteAndMemory, Empty>> luContext)
         {
             // If we already have an exception, clear these counts so "Run" will not report them spuriously.
             luContext.sharedLockCount = 0;


### PR DESCRIPTION
Expose Acquire/Release for LC
FasterLogIterator dispose fix
BasicContext and LockableContext are "stateless" struct wrappers for client session