### PR TITLE
[C#] Fix HashBucket latching

### DIFF
--- a/cs/src/core/Index/Common/RecordInfo.cs
+++ b/cs/src/core/Index/Common/RecordInfo.cs
@@ -136,7 +136,7 @@ namespace FASTER.core
             long tentativeBit = tentative ? kTentativeBitMask : 0;
 
             // Acquire exclusive lock (readers may still be present; we'll drain them later)
-            while (true)
+            for (; ; Thread.Yield())
             {
                 long expected_word = word;
                 if (IsIntermediateOrInvalidWord(expected_word))
@@ -148,7 +148,6 @@ namespace FASTER.core
                 }
                 if (spinCount > 0 && --spinCount <= 0)
                     return false;
-                Thread.Yield();
             }
 
             // Wait for readers to drain. Another session may hold an SLock on this record and need an epoch refresh to unlock, so limit this to avoid deadlock.
@@ -200,7 +199,7 @@ namespace FASTER.core
             int spinCount = Constants.kMaxLockSpins;
 
             // Acquire shared lock
-            while (true)
+            for (; ; Thread.Yield())
             {
                 long expected_word = word;
                 if (IsIntermediateOrInvalidWord(expected_word))
@@ -215,7 +214,6 @@ namespace FASTER.core
                 }
                 if (spinCount > 0 && --spinCount <= 0) 
                     return false;
-                Thread.Yield();
             }
             return true;
         }

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -130,7 +130,8 @@ namespace FASTER.core
         public static void ReleaseSharedLatch(ref HashEntryInfo hei)
         {
             ref long entry_word = ref hei.firstBucket->bucket_entries[Constants.kOverflowBucketIndex];
-            Debug.Assert((entry_word & kExclusiveLatchBitMask) == 0, "Trying to S unlatch an X latched record");
+            // X and S latches means an X latch is still trying to drain readers, like this one.
+            Debug.Assert((entry_word & kLatchBitMask) != kExclusiveLatchBitMask, "Trying to S unlatch an X-only latched record");
             Debug.Assert((entry_word & kSharedLatchBitMask) != 0, "Trying to S unlatch an unlatched record");
             Interlocked.Add(ref entry_word, -kSharedLatchIncrement);
         }

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -39,7 +40,8 @@ namespace FASTER.core
         public const int kTagShift = 62 - kTagSize;
         public const long kTagMask = (1L << kTagSize) - 1;
         public const long kTagPositionMask = (kTagMask << kTagShift);
-        public const long kAddressMask = (1L << 48) - 1;
+        public const int kAddressBits = 48;
+        public const long kAddressMask = (1L << kAddressBits) - 1;
 
         // Position of tag in hash value (offset is always in the least significant bits)
         public const int kHashTagShift = 64 - kTagSize;
@@ -82,58 +84,110 @@ namespace FASTER.core
     [StructLayout(LayoutKind.Explicit, Size = Constants.kEntriesPerBucket * 8)]
     internal unsafe struct HashBucket
     {
-        public const long kPinConstant = (1L << 48);
+        // We use the first overflow bucket for latching, reusing all bits after the address.
+        const int kSharedLatchBits = 63 - Constants.kAddressBits;
+        const int kExclusiveLatchBits = 1;
 
-        public const long kExclusiveLatchBitMask = (1L << 63);
+        // Shift positions of latches in word
+        const int kSharedLatchBitOffset = Constants.kAddressBits;
+        const int kExclusiveLatchBitOffset = kSharedLatchBitOffset + kSharedLatchBits;
+
+        // Shared latch constants
+        const long kSharedLatchBitMask = ((1L << kSharedLatchBits) - 1) << kSharedLatchBitOffset;
+        const long kSharedLatchIncrement = 1L << kSharedLatchBitOffset;
+
+        // Exclusive latch constants
+        const long kExclusiveLatchBitMask = 1L << kExclusiveLatchBitOffset;
+
+        // Comnbined mask
+        const long kLatchBitMask = kSharedLatchBitMask | kExclusiveLatchBitMask;
 
         [FieldOffset(0)]
         public fixed long bucket_entries[Constants.kEntriesPerBucket];
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryAcquireSharedLatch(HashBucket* bucket)
+        public static bool TryAcquireSharedLatch(ref HashEntryInfo hei)
         {
-            return Interlocked.Add(ref bucket->bucket_entries[Constants.kOverflowBucketIndex],
-                                   kPinConstant) > 0;
-        }
+            ref long entry_word = ref hei.firstBucket->bucket_entries[Constants.kOverflowBucketIndex];
+            int spinCount = Constants.kMaxLockSpins;
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ReleaseSharedLatch(HashBucket* bucket)
-        {
-            Interlocked.Add(ref bucket->bucket_entries[Constants.kOverflowBucketIndex],
-                            -kPinConstant);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryAcquireExclusiveLatch(HashBucket* bucket)
-        {
-            long expected_word = bucket->bucket_entries[Constants.kOverflowBucketIndex];
-            if ((expected_word & ~Constants.kAddressMask) == 0)
+            while (true)
             {
-                long desired_word = expected_word | kExclusiveLatchBitMask;
-                var found_word = Interlocked.CompareExchange(
-                                    ref bucket->bucket_entries[Constants.kOverflowBucketIndex],
-                                    desired_word,
-                                    expected_word);
-                return found_word == expected_word;
+                long expected_word = entry_word;
+                if (((expected_word & kExclusiveLatchBitMask) == 0) // not exclusively locked
+                    && (expected_word & kSharedLatchBitMask) != kSharedLatchBitMask) // shared lock is not full
+                {
+                    if (expected_word == Interlocked.CompareExchange(ref entry_word, expected_word + kSharedLatchIncrement, expected_word))
+                        return true;
+                }
+                if (spinCount > 0 && --spinCount <= 0)
+                    return false;
+                Thread.Yield();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ReleaseSharedLatch(ref HashEntryInfo hei)
+        {
+            ref long entry_word = ref hei.firstBucket->bucket_entries[Constants.kOverflowBucketIndex];
+            Debug.Assert((entry_word & kExclusiveLatchBitMask) == 0, "Trying to S unlatch an X latched record");
+            Debug.Assert((entry_word & kSharedLatchBitMask) != 0, "Trying to S unlatch an unlatched record");
+            Interlocked.Add(ref entry_word, -kSharedLatchIncrement);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryAcquireExclusiveLatch(ref HashEntryInfo hei)
+        {
+            ref long entry_word = ref hei.firstBucket->bucket_entries[Constants.kOverflowBucketIndex];
+            int spinCount = Constants.kMaxLockSpins;
+
+            // Acquire exclusive lock (readers may still be present; we'll drain them later)
+            while (true)
+            {
+                long expected_word = entry_word;
+                if ((expected_word & kExclusiveLatchBitMask) == 0)
+                {
+                    if (expected_word == Interlocked.CompareExchange(ref entry_word, expected_word | kExclusiveLatchBitMask, expected_word))
+                        break;
+                }
+                if (spinCount > 0 && --spinCount <= 0)
+                    return false;
+                Thread.Yield();
+            }
+
+            // Wait for readers to drain. Another session may hold an SLock on this record and need an epoch refresh to unlock, so limit this to avoid deadlock.
+            for (var ii = 0; ii < Constants.kMaxReaderLockDrainSpins; ++ii)
+            {
+                if ((entry_word & kSharedLatchBitMask) == 0)
+                    return true;
+                Thread.Yield();
+            }
+
+            // Release the exclusive bit and return false so the caller will retry the operation. Since we still have readers, we must CAS.
+            for (; ; Thread.Yield())
+            {
+                long expected_word = entry_word;
+                if (Interlocked.CompareExchange(ref entry_word, expected_word & ~kExclusiveLatchBitMask, expected_word) == expected_word)
+                    break;
             }
             return false;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ReleaseExclusiveLatch(HashBucket* bucket)
+        public static void ReleaseExclusiveLatch(ref HashEntryInfo hei)
         {
-            long expected_word = bucket->bucket_entries[Constants.kOverflowBucketIndex];
-            long desired_word = expected_word & Constants.kAddressMask;
-            var found_word = Interlocked.Exchange(
-                                ref bucket->bucket_entries[Constants.kOverflowBucketIndex],
-                                desired_word);
-        }
+            ref long entry_word = ref hei.firstBucket->bucket_entries[Constants.kOverflowBucketIndex];
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool NoSharedLatches(HashBucket* bucket)
-        {
-            long word = bucket->bucket_entries[Constants.kOverflowBucketIndex];
-            return (word & ~Constants.kAddressMask) == 0;
+            Debug.Assert((entry_word & kSharedLatchBitMask) == 0, "Trying to X unlatch an S latched record");
+            Debug.Assert((entry_word & kExclusiveLatchBitMask) != 0, "Trying to X unlatch an unlatched record");
+
+            // The address in the overflow bucket may change from unassigned to assigned, so retry
+            while (true)
+            {
+                long expected_word = entry_word;
+                if (expected_word == Interlocked.CompareExchange(ref entry_word, expected_word & ~kExclusiveLatchBitMask, expected_word))
+                    break;
+            }
         }
     }
 
@@ -367,20 +421,15 @@ namespace FASTER.core
         /// A helper function that is used to find the slot corresponding to a
         /// key in the specified version of the hash table
         /// </summary>
-        /// <param name="hash"></param>
-        /// <param name="tag"></param>
-        /// <param name="bucket"></param>
-        /// <param name="slot"></param>
-        /// <param name="entry"></param>
         /// <returns>true if such a slot exists, false otherwise</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool FindTag(long hash, ushort tag, ref HashBucket* bucket, ref int slot, ref HashBucketEntry entry)
+        internal bool FindTag(long hash, ushort tag, ref HashBucket* firstBucket, ref HashBucket* bucket, ref int slot, ref HashBucketEntry entry)
         {
             var target_entry_word = default(long);
             var entry_slot_bucket = default(HashBucket*);
             var version = resizeInfo.version;
             var masked_entry_word = hash & state[version].size_mask;
-            bucket = state[version].tableAligned + masked_entry_word;
+            firstBucket = bucket = state[version].tableAligned + masked_entry_word;
             slot = Constants.kInvalidEntrySlot;
 
             do
@@ -418,19 +467,18 @@ namespace FASTER.core
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void FindOrCreateTag(long hash, ushort tag, ref HashBucket* bucket, ref int slot, ref HashBucketEntry entry, long BeginAddress)
+        internal void FindOrCreateTag(long hash, ushort tag, ref HashBucket* firstBucket, ref HashBucket* bucket, ref int slot, ref HashBucketEntry entry, long BeginAddress)
         {
             var version = resizeInfo.version;
             var masked_entry_word = hash & state[version].size_mask;
 
             while (true)
             {
-                bucket = state[version].tableAligned + masked_entry_word;
+                firstBucket = bucket = state[version].tableAligned + masked_entry_word;
                 slot = Constants.kInvalidEntrySlot;
 
                 if (FindTagOrFreeInternal(hash, tag, ref bucket, ref slot, ref entry, BeginAddress))
                     return;
-
 
                 // Install tentative tag in free slot
                 entry = default;
@@ -458,85 +506,6 @@ namespace FASTER.core
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool FindTagInternal(long hash, ushort tag, ref HashBucket* bucket, ref int slot)
-        {
-            var target_entry_word = default(long);
-            var entry_slot_bucket = default(HashBucket*);
-
-            do
-            {
-                // Search through the bucket looking for our key. Last entry is reserved
-                // for the overflow pointer.
-                for (int index = 0; index < Constants.kOverflowBucketIndex; ++index)
-                {
-                    target_entry_word = *(((long*)bucket) + index);
-                    if (0 == target_entry_word)
-                    {
-                        continue;
-                    }
-
-                    HashBucketEntry entry = default;
-                    entry.word = target_entry_word;
-                    if (tag == entry.Tag)
-                    {
-                        slot = index;
-                        if (!entry.Tentative)
-                            return true;
-                    }
-                }
-
-                target_entry_word = *(((long*)bucket) + Constants.kOverflowBucketIndex) & Constants.kAddressMask;
-                // Go to next bucket in the chain
-
-
-                if (target_entry_word == 0)
-                {
-                    return false;
-                }
-                bucket = (HashBucket*)overflowBucketsAllocator.GetPhysicalAddress(target_entry_word);
-            } while (true);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool FindTagMaybeTentativeInternal(long hash, ushort tag, ref HashBucket* bucket, ref int slot)
-        {
-            var target_entry_word = default(long);
-            var entry_slot_bucket = default(HashBucket*);
-
-            do
-            {
-                // Search through the bucket looking for our key. Last entry is reserved
-                // for the overflow pointer.
-                for (int index = 0; index < Constants.kOverflowBucketIndex; ++index)
-                {
-                    target_entry_word = *(((long*)bucket) + index);
-                    if (0 == target_entry_word)
-                    {
-                        continue;
-                    }
-
-                    HashBucketEntry entry = default;
-                    entry.word = target_entry_word;
-                    if (tag == entry.Tag)
-                    {
-                        slot = index;
-                        return true;
-                    }
-                }
-
-                target_entry_word = *(((long*)bucket) + Constants.kOverflowBucketIndex) & Constants.kAddressMask;
-                // Go to next bucket in the chain
-
-
-                if (target_entry_word == 0)
-                {
-                    return false;
-                }
-                bucket = (HashBucket*)overflowBucketsAllocator.GetPhysicalAddress(target_entry_word);
-            } while (true);
-        }
-
         /// <summary>
         /// Find existing entry (non-tenative)
         /// If not found, return pointer to some empty slot
@@ -552,7 +521,6 @@ namespace FASTER.core
         private bool FindTagOrFreeInternal(long hash, ushort tag, ref HashBucket* bucket, ref int slot, ref HashBucketEntry entry, long BeginAddress = 0)
         {
             var target_entry_word = default(long);
-            var recordExists = false;
             var entry_slot_bucket = default(HashBucket*);
 
             do
@@ -588,16 +556,14 @@ namespace FASTER.core
                     if (tag == entry.Tag && !entry.Tentative)
                     {
                         slot = index;
-                        recordExists = true;
-                        return recordExists;
+                        return true;
                     }
                 }
 
-                target_entry_word = *(((long*)bucket) + Constants.kOverflowBucketIndex);
                 // Go to next bucket in the chain
+                target_entry_word = *(((long*)bucket) + Constants.kOverflowBucketIndex);
 
-
-                if ((target_entry_word & Constants.kAddressMask) == 0)
+                while ((target_entry_word & Constants.kAddressMask) == 0)
                 {
                     if (slot == Constants.kInvalidEntrySlot)
                     {
@@ -618,31 +584,28 @@ namespace FASTER.core
                             // Install failed, undo allocation; use the winner's entry
                             overflowBucketsAllocator.Free(logicalBucketAddress);
                             target_entry_word = result_word;
+                            continue;
                         }
                         else
                         {
-                            // Install succeeded
+                            // Install of new overflow bucket succeeded; tag was not found, so return the first slot of the new bucket
                             bucket = physicalBucketAddress;
                             slot = 0;
                             entry = default;
-                            return recordExists;
+                            return false;
                         }
                     }
                     else
                     {
-                        if (!recordExists)
-                        {
-                            bucket = entry_slot_bucket;
-                        }
+                        // Tag was not found and an empty slot was found, so return the empty slot
+                        bucket = entry_slot_bucket;
                         entry = default;
-                        break;
+                        return false;
                     }
                 }
 
                 bucket = (HashBucket*)overflowBucketsAllocator.GetPhysicalAddress(target_entry_word & Constants.kAddressMask);
             } while (true);
-
-            return recordExists;
         }
 
 

--- a/cs/src/core/Index/FASTER/FASTERIterator.cs
+++ b/cs/src/core/Index/FASTER/FASTERIterator.cs
@@ -117,11 +117,12 @@ namespace FASTER.core
                         ref var value = ref iter1.GetValue();
 
                         var bucket = default(HashBucket*);
+                        var firstBucket = default(HashBucket*);
                         var slot = default(int);
                         var entry = default(HashBucketEntry);
                         var hash = fht.Comparer.GetHashCode64(ref key);
                         var tag = (ushort)((ulong)hash >> Constants.kHashTagShift);
-                        if (fht.FindTag(hash, tag, ref bucket, ref slot, ref entry) && entry.Address == iter1.CurrentAddress)
+                        if (fht.FindTag(hash, tag, ref firstBucket, ref bucket, ref slot, ref entry) && entry.Address == iter1.CurrentAddress)
                         {
                             if (recordInfo.PreviousAddress >= fht.Log.BeginAddress)
                             {

--- a/cs/src/core/Index/FASTER/Implementation/HashEntryInfo.cs
+++ b/cs/src/core/Index/FASTER/Implementation/HashEntryInfo.cs
@@ -9,7 +9,10 @@ namespace FASTER.core
     /// <summary>Hash table entry information for a key</summary>
     internal unsafe struct HashEntryInfo
     {
-        /// <summary>The hash bucket for this key</summary>
+        /// <summary>The first bucket in this chain for this hash bucket</summary>
+        internal HashBucket* firstBucket;
+
+        /// <summary>The hash bucket for this key (may be an overflow bucket)</summary>
         internal HashBucket* bucket;
 
         /// <summary>The hash bucket entry slot for this key</summary>
@@ -27,6 +30,7 @@ namespace FASTER.core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal HashEntryInfo(long hash)
         {
+            firstBucket = default;
             bucket = default;
             slot = default;
             entry = default;
@@ -114,19 +118,21 @@ namespace FASTER.core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal unsafe bool FindTag(ref HashEntryInfo hei)
         {
+            hei.firstBucket = default;
             hei.bucket = default;
             hei.slot = default;
             hei.entry = default;
-            return FindTag(hei.hash, hei.tag, ref hei.bucket, ref hei.slot, ref hei.entry);
+            return FindTag(hei.hash, hei.tag, ref hei.firstBucket, ref hei.bucket, ref hei.slot, ref hei.entry);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal unsafe void FindOrCreateTag(ref HashEntryInfo hei)
         {
+            hei.firstBucket = default;
             hei.bucket = default;
             hei.slot = default;
             hei.entry = default;
-            FindOrCreateTag(hei.hash, hei.tag, ref hei.bucket, ref hei.slot, ref hei.entry, hlog.BeginAddress);
+            FindOrCreateTag(hei.hash, hei.tag, ref hei.firstBucket, ref hei.bucket, ref hei.slot, ref hei.entry, hlog.BeginAddress);
         }
     }
 }

--- a/cs/src/core/Index/FASTER/Implementation/Helpers.cs
+++ b/cs/src/core/Index/FASTER/Implementation/Helpers.cs
@@ -18,30 +18,6 @@ namespace FASTER.core
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void AcquireSharedLatch(Key key)
-        {
-            var bucket = default(HashBucket*);
-            var slot = default(int);
-            var hash = comparer.GetHashCode64(ref key);
-            var tag = (ushort)((ulong)hash >> Constants.kHashTagShift);
-            var entry = default(HashBucketEntry);
-            FindOrCreateTag(hash, tag, ref bucket, ref slot, ref entry, hlog.BeginAddress);
-            HashBucket.TryAcquireSharedLatch(bucket);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void ReleaseSharedLatch(Key key)
-        {
-            var bucket = default(HashBucket*);
-            var slot = default(int);
-            var hash = comparer.GetHashCode64(ref key);
-            var tag = (ushort)((ulong)hash >> Constants.kHashTagShift);
-            var entry = default(HashBucketEntry);
-            FindOrCreateTag(hash, tag, ref bucket, ref slot, ref entry, hlog.BeginAddress);
-            HashBucket.ReleaseSharedLatch(bucket);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static ref RecordInfo WriteTentativeInfo(ref Key key, AllocatorBase<Key, Value> log, long newPhysicalAddress, bool inNewVersion, bool tombstone, long previousAddress)
         {
             ref RecordInfo recordInfo = ref log.GetInfo(newPhysicalAddress);

--- a/cs/src/core/Index/FASTER/Implementation/InternalDelete.cs
+++ b/cs/src/core/Index/FASTER/Implementation/InternalDelete.cs
@@ -244,10 +244,10 @@ namespace FASTER.core
                 switch (latchOperation)
                 {
                     case LatchOperation.Shared:
-                        HashBucket.ReleaseSharedLatch(stackCtx.hei.bucket);
+                        HashBucket.ReleaseSharedLatch(ref stackCtx.hei);
                         break;
                     case LatchOperation.Exclusive:
-                        HashBucket.ReleaseExclusiveLatch(stackCtx.hei.bucket);
+                        HashBucket.ReleaseExclusiveLatch(ref stackCtx.hei);
                         break;
                     default:
                         break;
@@ -265,7 +265,7 @@ namespace FASTER.core
             {
                 case Phase.PREPARE:
                     {
-                        if (HashBucket.TryAcquireSharedLatch(hei.bucket))
+                        if (HashBucket.TryAcquireSharedLatch(ref hei))
                         {
                             // Set to release shared latch (default)
                             latchOperation = LatchOperation.Shared;
@@ -286,7 +286,7 @@ namespace FASTER.core
                     {
                         if (!CheckEntryVersionNew(logicalAddress))
                         {
-                            if (HashBucket.TryAcquireExclusiveLatch(hei.bucket))
+                            if (HashBucket.TryAcquireExclusiveLatch(ref hei))
                             {
                                 // Set to release exclusive latch (default)
                                 latchOperation = LatchOperation.Exclusive;

--- a/cs/src/core/Index/FASTER/Implementation/InternalRMW.cs
+++ b/cs/src/core/Index/FASTER/Implementation/InternalRMW.cs
@@ -313,10 +313,10 @@ namespace FASTER.core
                 switch (latchOperation)
                 {
                     case LatchOperation.Shared:
-                        HashBucket.ReleaseSharedLatch(stackCtx.hei.bucket);
+                        HashBucket.ReleaseSharedLatch(ref stackCtx.hei);
                         break;
                     case LatchOperation.Exclusive:
-                        HashBucket.ReleaseExclusiveLatch(stackCtx.hei.bucket);
+                        HashBucket.ReleaseExclusiveLatch(ref stackCtx.hei);
                         break;
                     default:
                         break;
@@ -334,7 +334,7 @@ namespace FASTER.core
             {
                 case Phase.PREPARE:
                     {
-                        if (HashBucket.TryAcquireSharedLatch(hei.bucket))
+                        if (HashBucket.TryAcquireSharedLatch(ref hei))
                         {
                             // Set to release shared latch (default)
                             latchOperation = LatchOperation.Shared;
@@ -355,7 +355,7 @@ namespace FASTER.core
                     {
                         if (!CheckEntryVersionNew(logicalAddress))
                         {
-                            if (HashBucket.TryAcquireExclusiveLatch(hei.bucket))
+                            if (HashBucket.TryAcquireExclusiveLatch(ref hei))
                             {
                                 // Set to release exclusive latch (default)
                                 latchOperation = LatchOperation.Exclusive;

--- a/cs/src/core/Index/FASTER/Implementation/InternalRead.cs
+++ b/cs/src/core/Index/FASTER/Implementation/InternalRead.cs
@@ -154,8 +154,8 @@ namespace FASTER.core
                     if (!useStartAddress)
                     {
                         // Failure to latch indicates CPR_SHIFT, but don't hold on to shared latch during IO
-                        if (HashBucket.TryAcquireSharedLatch(stackCtx.hei.bucket))
-                            HashBucket.ReleaseSharedLatch(stackCtx.hei.bucket);
+                        if (HashBucket.TryAcquireSharedLatch(ref stackCtx.hei))
+                            HashBucket.ReleaseSharedLatch(ref stackCtx.hei);
                         else
                             return OperationStatus.CPR_SHIFT_DETECTED;
                     }

--- a/cs/src/core/Index/FASTER/Implementation/InternalUpsert.cs
+++ b/cs/src/core/Index/FASTER/Implementation/InternalUpsert.cs
@@ -228,10 +228,10 @@ namespace FASTER.core
                     switch (latchOperation)
                     {
                         case LatchOperation.Shared:
-                            HashBucket.ReleaseSharedLatch(stackCtx.hei.bucket);
+                            HashBucket.ReleaseSharedLatch(ref stackCtx.hei);
                             break;
                         case LatchOperation.Exclusive:
-                            HashBucket.ReleaseExclusiveLatch(stackCtx.hei.bucket);
+                            HashBucket.ReleaseExclusiveLatch(ref stackCtx.hei);
                             break;
                         default:
                             break;
@@ -250,7 +250,7 @@ namespace FASTER.core
             {
                 case Phase.PREPARE:
                     {
-                        if (HashBucket.TryAcquireSharedLatch(hei.bucket))
+                        if (HashBucket.TryAcquireSharedLatch(ref hei))
                         {
                             // Set to release shared latch (default)
                             latchOperation = LatchOperation.Shared;
@@ -275,7 +275,7 @@ namespace FASTER.core
                     {
                         if (!CheckEntryVersionNew(logicalAddress))
                         {
-                            if (HashBucket.TryAcquireExclusiveLatch(hei.bucket))
+                            if (HashBucket.TryAcquireExclusiveLatch(ref hei))
                             {
                                 // Set to release exclusive latch (default)
                                 latchOperation = LatchOperation.Exclusive;

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -884,6 +884,7 @@ namespace FASTER.core
             var tag = default(ushort);
             var pointer = default(long);
             var recordStart = default(long);
+            var firstBucket = default(HashBucket*);
             var bucket = default(HashBucket*);
             var entry = default(HashBucketEntry);
             var slot = default(int);
@@ -906,7 +907,7 @@ namespace FASTER.core
                     tag = (ushort)((ulong)hash >> Constants.kHashTagShift);
 
                     entry = default;
-                    FindOrCreateTag(hash, tag, ref bucket, ref slot, ref entry, hlog.BeginAddress);
+                    FindOrCreateTag(hash, tag, ref firstBucket, ref bucket, ref slot, ref entry, hlog.BeginAddress);
 
                     bool ignoreRecord = ((pageLogicalAddress + pointer) >= options.fuzzyRegionStartAddress) && info.InNewVersion;
                     if (!options.undoNextVersion) ignoreRecord = false;

--- a/cs/test/ComponentRecoveryTests.cs
+++ b/cs/test/ComponentRecoveryTests.cs
@@ -104,6 +104,7 @@ namespace FASTER.test.recovery
             hash_table1.Initialize(size, 512);
 
             //do something
+            var firstBucket = default(HashBucket*);
             var bucket = default(HashBucket*);
             var slot = default(int);
 
@@ -116,7 +117,7 @@ namespace FASTER.test.recovery
                 var tag = (ushort)((ulong)hash >> Constants.kHashTagShift);
 
                 var entry = default(HashBucketEntry);
-                hash_table1.FindOrCreateTag(hash, tag, ref bucket, ref slot, ref entry, 0);
+                hash_table1.FindOrCreateTag(hash, tag, ref firstBucket, ref bucket, ref slot, ref entry, 0);
 
                 hash_table1.UpdateSlot(bucket, slot, entry.word, valueGenerator.Next(), out long found_word);
             }
@@ -134,7 +135,9 @@ namespace FASTER.test.recovery
             var keyGenerator2 = new Random(seed);
 
             var bucket1 = default(HashBucket*);
+            var firstBucket1 = default(HashBucket*);
             var bucket2 = default(HashBucket*);
+            var firstBucket2 = default(HashBucket*);
             var slot1 = default(int);
             var slot2 = default(int);
 
@@ -146,8 +149,8 @@ namespace FASTER.test.recovery
                 var hash = Utility.GetHashCode(key);
                 var tag = (ushort)((ulong)hash >> Constants.kHashTagShift);
 
-                var exists1 = hash_table1.FindTag(hash, tag, ref bucket1, ref slot1, ref entry1);
-                var exists2 = hash_table2.FindTag(hash, tag, ref bucket2, ref slot2, ref entry2);
+                var exists1 = hash_table1.FindTag(hash, tag, ref firstBucket1, ref bucket1, ref slot1, ref entry1);
+                var exists2 = hash_table2.FindTag(hash, tag, ref firstBucket2, ref bucket2, ref slot2, ref entry2);
 
                 Assert.AreEqual(exists2, exists1);
 

--- a/cs/test/TestUtils.cs
+++ b/cs/test/TestUtils.cs
@@ -229,18 +229,17 @@ namespace FASTER.test
             }
         }
 
-        internal unsafe static bool FindKey<Key, Value>(this FasterKV<Key, Value> fht, ref Key key, out HashBucketEntry entry, out HashBucket* bucket, out int slot)
+        internal unsafe static bool FindKey<Key, Value>(this FasterKV<Key, Value> fht, ref Key key, out HashBucketEntry entry)
         {
-            bucket = default;
-            slot = default;
+            var bucket = default(HashBucket*);
+            var firstBucket = default(HashBucket*);
+            int slot = default;
             entry = default;
 
             var hash = fht.Comparer.GetHashCode64(ref key);
             var tag = (ushort)((ulong)hash >> Constants.kHashTagShift);
 
-            return fht.FindTag(hash, tag, ref bucket, ref slot, ref entry);
+            return fht.FindTag(hash, tag, ref firstBucket, ref bucket, ref slot, ref entry);
         }
-
-        internal static unsafe bool FindKey<Key, Value>(this FasterKV<Key, Value> fht, ref Key key, out HashBucketEntry entry) => FindKey(fht, ref key, out entry, out _, out _);
     }
 }


### PR DESCRIPTION
Fix HashBucket latching:
- Add HEI.firstBucket and make sure the latching uses this
- Improve the latching logic to check appropriate conditions and spin to retry (with max spin count to failure)
- Fix FindTagOrFreeInternal to retry if CAS fails, and remove the unneeded recordExists variable
- Remove some unused methods