### PR TITLE
[C#] Option to create barrier at checkpoint version switch, support rollback

### DIFF
--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -877,6 +877,18 @@ namespace FASTER.core
         /// </summary>
         internal abstract int OverflowPageCount { get; }
 
+
+        /// <summary>
+        /// Reset the hybrid log
+        /// </summary>
+        public virtual void Reset()
+        {
+            this.FlushEvent.Initialize();
+            Array.Clear(PageStatusIndicator, 0, BufferSize);
+            for (int i = 0; i < BufferSize; i++)
+                PendingFlush[i].list.Clear();
+        }
+
         /// <summary>
         /// Initialize allocator
         /// </summary>

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
@@ -63,25 +64,31 @@ namespace FASTER.core
             base.Reset();
             for (int index = 0; index < BufferSize; index++)
             {
-                if (values[index] != null)
+                ReturnPage(index);
+            }
+            Initialize();
+        }
+
+        void ReturnPage(int index)
+        {
+            Debug.Assert(index < BufferSize);
+            if (values[index] != null)
+            {
+                overflowPagePool.TryAdd(new PageUnit
                 {
-                    overflowPagePool.TryAdd(new PageUnit
-                    {
 #if !NET5_0_OR_GREATER
                         handle = handles[index],
 #endif
-                        pointer = pointers[index],
-                        value = values[index]
-                    });
-                    values[index] = null;
-                    pointers[index] = 0;
+                    pointer = pointers[index],
+                    value = values[index]
+                });
+                values[index] = null;
+                pointers[index] = 0;
 #if !NET5_0_OR_GREATER
                     handles[index] = default;
 #endif
-                    Interlocked.Decrement(ref AllocatedPageCount);
-                }
+                Interlocked.Decrement(ref AllocatedPageCount);
             }
-            Initialize();
         }
 
         public override void Initialize()
@@ -280,23 +287,7 @@ namespace FASTER.core
         {
             ClearPage(page, 0);
             if (EmptyPageCount > 0)
-            {
-                int index = (int)(page % BufferSize);
-                overflowPagePool.TryAdd(new PageUnit
-                {
-#if !NET5_0_OR_GREATER
-                    handle = handles[index],
-#endif
-                    pointer = pointers[index],
-                    value = values[index]
-                });
-                values[index] = null;
-                pointers[index] = 0;
-#if !NET5_0_OR_GREATER
-                handles[index] = default;
-#endif
-                Interlocked.Decrement(ref AllocatedPageCount);
-            }
+                ReturnPage((int)(page % BufferSize));
         }
 
         /// <summary>

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -60,15 +60,28 @@ namespace FASTER.core
 
         public override void Reset()
         {
-            for (int i = 0; i < BufferSize; i++)
+            base.Reset();
+            for (int index = 0; index < BufferSize; index++)
             {
-                if (values[i] != null)
+                if (values[index] != null)
                 {
-                    Array.Clear(values[i], 0, values[i].Length);
+                    overflowPagePool.TryAdd(new PageUnit
+                    {
+#if !NET5_0_OR_GREATER
+                        handle = handles[index],
+#endif
+                        pointer = pointers[index],
+                        value = values[index]
+                    });
+                    values[index] = null;
+                    pointers[index] = 0;
+#if !NET5_0_OR_GREATER
+                    handles[index] = default;
+#endif
+                    Interlocked.Decrement(ref AllocatedPageCount);
                 }
             }
             Initialize();
-            base.Reset();
         }
 
         public override void Initialize()

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -58,9 +58,9 @@ namespace FASTER.core
             }
         }
 
-        public override void Reset(long diskBeginAddress, long diskFlushedUntilAddress)
+        public override void Reset()
         {
-            base.Reset(diskBeginAddress, diskFlushedUntilAddress);
+            base.Reset();
             for (int index = 0; index < BufferSize; index++)
             {
                 if (values[index] != null)

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -58,6 +58,19 @@ namespace FASTER.core
             }
         }
 
+        public override void Reset()
+        {
+            for (int i = 0; i < BufferSize; i++)
+            {
+                if (values[i] != null)
+                {
+                    Array.Clear(values[i], 0, values[i].Length);
+                }
+            }
+            Initialize();
+            base.Reset();
+        }
+
         public override void Initialize()
         {
             Initialize(Constants.kFirstValidAddress);

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -58,9 +58,9 @@ namespace FASTER.core
             }
         }
 
-        public override void Reset()
+        public override void Reset(long diskBeginAddress, long diskFlushedUntilAddress)
         {
-            base.Reset();
+            base.Reset(diskBeginAddress, diskFlushedUntilAddress);
             for (int index = 0; index < BufferSize; index++)
             {
                 if (values[index] != null)

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -87,6 +87,20 @@ namespace FASTER.core
 
         internal override int OverflowPageCount => overflowPagePool.Count;
 
+        public override void Reset()
+        {
+            for (int i = 0; i < BufferSize; i++)
+            {
+                if (values[i] != null)
+                {
+                    Array.Clear(values[i], 0, values[i].Length);
+                }
+            }
+            Array.Clear(segmentOffsets, 0, segmentOffsets.Length);
+            Initialize();
+            base.Reset();
+        }
+
         public override void Initialize()
         {
             Initialize(recordSize);

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -87,9 +87,9 @@ namespace FASTER.core
 
         internal override int OverflowPageCount => overflowPagePool.Count;
 
-        public override void Reset()
+        public override void Reset(long diskBeginAddress, long diskFlushedUntilAddress)
         {
-            base.Reset();
+            base.Reset(diskBeginAddress, diskFlushedUntilAddress);
             for (int index = 0; index < BufferSize; index++)
             {
                 if (values[index] != default)
@@ -282,6 +282,18 @@ namespace FASTER.core
         {
             base.TruncateUntilAddress(toAddress);
             objectLogDevice.TruncateUntilSegment((int)(toAddress >> LogSegmentSizeBits));
+        }
+
+        protected override void TruncateUntilAddressBlocking(long toAddress)
+        {
+            base.TruncateUntilAddressBlocking(toAddress);
+            objectLogDevice.TruncateUntilSegment((int)(toAddress >> LogSegmentSizeBits));
+        }
+
+        protected override void RemoveSegment(int segment)
+        {
+            base.RemoveSegment(segment);
+            objectLogDevice.RemoveSegment(segment);
         }
 
         protected override void WriteAsync<TContext>(long flushPage, DeviceIOCompletionCallback callback,  PageAsyncFlushResult<TContext> asyncResult)

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -89,16 +89,19 @@ namespace FASTER.core
 
         public override void Reset()
         {
-            for (int i = 0; i < BufferSize; i++)
+            base.Reset();
+            for (int index = 0; index < BufferSize; index++)
             {
-                if (values[i] != null)
+                if (values[index] != default)
                 {
-                    Array.Clear(values[i], 0, values[i].Length);
+                    overflowPagePool.TryAdd(values[index % BufferSize]);
+                    values[index % BufferSize] = default;
+                    Interlocked.Decrement(ref AllocatedPageCount);
                 }
             }
+
             Array.Clear(segmentOffsets, 0, segmentOffsets.Length);
             Initialize();
-            base.Reset();
         }
 
         public override void Initialize()

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -87,9 +87,9 @@ namespace FASTER.core
 
         internal override int OverflowPageCount => overflowPagePool.Count;
 
-        public override void Reset(long diskBeginAddress, long diskFlushedUntilAddress)
+        public override void Reset()
         {
-            base.Reset(diskBeginAddress, diskFlushedUntilAddress);
+            base.Reset();
             for (int index = 0; index < BufferSize; index++)
             {
                 if (values[index] != default)

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -75,6 +75,19 @@ namespace FASTER.core
 
         internal override int OverflowPageCount => overflowPagePool.Count;
 
+        public override void Reset()
+        {
+            for (int i = 0; i < BufferSize; i++)
+            {
+                if (values[i] != null)
+                {
+                    Array.Clear(values[i], 0, values[i].Length);
+                }
+            }
+            Initialize();
+            base.Reset();
+        }
+
         public override void Initialize()
         {
             Initialize(Constants.kFirstValidAddress);

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -77,15 +77,28 @@ namespace FASTER.core
 
         public override void Reset()
         {
-            for (int i = 0; i < BufferSize; i++)
+            base.Reset();
+            for (int index = 0; index < BufferSize; index++)
             {
-                if (values[i] != null)
+                if (values[index] != null)
                 {
-                    Array.Clear(values[i], 0, values[i].Length);
+                    overflowPagePool.TryAdd(new PageUnit
+                    {
+#if !NET5_0_OR_GREATER
+                        handle = handles[index],
+#endif
+                        pointer = pointers[index],
+                        value = values[index]
+                    });
+                    values[index] = null;
+                    pointers[index] = 0;
+#if !NET5_0_OR_GREATER
+                    handles[index] = default;
+#endif
+                    Interlocked.Decrement(ref AllocatedPageCount);
                 }
             }
             Initialize();
-            base.Reset();
         }
 
         public override void Initialize()

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -75,9 +75,9 @@ namespace FASTER.core
 
         internal override int OverflowPageCount => overflowPagePool.Count;
 
-        public override void Reset(long diskBeginAddress, long diskFlushedUntilAddress)
+        public override void Reset()
         {
-            base.Reset(diskBeginAddress, diskFlushedUntilAddress);
+            base.Reset();
             for (int index = 0; index < BufferSize; index++)
             {
                 if (values[index] != null)

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -75,9 +75,9 @@ namespace FASTER.core
 
         internal override int OverflowPageCount => overflowPagePool.Count;
 
-        public override void Reset()
+        public override void Reset(long diskBeginAddress, long diskFlushedUntilAddress)
         {
-            base.Reset();
+            base.Reset(diskBeginAddress, diskFlushedUntilAddress);
             for (int index = 0; index < BufferSize; index++)
             {
                 if (values[index] != null)

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -377,7 +377,7 @@ namespace FASTER.core
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ValueTask<FasterKV<Key, Value>.ReadAsyncResult<Input, Output, Context>> ReadAsync(ref Key key, ref Input input, ref ReadOptions readOptions,
-                                                                                                 Context userContext = default, long serialNo = 0, CancellationToken cancellationToken = default) 
+                                                                                                 Context userContext = default, long serialNo = 0, CancellationToken cancellationToken = default)
             => fht.ReadAsync(this.FasterSession, ref key, ref input, ref readOptions, userContext, serialNo, cancellationToken);
 
         /// <inheritdoc/>
@@ -448,12 +448,12 @@ namespace FASTER.core
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ValueTask<FasterKV<Key, Value>.UpsertAsyncResult<Input, Output, Context>> UpsertAsync(ref Key key, ref Input input, ref Value desiredValue, Context userContext = default, long serialNo = 0, CancellationToken token = default) 
+        public ValueTask<FasterKV<Key, Value>.UpsertAsyncResult<Input, Output, Context>> UpsertAsync(ref Key key, ref Input input, ref Value desiredValue, Context userContext = default, long serialNo = 0, CancellationToken token = default)
             => fht.UpsertAsync<Input, Output, Context, InternalFasterSession>(this.FasterSession, ref key, ref input, ref desiredValue, userContext, serialNo, token);
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ValueTask<FasterKV<Key, Value>.UpsertAsyncResult<Input, Output, Context>> UpsertAsync(Key key, Value desiredValue, Context userContext = default, long serialNo = 0, CancellationToken token = default) 
+        public ValueTask<FasterKV<Key, Value>.UpsertAsyncResult<Input, Output, Context>> UpsertAsync(Key key, Value desiredValue, Context userContext = default, long serialNo = 0, CancellationToken token = default)
             => UpsertAsync(ref key, ref desiredValue, userContext, serialNo, token);
 
         /// <inheritdoc/>
@@ -463,7 +463,7 @@ namespace FASTER.core
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Status RMW(ref Key key, ref Input input, ref Output output, Context userContext = default, long serialNo = 0) 
+        public Status RMW(ref Key key, ref Input input, ref Output output, Context userContext = default, long serialNo = 0)
             => RMW(ref key, ref input, ref output, out _, userContext, serialNo);
 
         /// <inheritdoc/>
@@ -507,7 +507,7 @@ namespace FASTER.core
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ValueTask<FasterKV<Key, Value>.RmwAsyncResult<Input, Output, Context>> RMWAsync(ref Key key, ref Input input, Context context = default, long serialNo = 0, CancellationToken token = default) 
+        public ValueTask<FasterKV<Key, Value>.RmwAsyncResult<Input, Output, Context>> RMWAsync(ref Key key, ref Input input, Context context = default, long serialNo = 0, CancellationToken token = default)
             => fht.RmwAsync<Input, Output, Context, InternalFasterSession>(this.FasterSession, ref key, ref input, context, serialNo, token);
 
         /// <inheritdoc/>
@@ -537,7 +537,7 @@ namespace FASTER.core
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ValueTask<FasterKV<Key, Value>.DeleteAsyncResult<Input, Output, Context>> DeleteAsync(ref Key key, Context userContext = default, long serialNo = 0, CancellationToken token = default) 
+        public ValueTask<FasterKV<Key, Value>.DeleteAsyncResult<Input, Output, Context>> DeleteAsync(ref Key key, Context userContext = default, long serialNo = 0, CancellationToken token = default)
             => fht.DeleteAsync<Input, Output, Context, InternalFasterSession>(this.FasterSession, ref key, userContext, serialNo, token);
 
         /// <inheritdoc/>
@@ -802,7 +802,7 @@ namespace FASTER.core
         /// <param name="compactUntilAddress">Compact log until this address</param>
         /// <param name="compactionType">Compaction type (whether we lookup records or scan log for liveness checking)</param>
         /// <returns>Address until which compaction was done</returns>
-        public long Compact(long compactUntilAddress, CompactionType compactionType = CompactionType.Scan) 
+        public long Compact(long compactUntilAddress, CompactionType compactionType = CompactionType.Scan)
             => Compact(compactUntilAddress, compactionType, default(DefaultCompactionFunctions<Key, Value>));
 
         /// <summary>
@@ -830,7 +830,7 @@ namespace FASTER.core
         {
             Input input = default;
             Output output = default;
-            return fht.Compact<Input, Output, Context, Functions, CompactionFunctions>(functions, compactionFunctions, ref input, ref output, untilAddress, compactionType, 
+            return fht.Compact<Input, Output, Context, Functions, CompactionFunctions>(functions, compactionFunctions, ref input, ref output, untilAddress, compactionType,
                     new SessionVariableLengthStructSettings<Value, Input> { valueLength = variableLengthStruct, inputLength = inputVariableLengthStruct });
         }
 
@@ -942,7 +942,7 @@ namespace FASTER.core
         /// </summary>
         internal bool IsInPreparePhase()
         {
-            return this.fht.SystemState.Phase == Phase.PREPARE;
+            return this.fht.SystemState.Phase == Phase.PREPARE || this.fht.SystemState.Phase == Phase.PREPARE_GROW;
         }
 
         #endregion Other Operations

--- a/cs/src/core/FasterLog/FasterLog.cs
+++ b/cs/src/core/FasterLog/FasterLog.cs
@@ -220,7 +220,7 @@ namespace FASTER.core
             Debug.Assert(!readOnlyMode);
 
             if (beginAddress == 0)
-                beginAddress = Constants.kFirstValidAddress;
+                beginAddress = allocator.GetFirstValidLogicalAddress(0);
 
             try
             {

--- a/cs/src/core/Index/CheckpointManagement/DeviceLogCommitCheckpointManager.cs
+++ b/cs/src/core/Index/CheckpointManagement/DeviceLogCommitCheckpointManager.cs
@@ -484,5 +484,10 @@ namespace FASTER.core
 
             pbuffer.Return();
         }
+
+        /// <inheritdoc />
+        public void CheckpointVersionShift(long oldVersion, long newVersion)
+        {
+        }
     }
 }

--- a/cs/src/core/Index/Common/CheckpointSettings.cs
+++ b/cs/src/core/Index/Common/CheckpointSettings.cs
@@ -45,5 +45,10 @@ namespace FASTER.core
         /// Whether we should throttle the disk IO for checkpoints (one write at a time, wait between each write) and issue IO from separate task (-1 = throttling disabled)
         /// </summary>
         public int ThrottleCheckpointFlushDelayMs = -1;
+
+        /// <summary>
+        /// Whether we use a barrier to ensure that threads are not in two different checkpoint versions at the same time
+        /// </summary>
+        public bool CheckpointVersionSwitchBarrier = false;
     }
 }

--- a/cs/src/core/Index/Common/FasterKVSettings.cs
+++ b/cs/src/core/Index/Common/FasterKVSettings.cs
@@ -140,6 +140,11 @@ namespace FASTER.core
         public int ThrottleCheckpointFlushDelayMs = -1;
 
         /// <summary>
+        /// Whether we use a barrier to ensure that threads are not in two different checkpoint versions at the same time
+        /// </summary>
+        public bool CheckpointVersionSwitchBarrier = false;
+
+        /// <summary>
         /// Create default configuration settings for FasterKV. You need to create and specify LogDevice 
         /// explicitly with this API.
         /// Use Utility.ParseSize to specify sizes in familiar string notation (e.g., "4k" and "4 MB").

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -136,11 +136,11 @@ namespace FASTER.core
 
             this.DoTransientLocking = lockingMode == LockingMode.Standard;
             this.DoEphemeralLocking = lockingMode == LockingMode.Ephemeral;
-            this.CheckpointVersionSwitchBarrier = checkpointSettings.CheckpointVersionSwitchBarrier;
 
             if (checkpointSettings is null)
                 checkpointSettings = new CheckpointSettings();
 
+            this.CheckpointVersionSwitchBarrier = checkpointSettings.CheckpointVersionSwitchBarrier;
             this.ThrottleCheckpointFlushDelayMs = checkpointSettings.ThrottleCheckpointFlushDelayMs;
 
             if (checkpointSettings.CheckpointDir != null && checkpointSettings.CheckpointManager != null)

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -739,9 +739,8 @@ namespace FASTER.core
                     {
                         SystemState.RemoveIntermediate(ref _systemState);
                         if (_systemState.Phase != Phase.PREPARE_GROW && _systemState.Phase != Phase.IN_PROGRESS_GROW)
-                        {
-                            return true;
-                        }
+                            break;
+                        ThreadStateMachineStep<Empty, Empty, Empty, NullFasterSession>(null, NullFasterSession.Instance, default);
                     }
                 }
             }
@@ -749,6 +748,7 @@ namespace FASTER.core
             {
                 epoch.Suspend();
             }
+            return true;
         }
 
         /// <summary>

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -66,6 +66,7 @@ namespace FASTER.core
 
         internal readonly bool DoTransientLocking;  // uses LockTable
         internal readonly bool DoEphemeralLocking;  // uses RecordInfo
+        readonly bool CheckpointVersionSwitchBarrier;  // version switch barrier
         internal readonly OverflowBucketLockTable<Key, Value> LockTable;
 
         internal void IncrementNumLockingSessions()
@@ -135,6 +136,7 @@ namespace FASTER.core
 
             this.DoTransientLocking = lockingMode == LockingMode.Standard;
             this.DoEphemeralLocking = lockingMode == LockingMode.Ephemeral;
+            this.CheckpointVersionSwitchBarrier = checkpointSettings.CheckpointVersionSwitchBarrier;
 
             if (checkpointSettings is null)
                 checkpointSettings = new CheckpointSettings();

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -71,22 +71,25 @@ namespace FASTER.core
             if (fasterSession.Ctx.phase == Phase.REST && newPhaseInfo.Phase == Phase.REST && fasterSession.Ctx.version == newPhaseInfo.Version)
                 return;
 
-            if (CheckpointVersionSwitchBarrier)
+            while (true)
             {
-                // In PREPARE phase, wait for threads to get to the next version
-                while (systemState.Phase == Phase.PREPARE)
-                {
-                    epoch.Suspend();
+                ThreadStateMachineStep(fasterSession.Ctx, fasterSession, default);
 
-                    // Outside epoch protection, wait for PREPARE to complete
-                    while (systemState.Phase == Phase.PREPARE)
-                        Thread.Yield();
+                // In prepare phases, after draining out ongoing transactions,
+                // spin and get threads to reach the next version before proceeding
 
-                    epoch.Resume();
-                }
+                if (CheckpointVersionSwitchBarrier &&
+                    fasterSession.Ctx.phase == Phase.PREPARE && 
+                    hlog.NumActiveLockingSessions == 0)
+                    continue;
+
+                if (fasterSession.Ctx.phase == Phase.PREPARE_GROW &&
+                    hlog.NumActiveLockingSessions == 0)
+                    continue;
+
+                break;
             }
 
-            ThreadStateMachineStep(fasterSession.Ctx, fasterSession, default);
         }
 
         internal static void InitContext<Input, Output, Context>(FasterExecutionContext<Input, Output, Context> ctx, int sessionID, string sessionName, long lsn = -1)

--- a/cs/src/core/Index/Recovery/Checkpoint.cs
+++ b/cs/src/core/Index/Recovery/Checkpoint.cs
@@ -41,6 +41,9 @@ namespace FASTER.core
 
         internal Task<LinkedCheckpointInfo> CheckpointTask => checkpointTcs.Task;
 
+        internal void CheckpointVersionShift(long oldVersion, long newVersion)
+            => checkpointManager.CheckpointVersionShift(oldVersion, newVersion);
+
         internal void WriteHybridLogMetaInfo()
         {
             var metadata = _hybridLogCheckpoint.info.ToByteArray();

--- a/cs/src/core/Index/Recovery/ICheckpointManager.cs
+++ b/cs/src/core/Index/Recovery/ICheckpointManager.cs
@@ -59,6 +59,13 @@ namespace FASTER.core
         void CommitLogCheckpoint(Guid logToken, byte[] commitMetadata);
 
         /// <summary>
+        /// Callback to indicate version shift during checkpoint
+        /// </summary>
+        /// <param name="oldVersion"></param>
+        /// <param name="newVersion"></param>
+        void CheckpointVersionShift(long oldVersion, long newVersion);
+
+        /// <summary>
         /// Commit log incremental checkpoint (incremental snapshot)
         /// </summary>
         /// <param name="logToken"></param>

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -365,11 +365,18 @@ namespace FASTER.core
             }
         }
         
-        void Reset()
+        /// <summary>
+        /// Reset the store to an empty state. WARNING: call only when store is quiesced.
+        /// </summary>
+        public void Reset()
         {
+            // Reset the hash index
             Array.Clear(state[resizeInfo.version].tableRaw, 0, state[resizeInfo.version].tableRaw.Length);
             overflowBucketsAllocator.Dispose();
             overflowBucketsAllocator = new MallocFixedPageSize<HashBucket>();
+
+            // Reset the hybrid log
+            hlog.Reset();
         }
 
         private long InternalRecover(IndexCheckpointInfo recoveredICInfo, HybridLogCheckpointInfo recoveredHLCInfo, int numPagesToPreload, bool undoNextVersion, long recoverTo)
@@ -377,10 +384,7 @@ namespace FASTER.core
             if (hlog.GetTailAddress() > hlog.GetFirstValidLogicalAddress(0))
             {
                 logger?.LogInformation("Recovery called on non-empty log - resetting to empty state first. Make sure store is quiesced before calling Recover on a running store.");
-                // Reset the hash index
                 Reset();
-                // Reset the hybrid log
-                hlog.Reset();
             }
 
             if (!RecoverToInitialPage(recoveredICInfo, recoveredHLCInfo, out long recoverFromAddress))
@@ -420,10 +424,7 @@ namespace FASTER.core
             if (hlog.GetTailAddress() > hlog.GetFirstValidLogicalAddress(0))
             {
                 logger?.LogInformation("Recovery called on non-empty log - resetting to empty state first. Make sure store is quiesced before calling Recover on a running store.");
-                // Reset the hash index
                 Reset();
-                // Reset the hybrid log
-                hlog.Reset();
             }
 
             if (!RecoverToInitialPage(recoveredICInfo, recoveredHLCInfo, out long recoverFromAddress))

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -376,11 +376,13 @@ namespace FASTER.core
         {
             if (hlog.GetTailAddress() > hlog.GetFirstValidLogicalAddress(0))
             {
-                logger?.LogInformation("Recovery called on non-empty log - resetting to empty state first");
+                logger?.LogInformation("Recovery called on non-empty log - resetting to empty state first. Make sure store is quiesced before calling Recover on a running store.");
+                // Reset the hash index
                 Reset();
+                // Reset the hybrid log
                 hlog.Reset();
             }
-            
+
             if (!RecoverToInitialPage(recoveredICInfo, recoveredHLCInfo, out long recoverFromAddress))
                 RecoverFuzzyIndex(recoveredICInfo);
 
@@ -415,6 +417,15 @@ namespace FASTER.core
 
         private async ValueTask<long> InternalRecoverAsync(IndexCheckpointInfo recoveredICInfo, HybridLogCheckpointInfo recoveredHLCInfo, int numPagesToPreload, bool undoNextVersion, long recoverTo, CancellationToken cancellationToken)
         {
+            if (hlog.GetTailAddress() > hlog.GetFirstValidLogicalAddress(0))
+            {
+                logger?.LogInformation("Recovery called on non-empty log - resetting to empty state first. Make sure store is quiesced before calling Recover on a running store.");
+                // Reset the hash index
+                Reset();
+                // Reset the hybrid log
+                hlog.Reset();
+            }
+
             if (!RecoverToInitialPage(recoveredICInfo, recoveredHLCInfo, out long recoverFromAddress))
                 await RecoverFuzzyIndexAsync(recoveredICInfo, cancellationToken).ConfigureAwait(false);
 

--- a/cs/src/core/Index/Synchronization/HybridLogCheckpointTask.cs
+++ b/cs/src/core/Index/Synchronization/HybridLogCheckpointTask.cs
@@ -34,6 +34,9 @@ namespace FASTER.core
                     // Capture begin address before checkpoint starts
                     faster._hybridLogCheckpoint.info.beginAddress = faster.hlog.BeginAddress;
                     break;
+                case Phase.IN_PROGRESS:
+                    faster.CheckpointVersionShift(lastVersion, next.Version);
+                    break;
                 case Phase.WAIT_FLUSH:
                     faster._hybridLogCheckpoint.info.headAddress = faster.hlog.HeadAddress;
                     faster._hybridLogCheckpoint.info.nextVersion = next.Version;

--- a/cs/src/core/Index/Synchronization/IndexResizeStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/IndexResizeStateMachine.cs
@@ -51,8 +51,6 @@ namespace FASTER.core
             switch (next.Phase)
             {
                 case Phase.PREPARE_GROW:
-                    faster.epoch.BumpCurrentEpoch(() => faster.GlobalStateMachineStep(next));
-                    break;
                 case Phase.IN_PROGRESS_GROW:
                 case Phase.REST:
                     // nothing to do
@@ -76,6 +74,11 @@ namespace FASTER.core
             switch (current.Phase)
             {
                 case Phase.PREPARE_GROW:
+                    faster.epoch.Mark(EpochPhaseIdx.Prepare, current.Version);
+                    if (faster.epoch.CheckIsComplete(EpochPhaseIdx.Prepare, current.Version) && faster.hlog.NumActiveLockingSessions == 0)
+                        faster.GlobalStateMachineStep(current);
+                    break;
+
                 case Phase.IN_PROGRESS_GROW:
                 case Phase.REST:
                     return;

--- a/cs/src/core/Index/Synchronization/IndexResizeStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/IndexResizeStateMachine.cs
@@ -109,6 +109,8 @@ namespace FASTER.core
                     break;
                 case Phase.PREPARE_GROW:
                     nextState.Phase = Phase.IN_PROGRESS_GROW;
+                    SetToVersion(start.Version + 1);
+                    nextState.Version = ToVersion();
                     break;
                 case Phase.IN_PROGRESS_GROW:
                     nextState.Phase = Phase.REST;

--- a/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
@@ -147,9 +147,8 @@ namespace FASTER.core
                     break;
                 case Phase.PREPARE:
                     nextState.Phase = Phase.IN_PROGRESS;
-                    // TODO: Move to long for system state as well. 
                     SetToVersion(targetVersion == -1 ? start.Version + 1 : targetVersion);
-                    nextState.Version = (int)ToVersion();
+                    nextState.Version = ToVersion();
                     break;
                 case Phase.IN_PROGRESS:
                     nextState.Phase = Phase.REST;

--- a/cs/test/RecoveryChecks.cs
+++ b/cs/test/RecoveryChecks.cs
@@ -287,6 +287,121 @@ namespace FASTER.test.recovery
                 s2.CompletePending(true);
             }
         }
+
+        [Test]
+        [Category("FasterKV"), Category("CheckpointRestore")]
+        public void RecoveryRollback([Values] CheckpointType checkpointType)
+        {
+            using var fht1 = new FasterKV<long, long>
+                (128,
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 11 },
+                checkpointSettings: new CheckpointSettings { CheckpointDir = path }
+                );
+
+            using var s1 = fht1.NewSession(new SimpleFunctions<long, long>());
+
+            for (long key = 0; key < 1000; key++)
+            {
+                s1.Upsert(ref key, ref key);
+            }
+
+            var task = fht1.TakeHybridLogCheckpointAsync(checkpointType);
+            (bool success, Guid token) = task.AsTask().GetAwaiter().GetResult();
+            Assert.IsTrue(success);
+
+            for (long key = 0; key < 1000; key++)
+            {
+                long output = default;
+                var status = s1.Read(ref key, ref output);
+                if (!status.IsPending)
+                {
+                    Assert.IsTrue(status.Found, $"status = {status}");
+                    Assert.AreEqual(key, output, $"output = {output}");
+                }
+            }
+            s1.CompletePendingWithOutputs(out var completedOutputs, true);
+            while (completedOutputs.Next())
+            {
+                Assert.IsTrue(completedOutputs.Current.Status.Found);
+                Assert.AreEqual(completedOutputs.Current.Key, completedOutputs.Current.Output, $"output = {completedOutputs.Current.Output}");
+            }
+            completedOutputs.Dispose();
+
+            for (long key = 1000; key < 2000; key++)
+            {
+                s1.Upsert(ref key, ref key);
+            }
+
+            // Rollback to previous checkpoint
+            fht1.Recover(default, token);
+
+            for (long key = 0; key < 1000; key++)
+            {
+                long output = default;
+                var status = s1.Read(ref key, ref output);
+                if (!status.IsPending)
+                {
+                    Assert.IsTrue(status.Found, $"status = {status}");
+                    Assert.AreEqual(key, output, $"output = {output}");
+                }
+            }
+            s1.CompletePendingWithOutputs(out completedOutputs, true);
+            while (completedOutputs.Next())
+            {
+                Assert.IsTrue(completedOutputs.Current.Status.Found);
+                Assert.AreEqual(completedOutputs.Current.Key, completedOutputs.Current.Output, $"output = {completedOutputs.Current.Output}");
+            }
+            completedOutputs.Dispose();
+
+            for (long key = 1000; key < 2000; key++)
+            {
+                long output = default;
+                var status = s1.Read(ref key, ref output);
+                if (!status.IsPending)
+                {
+                    Assert.IsTrue(status.NotFound, $"status = {status}");
+                }
+            }
+            s1.CompletePendingWithOutputs(out completedOutputs, true);
+            while (completedOutputs.Next())
+            {
+                Assert.IsTrue(completedOutputs.Current.Status.NotFound);
+            }
+            completedOutputs.Dispose();
+
+            for (long key = 1000; key < 2000; key++)
+            {
+                s1.Upsert(ref key, ref key);
+            }
+
+            for (long key = 0; key < 2000; key++)
+            {
+                long output = default;
+                var status = s1.Read(ref key, ref output);
+                if (!status.IsPending)
+                {
+                    Assert.IsTrue(status.Found, $"status = {status}");
+                    Assert.AreEqual(key, output, $"output = {output}");
+                }
+                else
+                {
+                    s1.CompletePendingWithOutputs(out completedOutputs, true);
+                    while (completedOutputs.Next())
+                    {
+                        Assert.IsTrue(completedOutputs.Current.Status.Found);
+                        Assert.AreEqual(completedOutputs.Current.Key, completedOutputs.Current.Output, $"output = {completedOutputs.Current.Output}");
+                    }
+                    completedOutputs.Dispose();
+                }
+            }
+            s1.CompletePendingWithOutputs(out completedOutputs, true);
+            while (completedOutputs.Next())
+            {
+                Assert.IsTrue(completedOutputs.Current.Status.Found);
+                Assert.AreEqual(completedOutputs.Current.Key, completedOutputs.Current.Output, $"output = {completedOutputs.Current.Output}");
+            }
+            completedOutputs.Dispose();
+        }
     }
 
     [TestFixture]

--- a/cs/test/RecoveryChecks.cs
+++ b/cs/test/RecoveryChecks.cs
@@ -294,7 +294,7 @@ namespace FASTER.test.recovery
         {
             using var fht1 = new FasterKV<long, long>
                 (128,
-                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 11 },
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20 },
                 checkpointSettings: new CheckpointSettings { CheckpointDir = path }
                 );
 

--- a/cs/test/RecoveryChecks.cs
+++ b/cs/test/RecoveryChecks.cs
@@ -294,7 +294,7 @@ namespace FASTER.test.recovery
         {
             using var fht1 = new FasterKV<long, long>
                 (128,
-                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 20 },
+                logSettings: new LogSettings { LogDevice = log, MutableFraction = 1, PageSizeBits = 10, MemorySizeBits = 11, SegmentSizeBits = 11 },
                 checkpointSettings: new CheckpointSettings { CheckpointDir = path }
                 );
 


### PR DESCRIPTION
Add Checkpoint option (default disabled) for whether we use a barrier to ensure that threads are not in two different checkpoint versions at the same time.

In the (PREPARE, v) phase, refresh will wait for all threads to get to the next version (IN_PROGRESS, v+1) before proceeding with the operation.

Also support basic recovery rollback, just call Recover on an existing store, and it will undo any uncheckpointed data before recovering to the given checkpoint. Make sure store is quiesced before attempting to call Recover on it.