### PR TITLE
[C#]Fix GetNext call in LockEvictionObserver

### DIFF
--- a/cs/src/core/Allocator/LockEvictionObserver.cs
+++ b/cs/src/core/Allocator/LockEvictionObserver.cs
@@ -24,7 +24,7 @@ namespace FASTER.core
         /// <param name="iter"></param>
         public void OnNext(IFasterScanIterator<Key, Value> iter)
         {
-            while (iter.GetNext(out RecordInfo info, out Key key, out Value value))
+            while (iter.GetNext(out RecordInfo info))
             {
                 // If it is not Invalid, we must Seal it so there is no possibility it will be missed while we're in the process
                 // of transferring it to the Lock Table. Use manualLocking as we want to transfer the locks, not drain them.
@@ -36,7 +36,7 @@ namespace FASTER.core
                 info.Seal(manualLocking: true);
 
                 // Now get it into the lock table, so it is ready as soon as the record is removed.
-                this.store.LockTable.TransferFromLogRecord(ref key, info);
+                this.store.LockTable.TransferFromLogRecord(ref iter.GetKey(), info);
             }
         }
 


### PR DESCRIPTION
The iter.GetNext(out RecordInfo, out Key, out Value) form does not work for VarLen so this was replaced with the (out RecordInfo) overload and calling iter.GetKey(), which works for all types.