### PR TITLE
[C#] Use long type for epochs

### DIFF
--- a/cs/samples/FasterLogSample/Program.cs
+++ b/cs/samples/FasterLogSample/Program.cs
@@ -33,11 +33,12 @@ namespace FasterLogSample
 
             // Create settings to write logs and commits at specified local path
             using var config = new FasterLogSettings("./FasterLogSample", deleteDirOnDispose: true);
+            config.AutoRefreshSafeTailAddress = true;
 
             // FasterLog will recover and resume if there is a previous commit found
             log = new FasterLog(config);
 
-            using (iter = log.Scan(log.BeginAddress, long.MaxValue))
+            using (iter = log.Scan(log.BeginAddress, long.MaxValue, scanUncommitted: true))
             {
                 if (sync)
                 {
@@ -48,8 +49,8 @@ namespace FasterLogSample
                     new Thread(() => ScanThread()).Start();
 
                     // Threads for reporting, commit
-                    new Thread(new ThreadStart(ReportThread)).Start();
-                    var t = new Thread(new ThreadStart(CommitThread));
+                    var t = new Thread(new ThreadStart(ReportThread)); //.Start();
+                    //var t = new Thread(new ThreadStart(CommitThread));
                     t.Start();
                     t.Join();
                 }

--- a/cs/samples/FasterLogSample/Program.cs
+++ b/cs/samples/FasterLogSample/Program.cs
@@ -33,12 +33,11 @@ namespace FasterLogSample
 
             // Create settings to write logs and commits at specified local path
             using var config = new FasterLogSettings("./FasterLogSample", deleteDirOnDispose: true);
-            config.AutoRefreshSafeTailAddress = true;
 
             // FasterLog will recover and resume if there is a previous commit found
             log = new FasterLog(config);
 
-            using (iter = log.Scan(log.BeginAddress, long.MaxValue, scanUncommitted: true))
+            using (iter = log.Scan(log.BeginAddress, long.MaxValue))
             {
                 if (sync)
                 {
@@ -49,8 +48,8 @@ namespace FasterLogSample
                     new Thread(() => ScanThread()).Start();
 
                     // Threads for reporting, commit
-                    var t = new Thread(new ThreadStart(ReportThread)); //.Start();
-                    //var t = new Thread(new ThreadStart(CommitThread));
+                    new Thread(new ThreadStart(ReportThread)).Start();
+                    var t = new Thread(new ThreadStart(CommitThread));
                     t.Start();
                     t.Join();
                 }

--- a/cs/src/core/ClientSession/BasicContext.cs
+++ b/cs/src/core/ClientSession/BasicContext.cs
@@ -28,11 +28,6 @@ namespace FASTER.core
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void UnsafeResumeThread(out int resumeEpoch)
-            => clientSession.UnsafeResumeThread(out resumeEpoch);
-
-        /// <inheritdoc/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void UnsafeSuspendThread()
             => clientSession.UnsafeSuspendThread();
 

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -80,7 +80,7 @@ namespace FASTER.core
         /// <summary>
         /// Local current epoch
         /// </summary>
-        public int LocalCurrentEpoch => fht.epoch.LocalCurrentEpoch;
+        public long LocalCurrentEpoch => fht.epoch.LocalCurrentEpoch;
 
         internal ClientSession(
             FasterKV<Key, Value> fht,
@@ -854,17 +854,6 @@ namespace FASTER.core
         internal void UnsafeResumeThread()
         {
             fht.epoch.Resume();
-            fht.InternalRefresh(ctx, FasterSession);
-        }
-
-        /// <summary>
-        /// Resume session on current thread. IMPORTANT: Call SuspendThread before any async op.
-        /// </summary>
-        /// <param name="resumeEpoch">Epoch that session resumes on; can be saved to see if epoch has changed</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void UnsafeResumeThread(out int resumeEpoch)
-        {
-            fht.epoch.Resume(out resumeEpoch);
             fht.InternalRefresh(ctx, FasterSession);
         }
 

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -77,11 +77,6 @@ namespace FASTER.core
                 throw new FasterException("Method call on acquired Context");
         }
 
-        /// <summary>
-        /// Local current epoch
-        /// </summary>
-        public long LocalCurrentEpoch => fht.epoch.LocalCurrentEpoch;
-
         internal ClientSession(
             FasterKV<Key, Value> fht,
             FasterKV<Key, Value>.FasterExecutionContext<Input, Output, Context> ctx,

--- a/cs/src/core/ClientSession/IUnsafeContext.cs
+++ b/cs/src/core/ClientSession/IUnsafeContext.cs
@@ -15,12 +15,6 @@ namespace FASTER.core
         void ResumeThread();
 
         /// <summary>
-        /// Resume session on current thread. IMPORTANT: Call SuspendThread before any async op.
-        /// </summary>
-        /// <param name="resumeEpoch">Epoch that the session resumed on; can be saved to see if epoch has changed</param>
-        void ResumeThread(out int resumeEpoch);
-
-        /// <summary>
         /// Suspend session on current thread
         /// </summary>
         void SuspendThread();
@@ -28,6 +22,6 @@ namespace FASTER.core
         /// <summary>
         /// Current epoch of the session
         /// </summary>
-        int LocalCurrentEpoch { get; }
+        long LocalCurrentEpoch { get; }
     }
 }

--- a/cs/src/core/ClientSession/IUnsafeContext.cs
+++ b/cs/src/core/ClientSession/IUnsafeContext.cs
@@ -18,10 +18,5 @@ namespace FASTER.core
         /// Suspend session on current thread
         /// </summary>
         void SuspendThread();
-
-        /// <summary>
-        /// Current epoch of the session
-        /// </summary>
-        long LocalCurrentEpoch { get; }
     }
 }

--- a/cs/src/core/ClientSession/LockableContext.cs
+++ b/cs/src/core/ClientSession/LockableContext.cs
@@ -41,9 +41,6 @@ namespace FASTER.core
             clientSession.UnsafeSuspendThread();
         }
 
-        /// <inheritdoc/>
-        public long LocalCurrentEpoch => clientSession.fht.epoch.LocalCurrentEpoch;
-
         #region Acquire and Dispose
 
         /// <summary>

--- a/cs/src/core/ClientSession/LockableContext.cs
+++ b/cs/src/core/ClientSession/LockableContext.cs
@@ -34,15 +34,6 @@ namespace FASTER.core
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void UnsafeResumeThread(out int resumeEpoch)
-        {
-            clientSession.CheckAcquired();
-            Debug.Assert(!clientSession.fht.epoch.ThisInstanceProtected());
-            clientSession.UnsafeResumeThread(out resumeEpoch);
-        }
-
-        /// <inheritdoc/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void UnsafeSuspendThread()
         {
             clientSession.CheckAcquired();
@@ -51,7 +42,7 @@ namespace FASTER.core
         }
 
         /// <inheritdoc/>
-        public int LocalCurrentEpoch => clientSession.fht.epoch.LocalCurrentEpoch;
+        public long LocalCurrentEpoch => clientSession.fht.epoch.LocalCurrentEpoch;
 
         #region Acquire and Dispose
 

--- a/cs/src/core/ClientSession/LockableUnsafeContext.cs
+++ b/cs/src/core/ClientSession/LockableUnsafeContext.cs
@@ -34,14 +34,6 @@ namespace FASTER.core
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void ResumeThread(out int resumeEpoch)
-        {
-            clientSession.CheckAcquired();
-            clientSession.UnsafeResumeThread(out resumeEpoch);
-        }
-
-        /// <inheritdoc/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SuspendThread()
         {
             clientSession.CheckAcquired();
@@ -50,7 +42,7 @@ namespace FASTER.core
         }
 
         /// <inheritdoc/>
-        public int LocalCurrentEpoch => clientSession.fht.epoch.LocalCurrentEpoch;
+        public long LocalCurrentEpoch => clientSession.fht.epoch.LocalCurrentEpoch;
 
         #region Acquire and Dispose
         internal void Acquire()

--- a/cs/src/core/ClientSession/LockableUnsafeContext.cs
+++ b/cs/src/core/ClientSession/LockableUnsafeContext.cs
@@ -41,9 +41,6 @@ namespace FASTER.core
             clientSession.UnsafeSuspendThread();
         }
 
-        /// <inheritdoc/>
-        public long LocalCurrentEpoch => clientSession.fht.epoch.LocalCurrentEpoch;
-
         #region Acquire and Dispose
         internal void Acquire()
         {

--- a/cs/src/core/ClientSession/UnsafeContext.cs
+++ b/cs/src/core/ClientSession/UnsafeContext.cs
@@ -42,14 +42,6 @@ namespace FASTER.core
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void ResumeThread(out int resumeEpoch)
-        {
-            CheckAcquired();
-            clientSession.UnsafeResumeThread(out resumeEpoch);
-        }
-
-        /// <inheritdoc/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SuspendThread()
         {
             Debug.Assert(clientSession.fht.epoch.ThisInstanceProtected());
@@ -57,7 +49,7 @@ namespace FASTER.core
         }
 
         /// <inheritdoc/>
-        public int LocalCurrentEpoch => clientSession.fht.epoch.LocalCurrentEpoch;
+        public long LocalCurrentEpoch => clientSession.fht.epoch.LocalCurrentEpoch;
 
         #region Acquire and Dispose
         internal void Acquire()

--- a/cs/src/core/ClientSession/UnsafeContext.cs
+++ b/cs/src/core/ClientSession/UnsafeContext.cs
@@ -48,9 +48,6 @@ namespace FASTER.core
             clientSession.UnsafeSuspendThread();
         }
 
-        /// <inheritdoc/>
-        public long LocalCurrentEpoch => clientSession.fht.epoch.LocalCurrentEpoch;
-
         #region Acquire and Dispose
         internal void Acquire()
         {

--- a/cs/src/core/Epochs/LightEpoch.cs
+++ b/cs/src/core/Epochs/LightEpoch.cs
@@ -14,7 +14,10 @@ namespace FASTER.core
     /// </summary>
     public unsafe sealed class LightEpoch
     {
-        private const int kCacheLineBytes = 64;
+        /// <summary>
+        /// Size of cache line in bytes
+        /// </summary>
+        const int kCacheLineBytes = 64;
 
         /// <summary>
         /// Default invalid index entry.
@@ -34,8 +37,8 @@ namespace FASTER.core
         /// <summary>
         /// Thread protection status entries.
         /// </summary>
-        Entry[] tableRaw;
-        Entry* tableAligned;
+        readonly Entry[] tableRaw;
+        readonly Entry* tableAligned;
 #if !NET5_0_OR_GREATER
         GCHandle tableHandle;
 #endif

--- a/cs/src/core/Epochs/LightEpoch.cs
+++ b/cs/src/core/Epochs/LightEpoch.cs
@@ -86,17 +86,12 @@ namespace FASTER.core
         /// <summary>
         /// Global current epoch value
         /// </summary>
-        public long CurrentEpoch;
+        long CurrentEpoch;
 
         /// <summary>
         /// Cached value of latest epoch that is safe to reclaim
         /// </summary>
-        public long SafeToReclaimEpoch;
-
-        /// <summary>
-        /// Local view of current epoch, for an epoch-protected thread
-        /// </summary>
-        public long LocalCurrentEpoch => (*(tableAligned + threadEntryIndex)).localCurrentEpoch;
+        long SafeToReclaimEpoch;
 
         /// <summary>
         /// Static constructor to setup shared cache-aligned space

--- a/cs/test/LockableUnsafeContextTests.cs
+++ b/cs/test/LockableUnsafeContextTests.cs
@@ -195,7 +195,7 @@ namespace FASTER.test.LockableUnsafeContext
 
             // Copied from UnsafeContextTests to test Async.
             using var luContext = session.GetLockableUnsafeContext();
-            luContext.ResumeThread(out var epoch);
+            luContext.ResumeThread();
 
             try
             {
@@ -314,7 +314,7 @@ namespace FASTER.test.LockableUnsafeContext
 
             using (var luContext = session.GetLockableUnsafeContext())
             {
-                luContext.ResumeThread(out var epoch);
+                luContext.ResumeThread();
 
                 try
                 {
@@ -531,7 +531,7 @@ namespace FASTER.test.LockableUnsafeContext
 
             using (var luContext = session.GetLockableUnsafeContext())
             {
-                luContext.ResumeThread(out var epoch);
+                luContext.ResumeThread();
 
                 try
                 {

--- a/cs/test/ModifiedBitTests.cs
+++ b/cs/test/ModifiedBitTests.cs
@@ -213,7 +213,7 @@ namespace FASTER.test.ModifiedTests
             session.ResetModified(key);
             using (var luContext = session.GetLockableUnsafeContext())
             {
-                luContext.ResumeThread(out var epoch);
+                luContext.ResumeThread();
                 AssertLockandModified(luContext, key, xlock: false, slock: false, modfied: false);
                 luContext.SuspendThread();
             }
@@ -224,7 +224,7 @@ namespace FASTER.test.ModifiedTests
             Status status = default;
             using (var luContext = session.GetLockableUnsafeContext())
             {
-                luContext.ResumeThread(out var epoch);
+                luContext.ResumeThread();
 
                 switch (updateOp)
                 {
@@ -281,7 +281,7 @@ namespace FASTER.test.ModifiedTests
             Status status = default;
             using (var unsafeContext = session.GetLockableUnsafeContext())
             {
-                unsafeContext.ResumeThread(out var epoch);
+                unsafeContext.ResumeThread();
                 switch (updateOp)
                 {
                     case UpdateOp.Upsert:

--- a/docs/_docs/30-fasterkv-manual-locking.md
+++ b/docs/_docs/30-fasterkv-manual-locking.md
@@ -32,7 +32,7 @@ Lock multiple keys:
 ```cs
     using (var luContext = session.GetLockableUnsafeContext())
     {
-        luContext.ResumeThread(out var epoch);
+        luContext.ResumeThread();
 
         luContext.Lock(24, LockType.Shared);
         luContext.Lock(51, LockType.Shared);
@@ -53,7 +53,7 @@ Lock multiple keys:
 ```cs
     using (var luContext = session.GetLockableUnsafeContext())
     {
-        luContext.ResumeThread(out var epoch);
+        luContext.ResumeThread();
 
         luContext.Lock(51, LockType.Shared);
 
@@ -65,8 +65,6 @@ Lock multiple keys:
 
         luContext.SuspendThread();
 ```
-
-TODO: Add sample with `luContext.LocalCurrentEpoch`.
 
 ## Internal Design
 


### PR DESCRIPTION
Also, remove overload of session Resume that returns epoch (no longer needed after native locking support added).