### PR TITLE
[C#] FasterLog scan fix when begin address moves ahead of scan

### DIFF
--- a/cs/src/core/FasterLog/FasterLog.cs
+++ b/cs/src/core/FasterLog/FasterLog.cs
@@ -51,6 +51,11 @@ namespace FASTER.core
         /// </summary>
         public long BeginAddress => beginAddress;
 
+        /// <summary>
+        /// BeginAddress as per allocator, used in tests
+        /// </summary>
+        internal long AllocatorBeginAddress => allocator.BeginAddress;
+
         // Here's a soft begin address that is observed by all access at the FasterLog level but not actually on the
         // allocator. This is to make sure that any potential physical deletes only happen after commit.
         long beginAddress;
@@ -888,7 +893,7 @@ namespace FASTER.core
             if (!spinWait) return;
             if (success)
                 WaitForCommit(actualTail, actualCommitNum);
-            else 
+            else
                 // Still need to imitate semantics to spin until all previous enqueues are committed when commit has been filtered  
                 WaitForCommit(tail, lastCommit);
         }

--- a/cs/src/core/FasterLog/FasterLogIterator.cs
+++ b/cs/src/core/FasterLog/FasterLogIterator.cs
@@ -658,13 +658,15 @@ namespace FASTER.core
                 physicalAddress = 0;
                 entryLength = 0;
                 currentAddress = nextAddress;
-                outNextAddress = nextAddress;
+                outNextAddress = currentAddress;
                 commitRecord = false;
 
                 // Check for boundary conditions
                 if (currentAddress < allocator.BeginAddress)
                 {
-                    currentAddress = allocator.BeginAddress;
+                    Utility.MonotonicUpdate(ref nextAddress, allocator.BeginAddress, out _);
+                    currentAddress = nextAddress;
+                    outNextAddress = currentAddress;
                 }
 
                 var _currentPage = currentAddress >> allocator.LogPageSizeBits;


### PR DESCRIPTION
If scan is below begin address, update nextAddress before returning. Also, make sure currentAddress and outNextAddress are consistent w.r.t. shared nextAddress field.