### PR TITLE
Bug fix for ReadAddress sample

### DIFF
--- a/cs/samples/ReadAddress/VersionedReadApp.cs
+++ b/cs/samples/ReadAddress/VersionedReadApp.cs
@@ -170,6 +170,8 @@ namespace ReadAddress
 
                 if (!ProcessRecord(store, status, recordMetadata.RecordInfo, lap, ref output))
                     break;
+
+                readOptions.StartAddress = recordMetadata.RecordInfo.PreviousAddress;
             }
         }
 


### PR DESCRIPTION
ReadAddress sample missing `ReadOptions.StartAddress` assignment in `ScanStore` method.