### PR TITLE
[C#] Convert *UnsafeContext to structs and acquire on demand

### DIFF
--- a/cs/benchmark/FasterSpanByteYcsbBenchmark.cs
+++ b/cs/benchmark/FasterSpanByteYcsbBenchmark.cs
@@ -125,8 +125,8 @@ namespace FASTER.benchmark
 #endif
 
             var session = store.For(functions).NewSession<FunctionsSB>();
-            var uContext = session.GetUnsafeContext();
-            uContext.ResumeThread();
+            var uContext = session.UnsafeContext;
+            uContext.BeginUnsafe();
 
             try
             {
@@ -203,10 +203,9 @@ namespace FASTER.benchmark
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
 
-            uContext.Dispose();
             session.Dispose();
 
             sw.Stop();
@@ -479,8 +478,8 @@ namespace FASTER.benchmark
             waiter.Wait();
 
             var session = store.For(functions).NewSession<FunctionsSB>();
-            var uContext = session.GetUnsafeContext();
-            uContext.ResumeThread();
+            var uContext = session.UnsafeContext;
+            uContext.BeginUnsafe();
 
 #if DASHBOARD
             var tstart = Stopwatch.GetTimestamp();
@@ -531,9 +530,8 @@ namespace FASTER.benchmark
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
-            uContext.Dispose();
             session.Dispose();
         }
 

--- a/cs/benchmark/FasterYcsbBenchmark.cs
+++ b/cs/benchmark/FasterYcsbBenchmark.cs
@@ -121,8 +121,8 @@ namespace FASTER.benchmark
 #endif
 
             var session = store.For(functions).NewSession<Functions>();
-            var uContext = session.GetUnsafeContext();
-            uContext.ResumeThread();
+            var uContext = session.UnsafeContext;
+            uContext.BeginUnsafe();
 
             try
             {
@@ -199,10 +199,9 @@ namespace FASTER.benchmark
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
 
-            uContext.Dispose();
             session.Dispose();
 
             sw.Stop();
@@ -319,7 +318,8 @@ namespace FASTER.benchmark
             if (testLoader.Options.LockImpl == (int)LockImpl.Manual)
             {
                 session = store.For(functions).NewSession<Functions>();
-                luContext = session.GetLockableUnsafeContext();
+                luContext = session.LockableUnsafeContext;
+                luContext.BeginLockable();
 
                 Console.WriteLine("Taking 2 manual locks");
                 luContext.Lock(xlock.key, xlock.kind);
@@ -436,7 +436,7 @@ namespace FASTER.benchmark
             {
                 luContext.Unlock(xlock.key, xlock.kind);
                 luContext.Unlock(slock.key, slock.kind);
-                luContext.Dispose();
+                luContext.EndLockable();
                 session.Dispose();
             }
 
@@ -467,8 +467,8 @@ namespace FASTER.benchmark
             waiter.Wait();
 
             var session = store.For(functions).NewSession<Functions>();
-            var uContext = session.GetUnsafeContext();
-            uContext.ResumeThread();
+            var uContext = session.UnsafeContext;
+            uContext.BeginUnsafe();
 
 #if DASHBOARD
             var tstart = Stopwatch.GetTimestamp();
@@ -518,9 +518,8 @@ namespace FASTER.benchmark
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
-            uContext.Dispose();
             session.Dispose();
         }
 

--- a/cs/src/core/ClientSession/BasicContext.cs
+++ b/cs/src/core/ClientSession/BasicContext.cs
@@ -16,6 +16,9 @@ namespace FASTER.core
     {
         readonly ClientSession<Key, Value, Input, Output, Context, Functions> clientSession;
 
+        /// <summary>Indicates whether this struct has been initialized</summary>
+        public bool IsNull => this.clientSession is null;
+
         internal BasicContext(ClientSession<Key, Value, Input, Output, Context, Functions> clientSession)
         {
             this.clientSession = clientSession;

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,8 +36,8 @@ namespace FASTER.core
 
         internal readonly InternalFasterSession FasterSession;
 
-        UnsafeContext<Key, Value, Input, Output, Context, Functions> uContext;
-        LockableUnsafeContext<Key, Value, Input, Output, Context, Functions> luContext;
+        readonly UnsafeContext<Key, Value, Input, Output, Context, Functions> uContext;
+        readonly LockableUnsafeContext<Key, Value, Input, Output, Context, Functions> luContext;
         readonly LockableContext<Key, Value, Input, Output, Context, Functions> lContext;
         readonly BasicContext<Key, Value, Input, Output, Context, Functions> bContext;
 
@@ -49,32 +50,34 @@ namespace FASTER.core
         internal ulong sharedLockCount;
         internal ulong exclusiveLockCount;
 
-        bool isAcquired;
+        bool isAcquiredLockable;
 
-        internal void Acquire()
+        internal void AcquireLockable()
         {
-            CheckNotAcquired();
+            CheckIsNotAcquiredLockable();
             fht.IncrementNumLockingSessions();
-            isAcquired = true;
+            isAcquiredLockable = true;
         }
 
-        internal void Release()
+        internal void ReleaseLockable(string methodName)
         {
-            CheckAcquired();
-            isAcquired = false;
+            CheckIsAcquiredLockable();
+            if (TotalLockCount > 0)
+                throw new FasterException($"{methodName} called with locks held: {sharedLockCount} shared locks, {exclusiveLockCount} exclusive locks");
+            isAcquiredLockable = false;
             fht.DecrementNumLockingSessions();
         }
 
-        internal void CheckAcquired()
+        internal void CheckIsAcquiredLockable()
         {
-            if (!isAcquired)
-                throw new FasterException("Method call on not-acquired Context");
+            if (!isAcquiredLockable)
+                throw new FasterException("Lockable method call when BeginLockable has not been called");
         }
 
-        void CheckNotAcquired()
+        void CheckIsNotAcquiredLockable()
         {
-            if (isAcquired)
-                throw new FasterException("Method call on acquired Context");
+            if (isAcquiredLockable)
+                throw new FasterException("BeginLockable cannot be called twice (call EndLockable first)");
         }
 
         internal ClientSession(
@@ -86,6 +89,8 @@ namespace FASTER.core
         {
             this.lContext = new(this);
             this.bContext = new(this);
+            this.luContext = new(this);
+            this.uContext = new(this);
 
             this.loggerFactory = loggerFactory;
             this.logger = loggerFactory?.CreateLogger($"ClientSession-{GetHashCode():X8}");
@@ -199,22 +204,12 @@ namespace FASTER.core
         /// <summary>
         /// Return a new interface to Faster operations that supports manual epoch control.
         /// </summary>
-        public UnsafeContext<Key, Value, Input, Output, Context, Functions> GetUnsafeContext()
-        {
-            this.uContext ??= new(this);
-            this.uContext.Acquire();
-            return this.uContext;
-        }
+        public UnsafeContext<Key, Value, Input, Output, Context, Functions> UnsafeContext => uContext;
 
         /// <summary>
         /// Return a new interface to Faster operations that supports manual locking and epoch control.
         /// </summary>
-        public LockableUnsafeContext<Key, Value, Input, Output, Context, Functions> GetLockableUnsafeContext()
-        {
-            this.luContext ??= new(this);
-            this.luContext.Acquire();
-            return this.luContext;
-        }
+        public LockableUnsafeContext<Key, Value, Input, Output, Context, Functions> LockableUnsafeContext => luContext;
 
         /// <summary>
         /// Return a session wrapper that supports manual locking.
@@ -655,40 +650,51 @@ namespace FASTER.core
         #region Other Operations
 
         /// <inheritdoc/>
-        public unsafe void ResetModified(ref Key key)
+        public void ResetModified(ref Key key)
         {
             UnsafeResumeThread();
             try
             {
-                OperationStatus status;
-                do
-                    status = fht.InternalModifiedBitOperation(ref key, out _);
-                while (fht.HandleImmediateNonPendingRetryStatus(status, ctx, FasterSession));
+                UnsafeResetModified(ref key);
             }
             finally
             {
                 UnsafeSuspendThread();
             }
         }
+
+        internal void UnsafeResetModified(ref Key key)
+        {
+            OperationStatus status;
+            do
+                status = fht.InternalModifiedBitOperation(ref key, out _);
+            while (fht.HandleImmediateNonPendingRetryStatus(status, ctx, FasterSession));
+        }
+
         /// <inheritdoc/>
         public unsafe void ResetModified(Key key) => ResetModified(ref key);
 
         /// <inheritdoc/>
-        internal unsafe bool IsModified(ref Key key)
+        internal bool IsModified(ref Key key)
         {
-            RecordInfo modifiedInfo;
             UnsafeResumeThread();
             try
             {
-                OperationStatus status;
-                do
-                    status = fht.InternalModifiedBitOperation(ref key, out modifiedInfo, false);
-                while (fht.HandleImmediateNonPendingRetryStatus(status, ctx, FasterSession));
+                return UnsafeIsModified(ref key);
             }
             finally
             {
                 UnsafeSuspendThread();
             }
+        }
+
+        internal bool UnsafeIsModified(ref Key key)
+        {
+            RecordInfo modifiedInfo;
+            OperationStatus status;
+            do
+                status = fht.InternalModifiedBitOperation(ref key, out modifiedInfo, false);
+            while (fht.HandleImmediateNonPendingRetryStatus(status, ctx, FasterSession));
             return modifiedInfo.Modified;
         }
 
@@ -848,6 +854,8 @@ namespace FASTER.core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void UnsafeResumeThread()
         {
+            // We do not track any "acquired" state here; if someone mixes calls between safe and unsafe contexts, they will 
+            // get the "trying to acquire already-acquired epoch" error.
             fht.epoch.Resume();
             fht.InternalRefresh(ctx, FasterSession);
         }
@@ -856,8 +864,11 @@ namespace FASTER.core
         /// Suspend session on current thread
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void UnsafeSuspendThread() 
-            => fht.epoch.Suspend();
+        internal void UnsafeSuspendThread()
+        {
+            Debug.Assert(fht.epoch.ThisInstanceProtected());
+            fht.epoch.Suspend();
+        }
 
         void IClientSession.AtomicSwitch(long version)
         {

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -72,11 +72,11 @@ namespace FASTER.core
             }
         }
 
-        internal void ReleaseLockable(string methodName)
+        internal void ReleaseLockable()
         {
             CheckIsAcquiredLockable();
             if (TotalLockCount > 0)
-                throw new FasterException($"{methodName} called with locks held: {sharedLockCount} shared locks, {exclusiveLockCount} exclusive locks");
+                throw new FasterException($"EndLockable called with locks held: {sharedLockCount} shared locks, {exclusiveLockCount} exclusive locks");
             InternalReleaseLockable();
         }
 

--- a/cs/src/core/ClientSession/ILockableContext.cs
+++ b/cs/src/core/ClientSession/ILockableContext.cs
@@ -10,6 +10,16 @@ namespace FASTER.core
     public interface ILockableContext<TKey>
     {
         /// <summary>
+        /// Begins a series of lock operations on possibly multiple keys; call before any locks are taken.
+        /// </summary>
+        void BeginLockable();
+
+        /// <summary>
+        /// Ends a series of lock operations on possibly multiple keys; call after all locks are released.
+        /// </summary>
+        void EndLockable();
+
+        /// <summary>
         /// Lock the key with the specified <paramref name="lockType"/>, waiting until it is acquired
         /// </summary>
         /// <param name="key">The key to lock</param>

--- a/cs/src/core/ClientSession/IUnsafeContext.cs
+++ b/cs/src/core/ClientSession/IUnsafeContext.cs
@@ -10,13 +10,13 @@ namespace FASTER.core
     public interface IUnsafeContext
     {
         /// <summary>
-        /// Resume session on current thread. IMPORTANT: Call SuspendThread before any async op.
+        /// Resume session on current thread. IMPORTANT: Call <see cref="EndUnsafe"/> before any async op.
         /// </summary>
-        void ResumeThread();
+        void BeginUnsafe();
 
         /// <summary>
         /// Suspend session on current thread
         /// </summary>
-        void SuspendThread();
+        void EndUnsafe();
     }
 }

--- a/cs/src/core/ClientSession/LockableContext.cs
+++ b/cs/src/core/ClientSession/LockableContext.cs
@@ -32,7 +32,7 @@ namespace FASTER.core
         public void BeginLockable() => clientSession.AcquireLockable();
 
         /// <inheritdoc/>
-        public void EndLockable() => clientSession.ReleaseLockable("LockableContext.EndLockable");
+        public void EndLockable() => clientSession.ReleaseLockable();
 
         #endregion Begin/EndLockable
 

--- a/cs/src/core/ClientSession/LockableContext.cs
+++ b/cs/src/core/ClientSession/LockableContext.cs
@@ -17,59 +17,31 @@ namespace FASTER.core
         readonly ClientSession<Key, Value, Input, Output, Context, Functions> clientSession;
         readonly InternalFasterSession FasterSession;
 
+        /// <summary>Indicates whether this struct has been initialized</summary>
+        public bool IsNull => this.clientSession is null;
+
         internal LockableContext(ClientSession<Key, Value, Input, Output, Context, Functions> clientSession)
         {
             this.clientSession = clientSession;
             FasterSession = new InternalFasterSession(clientSession);
         }
 
-        /// <inheritdoc/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void UnsafeResumeThread()
-        {
-            clientSession.CheckAcquired();
-            Debug.Assert(!clientSession.fht.epoch.ThisInstanceProtected());
-            clientSession.UnsafeResumeThread();
-        }
+        #region Begin/EndLockable
 
         /// <inheritdoc/>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void UnsafeSuspendThread()
-        {
-            clientSession.CheckAcquired();
-            Debug.Assert(clientSession.fht.epoch.ThisInstanceProtected());
-            clientSession.UnsafeSuspendThread();
-        }
+        public void BeginLockable() => clientSession.AcquireLockable();
 
-        #region Acquire and Dispose
+        /// <inheritdoc/>
+        public void EndLockable() => clientSession.ReleaseLockable("LockableContext.EndLockable");
 
-        /// <summary>
-        /// Acquire a lockable context
-        /// </summary>
-        public void Acquire()
-        {
-            clientSession.Acquire();
-        }
-
-        /// <summary>
-        /// Release a lockable context; does not actually dispose of anything
-        /// </summary>
-        public void Release()
-        {
-            if (clientSession.fht.epoch.ThisInstanceProtected())
-                throw new FasterException("Releasing LockableContext with a protected epoch; must call UnsafeSuspendThread");
-            if (clientSession.TotalLockCount > 0)
-                throw new FasterException($"Releasing LockableContext with locks held: {clientSession.sharedLockCount} shared locks, {clientSession.exclusiveLockCount} exclusive locks");
-            clientSession.Release();
-        }
-        #endregion Acquire and Dispose
+        #endregion Begin/EndLockable
 
         #region Key Locking
 
         /// <inheritdoc/>
         public unsafe void Lock(ref Key key, LockType lockType)
         {
-            clientSession.CheckAcquired();
+            clientSession.CheckIsAcquiredLockable();
             Debug.Assert(!clientSession.fht.epoch.ThisInstanceProtected());
             clientSession.UnsafeResumeThread();
             try
@@ -100,7 +72,7 @@ namespace FASTER.core
         /// <inheritdoc/>
         public void Unlock(ref Key key, LockType lockType)
         {
-            clientSession.CheckAcquired();
+            clientSession.CheckIsAcquiredLockable();
             Debug.Assert(!clientSession.fht.epoch.ThisInstanceProtected());
             clientSession.UnsafeResumeThread();
             try
@@ -131,7 +103,7 @@ namespace FASTER.core
         /// <inheritdoc/>
         public (bool exclusive, byte shared) IsLocked(ref Key key)
         {
-            clientSession.CheckAcquired();
+            clientSession.CheckIsAcquiredLockable();
             Debug.Assert(!clientSession.fht.epoch.ThisInstanceProtected());
             clientSession.UnsafeResumeThread();
             try
@@ -643,8 +615,8 @@ namespace FASTER.core
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public bool InPlaceUpdater(ref Key key, ref Input input, ref Value value, ref Output output, ref RecordInfo recordInfo, ref RMWInfo rmwInfo, out bool lockFailed, out OperationStatus status)
             {
-                recordInfo.SetDirtyAndModified();
                 lockFailed = false;
+                recordInfo.SetDirtyAndModified();
                 return _clientSession.InPlaceUpdater(ref key, ref input, ref output, ref value, ref recordInfo, ref rmwInfo, out status);
             }
 

--- a/cs/src/core/ClientSession/LockableUnsafeContext.cs
+++ b/cs/src/core/ClientSession/LockableUnsafeContext.cs
@@ -44,7 +44,7 @@ namespace FASTER.core
         public void BeginLockable() => clientSession.AcquireLockable();
 
         /// <inheritdoc/>
-        public void EndLockable() => clientSession.ReleaseLockable("LockableUnsafeContext.EndLockable");
+        public void EndLockable() => clientSession.ReleaseLockable();
         #endregion Begin/EndLockable
 
         #region Key Locking

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -545,7 +545,10 @@ namespace FASTER.core
                 }
 
                 if (valueTasks.Count == 0)
+                {
+                    // Note: The state machine will not advance as long as there are active locking sessions.
                     continue; // we need to re-check loop, so we return only when we are at REST
+                }
 
                 foreach (var task in valueTasks)
                 {

--- a/cs/stress/TestLoader.cs
+++ b/cs/stress/TestLoader.cs
@@ -226,7 +226,7 @@ namespace FASTER.stress
 
             var uContext = luContext as IUnsafeContext;
             if (isAsyncTest)
-                uContext.ResumeThread();
+                uContext.BeginUnsafe();
             try
             {
                 for (var ii = 0; ii < keyCount; ++ii)
@@ -240,7 +240,7 @@ namespace FASTER.stress
             finally
             {
                 if (isAsyncTest)
-                    uContext.SuspendThread();
+                    uContext.EndUnsafe();
             }
         }
 
@@ -251,7 +251,7 @@ namespace FASTER.stress
 
             var uContext = luContext as IUnsafeContext;
             if (isAsyncTest)
-                uContext.ResumeThread();
+                uContext.BeginUnsafe();
             try
             {
                 for (var ii = 0; ii < keyCount; ++ii)
@@ -265,7 +265,7 @@ namespace FASTER.stress
             finally
             {
                 if (isAsyncTest)
-                    uContext.SuspendThread();
+                    uContext.EndUnsafe();
             }
         }
 

--- a/cs/test/DisposeTests.cs
+++ b/cs/test/DisposeTests.cs
@@ -468,7 +468,7 @@ namespace FASTER.test.Dispose
             DoFlush(flushMode);
 
             // This is necessary for FlushMode.ReadOnly to test the readonly range in Delete() (otherwise we can't test SingleDeleter there)
-            using var luc = fht.NewSession(new DisposeFunctionsNoSync()).GetLockableUnsafeContext();
+            var luc = fht.NewSession(new DisposeFunctionsNoSync()).LockableUnsafeContext;
 
             void DoDelete(DisposeFunctions functions)
             {

--- a/cs/test/LockableUnsafeContextTests.cs
+++ b/cs/test/LockableUnsafeContextTests.cs
@@ -194,8 +194,8 @@ namespace FASTER.test.LockableUnsafeContext
             var sw = Stopwatch.StartNew();
 
             // Copied from UnsafeContextTests to test Async.
-            using var luContext = session.GetLockableUnsafeContext();
-            luContext.ResumeThread();
+            var luContext = session.LockableUnsafeContext;
+            luContext.BeginUnsafe();
 
             try
             {
@@ -209,9 +209,9 @@ namespace FASTER.test.LockableUnsafeContext
                     }
                     else
                     {
-                        luContext.SuspendThread();
+                        luContext.EndUnsafe();
                         var status = (await luContext.UpsertAsync(ref key1, ref value)).Complete();
-                        luContext.ResumeThread();
+                        luContext.BeginUnsafe();
                         Assert.IsFalse(status.IsPending);
                     }
                 }
@@ -232,9 +232,9 @@ namespace FASTER.test.LockableUnsafeContext
                     }
                     else
                     {
-                        luContext.SuspendThread();
+                        luContext.EndUnsafe();
                         (status, output) = (await luContext.ReadAsync(ref key1, ref input)).Complete();
-                        luContext.ResumeThread();
+                        luContext.BeginUnsafe();
                     }
                     if (!status.IsPending)
                     {
@@ -247,9 +247,9 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 else
                 {
-                    luContext.SuspendThread();
+                    luContext.EndUnsafe();
                     await luContext.CompletePendingAsync();
-                    luContext.ResumeThread();
+                    luContext.BeginUnsafe();
                 }
 
                 // Shift head and retry - should not find in main memory now
@@ -273,9 +273,9 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 else
                 {
-                    luContext.SuspendThread();
+                    luContext.EndUnsafe();
                     outputs = await luContext.CompletePendingWithOutputsAsync();
-                    luContext.ResumeThread();
+                    luContext.BeginUnsafe();
                 }
 
                 int count = 0;
@@ -289,7 +289,7 @@ namespace FASTER.test.LockableUnsafeContext
             }
             finally
             {
-                luContext.SuspendThread();
+                luContext.EndUnsafe();
             }
         }
 
@@ -312,110 +312,109 @@ namespace FASTER.test.LockableUnsafeContext
             Status status;
             Dictionary<int, LockType> locks = new();
 
-            using (var luContext = session.GetLockableUnsafeContext())
+            var luContext = session.LockableUnsafeContext;
+            luContext.BeginUnsafe();
+            luContext.BeginLockable();
+            try
             {
-                luContext.ResumeThread();
+                {   // key scope
+                    // Get initial source values
+                    int key = 24;
+                    luContext.Lock(key, LockType.Shared);
+                    AssertIsLocked(luContext, key, xlock: false, slock: true);
+                    locks[key] = LockType.Shared;
 
-                try
-                {
-                    {   // key scope
-                        // Get initial source values
-                        int key = 24;
-                        luContext.Lock(key, LockType.Shared);
-                        AssertIsLocked(luContext, key, xlock: false, slock: true);
-                        locks[key] = LockType.Shared;
+                    key = 51;
+                    luContext.Lock(key, LockType.Shared);
+                    locks[key] = LockType.Shared;
+                    AssertIsLocked(luContext, key, xlock: false, slock: true);
 
-                        key = 51;
-                        luContext.Lock(key, LockType.Shared);
-                        locks[key] = LockType.Shared;
-                        AssertIsLocked(luContext, key, xlock: false, slock: true);
+                    // Lock destination value.
+                    luContext.Lock(resultKey, LockType.Exclusive);
+                    locks[resultKey] = LockType.Exclusive;
+                    AssertIsLocked(luContext, resultKey, xlock: true, slock: false);
 
-                        // Lock destination value.
-                        luContext.Lock(resultKey, LockType.Exclusive);
-                        locks[resultKey] = LockType.Exclusive;
-                        AssertIsLocked(luContext, resultKey, xlock: true, slock: false);
-
-                        // Re-get source values, to verify (e.g. they may be in readcache now).
-                        // We just locked this above, but for FlushMode.OnDisk it will be in the LockTable and will still be PENDING.
-                        status = luContext.Read(24, out var value24);
-                        if (flushMode == FlushMode.OnDisk)
+                    // Re-get source values, to verify (e.g. they may be in readcache now).
+                    // We just locked this above, but for FlushMode.OnDisk it will be in the LockTable and will still be PENDING.
+                    status = luContext.Read(24, out var value24);
+                    if (flushMode == FlushMode.OnDisk)
+                    {
+                        if (status.IsPending)
                         {
-                            if (status.IsPending)
-                            {
-                                luContext.CompletePendingWithOutputs(out var completedOutputs, wait: true);
-                                Assert.True(completedOutputs.Next());
-                                value24 = completedOutputs.Current.Output;
-                                Assert.False(completedOutputs.Current.RecordMetadata.RecordInfo.IsLockedExclusive);
-                                Assert.Less(0, completedOutputs.Current.RecordMetadata.RecordInfo.NumLockedShared);
-                                Assert.False(completedOutputs.Next());
-                                completedOutputs.Dispose();
-                            }
+                            luContext.CompletePendingWithOutputs(out var completedOutputs, wait: true);
+                            Assert.True(completedOutputs.Next());
+                            value24 = completedOutputs.Current.Output;
+                            Assert.False(completedOutputs.Current.RecordMetadata.RecordInfo.IsLockedExclusive);
+                            Assert.Less(0, completedOutputs.Current.RecordMetadata.RecordInfo.NumLockedShared);
+                            Assert.False(completedOutputs.Next());
+                            completedOutputs.Dispose();
                         }
-                        else
-                        {
-                            Assert.IsFalse(status.IsPending, status.ToString());
-                        }
-
-                        status = luContext.Read(51, out var value51);
-                        if (flushMode == FlushMode.OnDisk)
-                        {
-                            if (status.IsPending)
-                            {
-                                luContext.CompletePendingWithOutputs(out var completedOutputs, wait: true);
-                                Assert.True(completedOutputs.Next());
-                                value51 = completedOutputs.Current.Output;
-                                Assert.False(completedOutputs.Current.RecordMetadata.RecordInfo.IsLockedExclusive);
-                                Assert.Less(0, completedOutputs.Current.RecordMetadata.RecordInfo.NumLockedShared);
-                                Assert.False(completedOutputs.Next());
-                                completedOutputs.Dispose();
-                            }
-                        }
-                        else
-                        {
-                            Assert.IsFalse(status.IsPending, status.ToString());
-                        }
-
-                        // Set the phase to Phase.INTERMEDIATE to test the non-Phase.REST blocks
-                        session.ctx.phase = phase;
-                        int dummyInOut = 0;
-                        status = useRMW
-                            ? luContext.RMW(ref resultKey, ref expectedResult, ref dummyInOut, out RecordMetadata recordMetadata)
-                            : luContext.Upsert(ref resultKey, ref dummyInOut, ref expectedResult, ref dummyInOut, out recordMetadata);
-                        if (flushMode == FlushMode.OnDisk)
-                        {
-                            if (status.IsPending)
-                            {
-                                luContext.CompletePendingWithOutputs(out var completedOutputs, wait: true);
-                                Assert.True(completedOutputs.Next());
-                                resultValue = completedOutputs.Current.Output;
-                                Assert.True(completedOutputs.Current.RecordMetadata.RecordInfo.IsLockedExclusive);
-                                Assert.AreEqual(0, completedOutputs.Current.RecordMetadata.RecordInfo.NumLockedShared);
-                                Assert.False(completedOutputs.Next());
-                                completedOutputs.Dispose();
-                            }
-                        }
-                        else
-                        {
-                            Assert.IsFalse(status.IsPending, status.ToString());
-                        }
-
-                        // Reread the destination to verify
-                        status = luContext.Read(resultKey, out resultValue);
-                        Assert.IsFalse(status.IsPending, status.ToString());
-                        Assert.AreEqual(expectedResult, resultValue);
                     }
-                    foreach (var key in locks.Keys.OrderBy(key => -key))
-                        luContext.Unlock(key, locks[key]);
+                    else
+                    {
+                        Assert.IsFalse(status.IsPending, status.ToString());
+                    }
+
+                    status = luContext.Read(51, out var value51);
+                    if (flushMode == FlushMode.OnDisk)
+                    {
+                        if (status.IsPending)
+                        {
+                            luContext.CompletePendingWithOutputs(out var completedOutputs, wait: true);
+                            Assert.True(completedOutputs.Next());
+                            value51 = completedOutputs.Current.Output;
+                            Assert.False(completedOutputs.Current.RecordMetadata.RecordInfo.IsLockedExclusive);
+                            Assert.Less(0, completedOutputs.Current.RecordMetadata.RecordInfo.NumLockedShared);
+                            Assert.False(completedOutputs.Next());
+                            completedOutputs.Dispose();
+                        }
+                    }
+                    else
+                    {
+                        Assert.IsFalse(status.IsPending, status.ToString());
+                    }
+
+                    // Set the phase to Phase.INTERMEDIATE to test the non-Phase.REST blocks
+                    session.ctx.phase = phase;
+                    int dummyInOut = 0;
+                    status = useRMW
+                        ? luContext.RMW(ref resultKey, ref expectedResult, ref dummyInOut, out RecordMetadata recordMetadata)
+                        : luContext.Upsert(ref resultKey, ref dummyInOut, ref expectedResult, ref dummyInOut, out recordMetadata);
+                    if (flushMode == FlushMode.OnDisk)
+                    {
+                        if (status.IsPending)
+                        {
+                            luContext.CompletePendingWithOutputs(out var completedOutputs, wait: true);
+                            Assert.True(completedOutputs.Next());
+                            resultValue = completedOutputs.Current.Output;
+                            Assert.True(completedOutputs.Current.RecordMetadata.RecordInfo.IsLockedExclusive);
+                            Assert.AreEqual(0, completedOutputs.Current.RecordMetadata.RecordInfo.NumLockedShared);
+                            Assert.False(completedOutputs.Next());
+                            completedOutputs.Dispose();
+                        }
+                    }
+                    else
+                    {
+                        Assert.IsFalse(status.IsPending, status.ToString());
+                    }
+
+                    // Reread the destination to verify
+                    status = luContext.Read(resultKey, out resultValue);
+                    Assert.IsFalse(status.IsPending, status.ToString());
+                    Assert.AreEqual(expectedResult, resultValue);
                 }
-                catch (Exception)
-                {
-                    ClearCountsOnError(session);
-                    throw;
-                }
-                finally
-                {
-                    luContext.SuspendThread();
-                }
+                foreach (var key in locks.Keys.OrderBy(key => -key))
+                    luContext.Unlock(key, locks[key]);
+            }
+            catch (Exception)
+            {
+                ClearCountsOnError(session);
+                throw;
+            }
+            finally
+            {
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
 
             // Verify reading the destination from the full session.
@@ -441,8 +440,9 @@ namespace FASTER.test.LockableUnsafeContext
             var useRMW = updateOp == UpdateOp.RMW;
             Status status;
 
-            using var luContext = session.GetLockableUnsafeContext();
-            luContext.ResumeThread();
+            var luContext = session.LockableUnsafeContext;
+            luContext.BeginUnsafe();
+            luContext.BeginLockable();
 
             try
             {
@@ -501,7 +501,8 @@ namespace FASTER.test.LockableUnsafeContext
             }
             finally
             {
-                luContext.SuspendThread();
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
 
             // Verify from the full session.
@@ -529,38 +530,38 @@ namespace FASTER.test.LockableUnsafeContext
             int resultKey = resultLockTarget == ResultLockTarget.LockTable ? numRecords + 1 : 75;
             Status status;
 
-            using (var luContext = session.GetLockableUnsafeContext())
+            var luContext = session.LockableUnsafeContext;
+            luContext.BeginUnsafe();
+            luContext.BeginLockable();
+
+            try
             {
-                luContext.ResumeThread();
+                // Lock destination value.
+                luContext.Lock(resultKey, LockType.Exclusive);
+                locks[resultKey] = LockType.Exclusive;
+                AssertIsLocked(luContext, resultKey, xlock: true, slock: false);
 
-                try
-                {
-                    // Lock destination value.
-                    luContext.Lock(resultKey, LockType.Exclusive);
-                    locks[resultKey] = LockType.Exclusive;
-                    AssertIsLocked(luContext, resultKey, xlock: true, slock: false);
+                // Set the phase to Phase.INTERMEDIATE to test the non-Phase.REST blocks
+                session.ctx.phase = phase;
+                status = luContext.Delete(ref resultKey);
+                Assert.IsFalse(status.IsPending, status.ToString());
 
-                    // Set the phase to Phase.INTERMEDIATE to test the non-Phase.REST blocks
-                    session.ctx.phase = phase;
-                    status = luContext.Delete(ref resultKey);
-                    Assert.IsFalse(status.IsPending, status.ToString());
+                // Reread the destination to verify
+                status = luContext.Read(resultKey, out var _);
+                Assert.IsFalse(status.Found, status.ToString());
 
-                    // Reread the destination to verify
-                    status = luContext.Read(resultKey, out var _);
-                    Assert.IsFalse(status.Found, status.ToString());
-
-                    foreach (var key in locks.Keys.OrderBy(key => key))
-                        luContext.Unlock(key, locks[key]);
-                }
-                catch (Exception)
-                {
-                    ClearCountsOnError(session);
-                    throw;
-                }
-                finally
-                {
-                    luContext.SuspendThread();
-                }
+                foreach (var key in locks.Keys.OrderBy(key => key))
+                    luContext.Unlock(key, locks[key]);
+            }
+            catch (Exception)
+            {
+                ClearCountsOnError(session);
+                throw;
+            }
+            finally
+            {
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
 
             // Verify reading the destination from the full session.
@@ -588,8 +589,9 @@ namespace FASTER.test.LockableUnsafeContext
                 Random rng = new(tid + 101);
 
                 using var localSession = fht.For(new LockableUnsafeFunctions()).NewSession<LockableUnsafeFunctions>();
-                using var luContext = localSession.GetLockableUnsafeContext();
-                luContext.ResumeThread();
+                var luContext = localSession.LockableUnsafeContext;
+                luContext.BeginUnsafe();
+                luContext.BeginLockable();
 
                 for (var iteration = 0; iteration < numIterations; ++iteration)
                 {
@@ -605,7 +607,8 @@ namespace FASTER.test.LockableUnsafeContext
                     locks.Clear();
                 }
 
-                luContext.SuspendThread();
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
 
             void runOpThread(int tid)
@@ -688,11 +691,12 @@ namespace FASTER.test.LockableUnsafeContext
             fht.Log.FlushAndEvict(wait: true);
 
             using var session = fht.NewSession(new SimpleFunctions<int, int>());
-            using var luContext = session.GetLockableUnsafeContext();
+            var luContext = session.LockableUnsafeContext;
             int input = 0, output = 0, key = transferToExistingKey;
             ReadOptions readOptions = new() { ReadFlags = ReadFlags.CopyReadsToTail};
 
-            luContext.ResumeThread();
+            luContext.BeginUnsafe();
+            luContext.BeginLockable();
             try
             {
                 AddLockTableEntry(luContext, key, immutable: false);
@@ -710,7 +714,8 @@ namespace FASTER.test.LockableUnsafeContext
             }
             finally
             {
-                luContext.SuspendThread();
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
         }
 
@@ -722,10 +727,11 @@ namespace FASTER.test.LockableUnsafeContext
             Populate();
 
             using var session = fht.NewSession(new SimpleFunctions<int, int>());
-            using var luContext = session.GetLockableUnsafeContext();
+            var luContext = session.LockableUnsafeContext;
             int key = transferToExistingKey;
 
-            luContext.ResumeThread();
+            luContext.BeginUnsafe();
+            luContext.BeginLockable();
             try
             {
                 luContext.Lock(ref key, LockType.Exclusive);
@@ -746,7 +752,8 @@ namespace FASTER.test.LockableUnsafeContext
             }
             finally
             {
-                luContext.SuspendThread();
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
         }
 
@@ -768,8 +775,9 @@ namespace FASTER.test.LockableUnsafeContext
             PopulateAndEvict(recordRegion == ChainTests.RecordRegion.Immutable);
 
             using var session = fht.NewSession(new SimpleFunctions<int, int>());
-            using var luContext = session.GetLockableUnsafeContext();
-            luContext.ResumeThread();
+            var luContext = session.LockableUnsafeContext;
+            luContext.BeginUnsafe();
+            luContext.BeginLockable();
 
             int key = -1;
             try
@@ -798,7 +806,8 @@ namespace FASTER.test.LockableUnsafeContext
             }
             finally
             {
-                luContext.SuspendThread();
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
         }
 
@@ -810,8 +819,9 @@ namespace FASTER.test.LockableUnsafeContext
             PopulateAndEvict(recordRegion == ChainTests.RecordRegion.Immutable);
 
             using var session = fht.NewSession(new SimpleFunctions<int, int>());
-            using var luContext = session.GetLockableUnsafeContext();
-            luContext.ResumeThread();
+            var luContext = session.LockableUnsafeContext;
+            luContext.BeginUnsafe();
+            luContext.BeginLockable();
 
             int key = -1;
             try
@@ -840,7 +850,8 @@ namespace FASTER.test.LockableUnsafeContext
             }
             finally
             {
-                luContext.SuspendThread();
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
         }
 
@@ -852,8 +863,9 @@ namespace FASTER.test.LockableUnsafeContext
             PopulateAndEvict(recordRegion == ChainTests.RecordRegion.Immutable);
 
             using var session = fht.NewSession(new SimpleFunctions<int, int>());
-            using var luContext = session.GetLockableUnsafeContext();
-            luContext.ResumeThread();
+            var luContext = session.LockableUnsafeContext;
+            luContext.BeginUnsafe();
+            luContext.BeginLockable();
 
             int key = -1;
             try
@@ -887,7 +899,8 @@ namespace FASTER.test.LockableUnsafeContext
             }
             finally
             {
-                luContext.SuspendThread();
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
         }
 
@@ -898,14 +911,15 @@ namespace FASTER.test.LockableUnsafeContext
         {
             // For this, just don't load anything, and it will happen in lock table.
             using var session = fht.NewSession(new SimpleFunctions<int, int>());
-            using var luContext = session.GetLockableUnsafeContext();
+            var luContext = session.LockableUnsafeContext;
 
             Dictionary<int, LockType> locks = new();
             var rng = new Random(101);
             foreach (var key in Enumerable.Range(0, numRecords).Select(ii => rng.Next(numRecords)))
                 locks[key] = (key & 1) == 0 ? LockType.Exclusive : LockType.Shared;
 
-            luContext.ResumeThread();
+            luContext.BeginUnsafe();
+            luContext.BeginLockable();
             try
             {
 
@@ -935,7 +949,8 @@ namespace FASTER.test.LockableUnsafeContext
             }
             finally
             {
-                luContext.SuspendThread();
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
 
             Assert.IsFalse(fht.LockTable.IsActive);
@@ -950,13 +965,12 @@ namespace FASTER.test.LockableUnsafeContext
             Populate();
             this.fht.Log.ShiftReadOnlyAddress(this.fht.Log.TailAddress, wait: true);
 
-            using var luContext = session.GetLockableUnsafeContext();
-
             const int key = 42;
-
             static int getValue(int key) => key + valueMult;
 
-            luContext.ResumeThread();
+            var luContext = session.LockableUnsafeContext;
+            luContext.BeginUnsafe();
+            luContext.BeginLockable();
 
             try
             {
@@ -988,7 +1002,8 @@ namespace FASTER.test.LockableUnsafeContext
             }
             finally
             {
-                luContext.SuspendThread();
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
         }
 
@@ -1001,8 +1016,8 @@ namespace FASTER.test.LockableUnsafeContext
             using var updateSession = fht.NewSession(new SimpleFunctions<int, int>());
             using var lockSession = fht.NewSession(new SimpleFunctions<int, int>());
 
-            using var updateLuContext = updateSession.GetLockableUnsafeContext();
-            using var lockLuContext = lockSession.GetLockableUnsafeContext();
+            var updateLuContext = updateSession.LockableUnsafeContext;
+            var lockLuContext = lockSession.LockableUnsafeContext;
 
             LockType getLockType(int key) => ((key & 1) == 0) ? LockType.Exclusive : LockType.Shared;
             int getValue(int key) => key + valueMult;
@@ -1018,6 +1033,9 @@ namespace FASTER.test.LockableUnsafeContext
             // Now populate the main area of the log.
             Populate();
 
+            lockLuContext.BeginUnsafe();
+            lockLuContext.BeginLockable();
+
             HashSet<int> locks = new();
             void lockKey(int key)
             {
@@ -1030,7 +1048,6 @@ namespace FASTER.test.LockableUnsafeContext
                 locks.Remove(key);
             }
 
-            lockLuContext.ResumeThread();
             try
             {
 
@@ -1077,14 +1094,18 @@ namespace FASTER.test.LockableUnsafeContext
             }
             finally
             {
-                lockLuContext.SuspendThread();
+                lockLuContext.EndLockable();
+                lockLuContext.EndUnsafe();
             }
 
             void locker(int key)
             {
                 try
                 {
-                    lockLuContext.ResumeThread();
+                    // Begin/EndLockable are called outside this function; we could not EndLockable in here as the lock lifetime is beyond that.
+                    // (BeginLockable's scope is the session; BeginUnsafe's scope is the thread. The session is still "mono-threaded" here because
+                    // only one thread at a time is making calls on it.)
+                    lockLuContext.BeginUnsafe();
                     if (lockOp == LockOperationType.Lock)
                         lockKey(key);
                     else
@@ -1097,13 +1118,13 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 finally
                 {
-                    lockLuContext.SuspendThread();
+                    lockLuContext.EndUnsafe();
                 }
             }
 
             void updater(int key)
             {
-                updateLuContext.ResumeThread();
+                updateLuContext.BeginUnsafe();
 
                 try
                 {
@@ -1127,7 +1148,7 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 finally
                 {
-                    updateLuContext.SuspendThread();
+                    updateLuContext.EndUnsafe();
                 }
             }
         }
@@ -1140,12 +1161,13 @@ namespace FASTER.test.LockableUnsafeContext
             Populate();
 
             using var session = fht.NewSession(new SimpleFunctions<int, int>());
-            using var luContext = session.GetLockableUnsafeContext();
+            var luContext = session.LockableUnsafeContext;
 
             const int key = 42;
             var maxLocks = 63;
 
-            luContext.ResumeThread();
+            luContext.BeginUnsafe();
+            luContext.BeginLockable();
             try
             {
 
@@ -1172,7 +1194,8 @@ namespace FASTER.test.LockableUnsafeContext
             }
             finally
             {
-                luContext.SuspendThread();
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
         }
 
@@ -1184,14 +1207,15 @@ namespace FASTER.test.LockableUnsafeContext
             Populate();
 
             using var session = fht.NewSession(new SimpleFunctions<int, int>());
-            using var luContext = session.GetLockableUnsafeContext();
+            var luContext = session.LockableUnsafeContext;
 
             Dictionary<int, LockType> locks = new();
             var rng = new Random(101);
             foreach (var key in Enumerable.Range(0, numRecords / 5).Select(ii => rng.Next(numRecords)))
                 locks[key] = (key & 1) == 0 ? LockType.Exclusive : LockType.Shared;
 
-            luContext.ResumeThread();
+            luContext.BeginUnsafe();
+            luContext.BeginLockable();
 
             try
             {
@@ -1243,7 +1267,8 @@ namespace FASTER.test.LockableUnsafeContext
             }
             finally
             {
-                luContext.SuspendThread();
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
 
             Assert.IsFalse(fht.LockTable.IsActive);
@@ -1267,11 +1292,13 @@ namespace FASTER.test.LockableUnsafeContext
             bool success = true;
             {
                 using var session = fht.NewSession(new SimpleFunctions<int, int>());
-                using var luContext = session.GetLockableUnsafeContext();
+                var luContext = session.LockableUnsafeContext;
 
                 try
                 {
-                    luContext.ResumeThread();
+                    // We must retain this BeginLockable across the checkpoint, because we can't call EndLockable with locks held.
+                    luContext.BeginUnsafe();
+                    luContext.BeginLockable();
 
                     // For this single-threaded test, the locking does not really have to be in order, but for consistency do it.
                     foreach (var key in locks.Keys.OrderBy(k => k))
@@ -1280,11 +1307,12 @@ namespace FASTER.test.LockableUnsafeContext
                 catch (Exception)
                 {
                     ClearCountsOnError(session);
+                    luContext.EndLockable();
                     throw;
                 }
                 finally
                 {
-                    luContext.SuspendThread();
+                    luContext.EndUnsafe();
                 }
 
                 this.fht.Log.ShiftReadOnlyAddress(this.fht.Log.TailAddress, wait: true);
@@ -1300,7 +1328,7 @@ namespace FASTER.test.LockableUnsafeContext
 
                 try
                 {
-                    luContext.ResumeThread();
+                    luContext.BeginUnsafe();
                     foreach (var key in locks.Keys.OrderBy(k => -k))
                         luContext.Unlock(key, locks[key]);
                 }
@@ -1311,7 +1339,8 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 finally
                 {
-                    luContext.SuspendThread();
+                    luContext.EndLockable();
+                    luContext.EndUnsafe();
                 }
             }
 
@@ -1324,8 +1353,8 @@ namespace FASTER.test.LockableUnsafeContext
                 await this.fht.RecoverAsync(fullCheckpointToken);
 
             {
-                using var luContext = this.session.GetLockableUnsafeContext();
-                luContext.ResumeThread();
+                var luContext = this.session.LockableUnsafeContext;
+                luContext.BeginUnsafe();
 
                 try
                 {
@@ -1343,7 +1372,7 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 finally
                 {
-                    luContext.SuspendThread();
+                    luContext.EndUnsafe();
                 }
             }
         }
@@ -1387,7 +1416,7 @@ namespace FASTER.test.LockableUnsafeContext
         async static Task PrimaryWriter(FasterKV<long, long> primaryStore, SyncMode syncMode)
         {
             using var s1 = primaryStore.NewSession(new SimpleFunctions<long, long>());
-            using var luc1 = s1.GetLockableUnsafeContext();
+            var luc1 = s1.LockableUnsafeContext;
 
             // Upserting keys at primary starting from key 0
             for (long key = 0; key < numSecondaryReaderKeys; key++)
@@ -1413,7 +1442,8 @@ namespace FASTER.test.LockableUnsafeContext
 
                 try
                 {
-                    luc1.ResumeThread();
+                    luc1.BeginUnsafe();
+                    luc1.BeginLockable();
                     luc1.Lock(key, LockType.Shared);
                 }
                 catch (Exception)
@@ -1423,7 +1453,8 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 finally
                 {
-                    luc1.SuspendThread();
+                    luc1.EndLockable();
+                    luc1.EndUnsafe();
                 }
             }
 
@@ -1432,7 +1463,8 @@ namespace FASTER.test.LockableUnsafeContext
 
             try
             {
-                luc1.ResumeThread();
+                luc1.BeginUnsafe();
+                luc1.BeginLockable();
 
                 // Unlock everything before we Dispose() luc1
                 for (long kk = 0; kk < numSecondaryReaderKeys; kk++)
@@ -1447,14 +1479,15 @@ namespace FASTER.test.LockableUnsafeContext
             }
             finally
             {
-                luc1.SuspendThread();
+                luc1.EndLockable();
+                luc1.EndUnsafe();
             }
         }
 
         async static Task SecondaryReader(FasterKV<long, long> secondaryStore, SyncMode syncMode)
         {
             using var s1 = secondaryStore.NewSession(new SimpleFunctions<long, long>());
-            using var luc1 = s1.GetLockableUnsafeContext();
+            var luc1 = s1.LockableUnsafeContext;
 
             long key = 0, output = 0;
             while (true)
@@ -1474,7 +1507,8 @@ namespace FASTER.test.LockableUnsafeContext
                     continue;
                 }
 
-                luc1.ResumeThread();
+                luc1.BeginUnsafe();
+                luc1.BeginLockable();
                 try
                 {
                     while (true)
@@ -1503,7 +1537,8 @@ namespace FASTER.test.LockableUnsafeContext
                 }
                 finally
                 {
-                    luc1.SuspendThread();
+                    luc1.EndLockable();
+                    luc1.EndUnsafe();
                 }
             }
         }

--- a/cs/test/ReadCacheChainTests.cs
+++ b/cs/test/ReadCacheChainTests.cs
@@ -495,7 +495,7 @@ namespace FASTER.test.ReadCacheTests
             CreateChain();
 
             using var session = fht.NewSession(new SimpleFunctions<int, int>());
-            using var luContext = session.GetLockableUnsafeContext();
+            var luContext = session.LockableUnsafeContext;
 
             Dictionary<int, LockType> locks = new()
             {
@@ -504,7 +504,8 @@ namespace FASTER.test.ReadCacheTests
                 { highChainKey, LockType.Exclusive }
             };
 
-            luContext.ResumeThread();
+            luContext.BeginUnsafe();
+            luContext.BeginLockable();
 
             try
             {
@@ -536,7 +537,8 @@ namespace FASTER.test.ReadCacheTests
             }
             finally
             {
-                luContext.SuspendThread();
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
 
             Assert.IsFalse(fht.LockTable.IsActive);
@@ -556,7 +558,7 @@ namespace FASTER.test.ReadCacheTests
             //CreateChain();
 
             using var session = fht.NewSession(new SimpleFunctions<int, int>());
-            using var luContext = session.GetLockableUnsafeContext();
+            var luContext = session.LockableUnsafeContext;
 
             Dictionary<int, LockType> locks = new()
             {
@@ -565,7 +567,9 @@ namespace FASTER.test.ReadCacheTests
                 { highChainKey, LockType.Exclusive }
             };
 
-            luContext.ResumeThread();
+            luContext.BeginUnsafe();
+            luContext.BeginLockable();
+
             try
             {
                 // For this single-threaded test, the locking does not really have to be in order, but for consistency do it.
@@ -612,7 +616,8 @@ namespace FASTER.test.ReadCacheTests
             }
             finally
             {
-                luContext.SuspendThread();
+                luContext.EndLockable();
+                luContext.EndUnsafe();
             }
 
             Assert.IsFalse(fht.LockTable.IsActive);

--- a/cs/test/ThreadSession.cs
+++ b/cs/test/ThreadSession.cs
@@ -58,8 +58,8 @@ namespace FASTER.test.statemachine
         private void SecondSession()
         {
             s2 = fht.NewSession(f, null);
-            uc2 = s2.GetUnsafeContext();
-            uc2.ResumeThread();
+            uc2 = s2.UnsafeContext;
+            uc2.BeginUnsafe();
 
             ev.Set();
 
@@ -73,8 +73,7 @@ namespace FASTER.test.statemachine
                         ev.Set();
                         break;
                     case "dispose":
-                        uc2.SuspendThread();
-                        uc2.Dispose();
+                        uc2.EndUnsafe();
                         s2.Dispose();
                         ev.Set();
                         return;
@@ -149,30 +148,28 @@ namespace FASTER.test.statemachine
                     case "dispose":
                         if (isProtected)
                         {
-                            luc.SuspendThread();
-                            luc.Dispose();
-
+                            luc.EndUnsafe();
                         }
                         session.Dispose();
                         ev.Set();
                         return;
                     case "getLUC":
-                        luc = session.GetLockableUnsafeContext();
+                        luc = session.LockableUnsafeContext;
                         if (session.IsInPreparePhase())
                         {
-                            luc.Dispose();
                             this.isProtected = false;
                         }
                         else
                         {
-                            luc.ResumeThread();
+                            luc.BeginUnsafe();
+                            luc.BeginLockable();
                             this.isProtected = true;
                         }
                         ev.Set();
                         break;
                     case "DisposeLUC":
-                        luc.SuspendThread();
-                        luc.Dispose();
+                        luc.EndLockable();
+                        luc.EndUnsafe();
                         this.isProtected = false;
                         ev.Set();
                         break;

--- a/cs/test/UnsafeContextTests.cs
+++ b/cs/test/UnsafeContextTests.cs
@@ -39,14 +39,13 @@ namespace FASTER.test.UnsafeContext
             logSettings.LogDevice = log;
             fht = new FasterKV<KeyStruct, ValueStruct>(size, logSettings);
             fullSession = fht.For(new Functions()).NewSession<Functions>();
-            uContext = fullSession.GetUnsafeContext();
+            uContext = fullSession.UnsafeContext;
         }
 
         [TearDown]
         public void TearDown()
         {
-            uContext?.Dispose();
-            uContext = null;
+            uContext = default;
             fullSession?.Dispose();
             fullSession = null;
             fht?.Dispose();
@@ -75,7 +74,7 @@ namespace FASTER.test.UnsafeContext
         public void NativeInMemWriteRead([Values] DeviceType deviceType)
         {
             Setup(128, new LogSettings { PageSizeBits = 10, MemorySizeBits = 12, SegmentSizeBits = 22 }, deviceType);
-            uContext.ResumeThread();
+            uContext.BeginUnsafe();
 
             try
             {
@@ -94,7 +93,7 @@ namespace FASTER.test.UnsafeContext
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
         }
 
@@ -104,7 +103,7 @@ namespace FASTER.test.UnsafeContext
         public void NativeInMemWriteReadDelete([Values] DeviceType deviceType)
         {
             Setup(128, new LogSettings { PageSizeBits = 10, MemorySizeBits = 12, SegmentSizeBits = 22 }, deviceType);
-            uContext.ResumeThread();
+            uContext.BeginUnsafe();
 
             try
             {
@@ -135,7 +134,7 @@ namespace FASTER.test.UnsafeContext
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
         }
 
@@ -152,7 +151,7 @@ namespace FASTER.test.UnsafeContext
 
             // Setup(128, new LogSettings { MemorySizeBits = 22, SegmentSizeBits = 22, PageSizeBits = 10 }, deviceType);
             Setup(128, new LogSettings { MemorySizeBits = 29 }, deviceType);
-            uContext.ResumeThread();
+            uContext.BeginUnsafe();
 
             try
             {
@@ -193,7 +192,7 @@ namespace FASTER.test.UnsafeContext
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
         }
 
@@ -209,7 +208,7 @@ namespace FASTER.test.UnsafeContext
 
             // Setup(128, new LogSettings { MemorySizeBits = 22, SegmentSizeBits = 22, PageSizeBits = 10 }, deviceType);
             Setup(128, new LogSettings { MemorySizeBits = 29 }, deviceType);
-            uContext.ResumeThread();
+            uContext.BeginUnsafe();
 
             try
             {
@@ -256,7 +255,7 @@ namespace FASTER.test.UnsafeContext
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
         }
 
@@ -274,7 +273,7 @@ namespace FASTER.test.UnsafeContext
             var sw = Stopwatch.StartNew();
 
             Setup(128, new LogSettings { MemorySizeBits = 22, SegmentSizeBits = 22, PageSizeBits = 10 }, deviceType);
-            uContext.ResumeThread();
+            uContext.BeginUnsafe();
 
             try
             {
@@ -289,9 +288,9 @@ namespace FASTER.test.UnsafeContext
                     }
                     else
                     {
-                        uContext.SuspendThread();
+                        uContext.EndUnsafe();
                         var status = (await uContext.UpsertAsync(ref key1, ref value)).Complete();
-                        uContext.ResumeThread();
+                        uContext.BeginUnsafe();
                         Assert.IsFalse(status.IsPending);
                     }
                 }
@@ -313,9 +312,9 @@ namespace FASTER.test.UnsafeContext
                     }
                     else
                     {
-                        uContext.SuspendThread();
+                        uContext.EndUnsafe();
                         (status, output) = (await uContext.ReadAsync(ref key1, ref input)).Complete();
-                        uContext.ResumeThread();
+                        uContext.BeginUnsafe();
                     }
                     if (!status.IsPending)
                     {
@@ -329,9 +328,9 @@ namespace FASTER.test.UnsafeContext
                 }
                 else
                 {
-                    uContext.SuspendThread();
+                    uContext.EndUnsafe();
                     await uContext.CompletePendingAsync();
-                    uContext.ResumeThread();
+                    uContext.BeginUnsafe();
                 }
 
                 // Shift head and retry - should not find in main memory now
@@ -356,9 +355,9 @@ namespace FASTER.test.UnsafeContext
                 }
                 else
                 {
-                    uContext.SuspendThread();
+                    uContext.EndUnsafe();
                     outputs = await uContext.CompletePendingWithOutputsAsync();
-                    uContext.ResumeThread();
+                    uContext.BeginUnsafe();
                 }
 
                 int count = 0;
@@ -373,7 +372,7 @@ namespace FASTER.test.UnsafeContext
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
         }
 
@@ -386,7 +385,7 @@ namespace FASTER.test.UnsafeContext
             OutputStruct output = default;
 
             Setup(128, new LogSettings { MemorySizeBits = 22, SegmentSizeBits = 22, PageSizeBits = 10 }, deviceType);
-            uContext.ResumeThread();
+            uContext.BeginUnsafe();
 
             try
             {
@@ -446,7 +445,7 @@ namespace FASTER.test.UnsafeContext
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
         }
 
@@ -458,7 +457,7 @@ namespace FASTER.test.UnsafeContext
             InputStruct input = default;
 
             Setup(128, new LogSettings { MemorySizeBits = 22, SegmentSizeBits = 22, PageSizeBits = 10 }, deviceType);
-            uContext.ResumeThread();
+            uContext.BeginUnsafe();
 
             try
             {
@@ -511,7 +510,7 @@ namespace FASTER.test.UnsafeContext
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
         }
 
@@ -524,7 +523,7 @@ namespace FASTER.test.UnsafeContext
             InputStruct input = default;
 
             Setup(128, new LogSettings { MemorySizeBits = 22, SegmentSizeBits = 22, PageSizeBits = 10 }, deviceType);
-            uContext.ResumeThread();
+            uContext.BeginUnsafe();
 
             try
             {
@@ -543,7 +542,7 @@ namespace FASTER.test.UnsafeContext
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
         }
 
@@ -553,7 +552,7 @@ namespace FASTER.test.UnsafeContext
         public void ReadNoRefKey([Values] DeviceType deviceType)
         {
             Setup(128, new LogSettings { MemorySizeBits = 22, SegmentSizeBits = 22, PageSizeBits = 10 }, deviceType);
-            uContext.ResumeThread();
+            uContext.BeginUnsafe();
 
             try
             {
@@ -572,7 +571,7 @@ namespace FASTER.test.UnsafeContext
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
         }
 
@@ -584,7 +583,7 @@ namespace FASTER.test.UnsafeContext
         public void ReadWithoutInput([Values] DeviceType deviceType)
         {
             Setup(128, new LogSettings { MemorySizeBits = 22, SegmentSizeBits = 22, PageSizeBits = 10 }, deviceType);
-            uContext.ResumeThread();
+            uContext.BeginUnsafe();
 
             try
             {
@@ -605,7 +604,7 @@ namespace FASTER.test.UnsafeContext
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
         }
 
@@ -619,7 +618,7 @@ namespace FASTER.test.UnsafeContext
             deviceType = DeviceType.MLSD;
 
             Setup(128, new LogSettings { MemorySizeBits = 29 }, deviceType);
-            uContext.ResumeThread();
+            uContext.BeginUnsafe();
 
             try
             {
@@ -640,7 +639,7 @@ namespace FASTER.test.UnsafeContext
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
         }
 
@@ -651,7 +650,7 @@ namespace FASTER.test.UnsafeContext
         public void ReadBareMinParams([Values] DeviceType deviceType)
         {
             Setup(128, new LogSettings { MemorySizeBits = 22, SegmentSizeBits = 22, PageSizeBits = 10 }, deviceType);
-            uContext.ResumeThread();
+            uContext.BeginUnsafe();
 
             try
             {
@@ -670,7 +669,7 @@ namespace FASTER.test.UnsafeContext
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
         }
 
@@ -684,7 +683,7 @@ namespace FASTER.test.UnsafeContext
             deviceType = DeviceType.MLSD;
 
             Setup(128, new LogSettings { MemorySizeBits = 29 }, deviceType);
-            uContext.ResumeThread();
+            uContext.BeginUnsafe();
 
             try
             {
@@ -706,7 +705,7 @@ namespace FASTER.test.UnsafeContext
             }
             finally
             {
-                uContext.SuspendThread();
+                uContext.EndUnsafe();
             }
         }
     }


### PR DESCRIPTION
Also, this changes "Acquire/Release" to BeginUnsafe/EndUnsafe (for manual epoch management) and Begin/EndLockable (for manual locking).

Added a check to BeginLockable to wait until any in-prepare checkpoint state has moved on.