### PR TITLE
Set persisted commit number after recovery

### DIFF
--- a/cs/src/core/FasterLog/FasterLog.cs
+++ b/cs/src/core/FasterLog/FasterLog.cs
@@ -1918,6 +1918,8 @@ namespace FASTER.core
             iterators = CompleteRestoreFromCommit(info);
             cookie = info.Cookie;
             commitNum = info.CommitNum;
+            // After recovery  persisted commitnum remians 0 so we need to set it to latest commit number
+            persistedCommitNum = info.CommitNum;
             beginAddress = allocator.BeginAddress;
             if (readOnlyMode)
                 allocator.HeadAddress = long.MaxValue;


### PR DESCRIPTION
Else it doesn't respond if the first call after recovery is a get call
As the value of persisted commit number remained 0. So was unable to send back the response. 
