### PR TITLE
Fix: Some platforms try get a segmentId from the main log file.

### DIFF
--- a/cs/src/core/Device/LocalStorageDevice.cs
+++ b/cs/src/core/Device/LocalStorageDevice.cs
@@ -153,6 +153,10 @@ namespace FASTER.core
             List<int> segids = new();
             foreach (System.IO.FileInfo item in di.GetFiles(bareName + "*"))
             {
+                if (item.Name == bareName)
+                {
+                    continue;
+                }
                 segids.Add(int.Parse(item.Name.Replace(bareName, "").Replace(".", "")));
             }
             segids.Sort();

--- a/cs/src/core/Device/ManagedLocalStorageDevice.cs
+++ b/cs/src/core/Device/ManagedLocalStorageDevice.cs
@@ -72,6 +72,10 @@ namespace FASTER.core
             List<int> segids = new();
             foreach (FileInfo item in di.GetFiles(bareName + "*"))
             {
+                if (item.Name == bareName)
+                {
+                    continue;
+                }
                 segids.Add(Int32.Parse(item.Name.Replace(bareName, "").Replace(".", "")));
             }
             segids.Sort();


### PR DESCRIPTION
Fixes #767 

Avoids `Int32.Parse` failure on platforms that return the main log file as one of the matches for `di.GetFiles(bareName + "*")`.