### PR TITLE
Optimize the uses of ThreadStatic in class having static ctor

### DIFF
--- a/cs/src/core/Epochs/LightEpoch.cs
+++ b/cs/src/core/Epochs/LightEpoch.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -15,10 +15,7 @@ namespace FASTER.core
     public unsafe sealed class LightEpoch
     {
         /// <summary>
-        /// Size of cache line in bytes
-        /// </summary>
-        const int kCacheLineBytes = 64;
-
+        /// Store thread-static metadata separately; see https://github.com/microsoft/FASTER/pull/746
         /// </summary>
         private class Metadata
         {
@@ -52,6 +49,11 @@ namespace FASTER.core
             [ThreadStatic]
             internal static int threadEntryIndexCount;
         }
+
+        /// <summary>
+        /// Size of cache line in bytes
+        /// </summary>
+        const int kCacheLineBytes = 64;
 
         /// <summary>
         /// Default invalid index entry.
@@ -284,7 +286,6 @@ namespace FASTER.core
         {
             Debug.Assert(markerIdx < 6);
             (*(tableAligned + Metadata.threadEntryIndex)).markers[markerIdx] = version;
-
         }
 
         /// <summary>
@@ -488,7 +489,7 @@ namespace FASTER.core
         /// </summary>
         /// <param name="h"></param>
         /// <returns></returns>
-        private static int Murmur3(int h)
+        static int Murmur3(int h)
         {
             uint a = (uint)h;
             a ^= a >> 16;

--- a/cs/src/core/Epochs/LightEpoch.cs
+++ b/cs/src/core/Epochs/LightEpoch.cs
@@ -101,7 +101,6 @@ namespace FASTER.core
         long SafeToReclaimEpoch;
 
         /// <summary>
-        public int LocalCurrentEpoch => (*(tableAligned + Metadata.threadEntryIndex)).localCurrentEpoch;
         /// Static constructor to setup shared cache-aligned space
         /// to store per-entry count of instances using that entry
         /// </summary>
@@ -175,20 +174,6 @@ namespace FASTER.core
             {
                 if ((*(tableAligned + entry)).threadId == entry)
                     return true;
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Check whether any epoch instance is protected on this thread
-        /// </summary>
-        /// <returns>Result of the check</returns>
-        public static bool AnyInstanceProtected()
-        {
-            int entry = Metadata.threadEntryIndex;
-            if (kInvalidIndex != entry)
-            {
-                return Metadata.threadEntryIndexCount > 0;
             }
             return false;
         }
@@ -298,7 +283,7 @@ namespace FASTER.core
         public void Mark(int markerIdx, long version)
         {
             Debug.Assert(markerIdx < 6);
-            (*(tableAligned + Metadata.threadEntryIndex)).markers[markerIdx] = (int)version;
+            (*(tableAligned + Metadata.threadEntryIndex)).markers[markerIdx] = version;
 
         }
 


### PR DESCRIPTION
In a class that has `static ctor`, accessing static fields include `ThreadStatic` is challenging. We have a helper call to find the base address of the variable to access and generally this helper call is not optimizable. Meaning, if we are accessing such variable in a loop, the corresponding helper call cannot be move around to optimize code. The reason being, we need to be precise at what time the ctor will be called and there are rules that govern that. Because of lack of ability to move the helper call around, if we access a static variable inside a loop, we will be calling the helper call in every single iteration. Find the base address is time consuming as well because it has to go through at least 3 looks up tables (module, thread and the variable). 

However, in absence of `static ctor`, we can safely move around the helper call and also move it outside the loop in some cases. I noticed that `ReserveEntry()` has such code and the code generated is sub-optimal. We are fixing it in .NET in https://github.com/dotnet/runtime/pull/75785, but it will be in .NET 8.

Till then, I was thinking of fixing it in this code base to not see those issues. For that, I have created a private class and moved most of the `ThreadStatic` variables inside it. Here is the code gen difference:

```c#

    public class X {

        [ThreadStatic]
        public static int startOffset1 = 1;
    }

    public unsafe class TLS {
     [MethodImpl(MethodImplOptions.NoInlining)]
     static TLS() {
    }

    [ThreadStatic]
    public static int startOffset1 = 1;

    [MethodImpl(MethodImplOptions.NoInlining)]
    static int Test1(int n) {
        int result = 0;
            for (int i = 0; i < n; i++) {
                result += startOffset1;
        }
        return result;
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    static int Test2(int n) {
        int result = 0;
        for (int i = 0; i < n; i++) {
            result += X.startOffset1;
        }
        return result;
    }
}
```

Test1 code:

```asm

G_M64761_IG01:
       push     rdi
       push     rsi
       push     rbx
       sub      rsp, 32
       mov      esi, ecx
                                                ;; size=9 bbWeight=1    PerfScore 3.50
G_M64761_IG02:
       xor      edi, edi
       xor      ebx, ebx
       test     esi, esi
       jle      SHORT G_M64761_IG04
                                                ;; size=8 bbWeight=1    PerfScore 1.75
G_M64761_IG03:
       mov      rcx, 0xD1FFAB1E
       mov      edx, 9
       call     CORINFO_HELP_GETSHARED_NONGCTHREADSTATIC_BASE
       movzx    rax, word  ptr [rax+28H]
       add      edi, eax
       inc      ebx
       cmp      ebx, esi
       jl       SHORT G_M64761_IG03
                                                ;; size=32 bbWeight=4    PerfScore 21.00
G_M64761_IG04:
       mov      eax, edi
                                                ;; size=2 bbWeight=1    PerfScore 0.25
G_M64761_IG05:
       add      rsp, 32
       pop      rbx
       pop      rsi
       pop      rdi
       ret
```

Test2 code:

```asm
G_M35802_IG01:
       push     rdi
       push     rsi
       push     rbx
       sub      rsp, 32
       mov      esi, ecx
                                                ;; size=9 bbWeight=1    PerfScore 3.50
G_M35802_IG02:
       xor      edi, edi
       xor      ebx, ebx
       test     esi, esi
       jle      SHORT G_M35802_IG04
       mov      rcx, 0xD1FFAB1E
       mov      edx, 8
       call     CORINFO_HELP_GETSHARED_NONGCTHREADSTATIC_BASE
       mov      eax, dword ptr [rax+24H]
                                                ;; size=31 bbWeight=1    PerfScore 5.25
G_M35802_IG03:
       add      edi, eax
       inc      ebx
       cmp      ebx, esi
       jl       SHORT G_M35802_IG03
                                                ;; size=8 bbWeight=4    PerfScore 7.00
G_M35802_IG04:
       mov      eax, edi
                                                ;; size=2 bbWeight=1    PerfScore 0.25
G_M35802_IG05:
       add      rsp, 32
       pop      rbx
       pop      rsi
       pop      rdi
       ret
```

If you see here, in `Test2`, the helper call `CORINFO_HELP_GETSHARED_NONGCTHREADSTATIC_BASE` has been moved out of IG03 loop because it is being accessed using no ctor class `X`, but in `Test1` we will call the helper inside loop.