### PR TITLE
[C#] Implement Push iterators

### DIFF
--- a/cs/samples/StoreVarLenTypes/SpanByteSample.cs
+++ b/cs/samples/StoreVarLenTypes/SpanByteSample.cs
@@ -25,10 +25,10 @@ namespace StoreVarLenTypes
 
             public bool OnStart(long beginAddress, long endAddress) => true;
 
-            public bool ConcurrentReader(ref SpanByte key, ref SpanByte value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress)
-                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords, nextAddress);
+            public bool ConcurrentReader(ref SpanByte key, ref SpanByte value, RecordMetadata recordMetadata, long numberOfRecords)
+                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords);
 
-            public bool SingleReader(ref SpanByte key, ref SpanByte value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress) 
+            public bool SingleReader(ref SpanByte key, ref SpanByte value, RecordMetadata recordMetadata, long numberOfRecords) 
                 => key.ToByteArray()[0] == count++;
 
             public void OnException(Exception exception, long numberOfRecords) { }

--- a/cs/samples/StoreVarLenTypes/SpanByteSample.cs
+++ b/cs/samples/StoreVarLenTypes/SpanByteSample.cs
@@ -18,6 +18,24 @@ namespace StoreVarLenTypes
     /// </summary>
     public class SpanByteSample
     {
+        // Functions for the push scan iterator.
+        internal struct ScanFunctions : IScanIteratorFunctions<SpanByte, SpanByte>
+        {
+            internal long count;
+
+            public bool OnStart(long beginAddress, long endAddress) => true;
+
+            public bool ConcurrentReader(ref SpanByte key, ref SpanByte value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress)
+                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords, nextAddress);
+
+            public bool SingleReader(ref SpanByte key, ref SpanByte value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress) 
+                => key.ToByteArray()[0] == count++;
+
+            public void OnException(Exception exception, long numberOfRecords) { }
+
+            public void OnStop(bool completed, long numberOfRecords) { }
+        }
+
         public static void Run()
         {
             // VarLen types do not need an object log
@@ -40,8 +58,9 @@ namespace StoreVarLenTypes
             Span<byte> keyMem = stackalloc byte[1000];
             Span<byte> valueMem = stackalloc byte[1000];
 
+            const int numRecords = 200;
             byte i;
-            for (i = 0; i < 200; i++)
+            for (i = 0; i < numRecords; i++)
             {
                 var keyLen = r.Next(1, 1000);
                 var key = keyMem.Slice(0, keyLen);
@@ -55,51 +74,45 @@ namespace StoreVarLenTypes
                 s.Upsert(key, value);
             }
 
-            bool success = true;
+            ScanFunctions scanFunctions = new();
+            bool success = store.Log.Scan(ref scanFunctions, store.Log.BeginAddress, store.Log.TailAddress)
+                           && scanFunctions.count == numRecords;
 
-            i = 0;
-            using (IFasterScanIterator<SpanByte, SpanByte> iterator = store.Log.Scan(store.Log.BeginAddress, store.Log.TailAddress))
+            if (!success)
             {
-                while (iterator.GetNext(out RecordInfo recordInfo))
+                Console.WriteLine("SpanByteSample: Error on Scan!");
+            }
+            else
+            {
+                r = new Random(100);
+                for (i = 0; i < numRecords; i++)
                 {
-                    ref var key = ref iterator.GetKey();
-                    if (key.ToByteArray()[0] != i++)
+                    var keyLen = r.Next(1, 1000);
+                    Span<byte> key = keyMem.Slice(0, keyLen);
+                    key.Fill(i);
+
+                    var valLen = r.Next(1, 1000);
+
+                    // Option 2: Converting fixed Span<byte> to SpanByte
+                    var status = s.Read(SpanByte.FromFixedSpan(key), out byte[] output, userContext: (byte)valLen);
+
+                    var expectedValue = valueMem.Slice(0, valLen);
+                    expectedValue.Fill((byte)valLen);
+
+                    if (status.IsPending)
                     {
-                        success = false;
-                        break;
+                        s.CompletePendingWithOutputs(out var completedOutputs, wait: true);
+                        using (completedOutputs)
+                        {
+                            success = completedOutputs.Next();
+                            if (success)
+                                (status, output) = (completedOutputs.Current.Status, completedOutputs.Current.Output);
+                        }
                     }
-                }
-            }
-
-            if (i != 200)
-            {
-                success = false;
-            }
-
-            r = new Random(100);
-            for (i = 0; i < 200; i++)
-            {
-                var keyLen = r.Next(1, 1000);
-                Span<byte> key = keyMem.Slice(0, keyLen);
-                key.Fill(i);
-
-                var valLen = r.Next(1, 1000);
-
-                // Option 2: Converting fixed Span<byte> to SpanByte
-                var status = s.Read(SpanByte.FromFixedSpan(key), out byte[] output, userContext: (byte)valLen);
-
-                var expectedValue = valueMem.Slice(0, valLen);
-                expectedValue.Fill((byte)valLen);
-
-                if (status.IsPending)
-                {
-                    s.CompletePending(true);
-                }
-                else
-                {
-                    if (!status.Found || (!output.SequenceEqual(expectedValue.ToArray())))
+                    success &= status.Found && output.SequenceEqual(expectedValue.ToArray());
+                    if (!success)
                     {
-                        success = false;
+                        Console.WriteLine("SpanByteSample: Error on Read!");
                         break;
                     }
                 }
@@ -107,8 +120,6 @@ namespace StoreVarLenTypes
 
             if (success)
                 Console.WriteLine("SpanByteSample: Success!");
-            else
-                Console.WriteLine("Error!");
 
             s.Dispose();
             store.Dispose();

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -41,7 +41,7 @@ namespace FASTER.core
     /// </summary>
     /// <typeparam name="Key"></typeparam>
     /// <typeparam name="Value"></typeparam>
-    public abstract partial class AllocatorBase<Key, Value> : IDisposable
+    internal abstract partial class AllocatorBase<Key, Value> : IDisposable
     {
         /// <summary>
         /// Epoch information

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -767,13 +767,19 @@ namespace FASTER.core
         public abstract long[] GetSegmentOffsets();
 
         /// <summary>
-        /// Pull-based scan interface for HLOG
+        /// Pull-based scan interface for HLOG; user calls GetNext() which advances through the address range.
         /// </summary>
-        /// <param name="beginAddress"></param>
-        /// <param name="endAddress"></param>
-        /// <param name="scanBufferingMode"></param>
         /// <returns></returns>
         public abstract IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering);
+
+        /// <summary>
+        /// Push-based scan interface for HLOG; scan the log given address range, calling <paramref name="scanFunctions"/> for each record.
+        /// </summary>
+        /// <returns>True if Scan completed; false if Scan ended early due to one of the TScanIterator reader functions returning false</returns>
+        internal abstract bool Scan<Input, Output, Context, FasterSession, TScanFunctions>(FasterSession fasterSession, long beginAddress, long endAddress, TScanFunctions scanFunctions,
+                ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering)
+            where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
+            where TScanFunctions : IScanIteratorFunctions<Key, Value>;
 
         /// <summary>
         /// Scan page guaranteed to be in memory

--- a/cs/src/core/Allocator/AsyncIOContext.cs
+++ b/cs/src/core/Allocator/AsyncIOContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -57,25 +58,79 @@ namespace FASTER.core
         /// </summary>
         public AsyncQueue<AsyncIOContext<Key, Value>> callbackQueue;
 
-
         /// <summary>
         /// Async Operation ValueTask backer
         /// </summary>
         public TaskCompletionSource<AsyncIOContext<Key, Value>> asyncOperation;
 
         /// <summary>
+        /// Synchronous completion event
+        /// </summary>
+        internal AsyncIOContextCompletionEvent<Key, Value> completionEvent;
+
+        /// <summary>
         /// Indicates whether this is a default instance with no pending operation
         /// </summary>
-        public bool IsDefault() => this.callbackQueue is null && this.asyncOperation is null;
+        public bool IsDefault() => this.callbackQueue is null && this.asyncOperation is null && this.completionEvent is null;
 
         /// <summary>
         /// Dispose
         /// </summary>
         public void Dispose()
         {
-            // Do not dispose request_key as it is a shallow copy
-            // of the key in pendingContext
-            record.Return();
+            // Do not dispose request_key as it is a shallow copy of the key in pendingContext
+            record?.Return();
+            record = null;
+        }
+    }
+
+    // Wrapper class so we can communicate back the context.record even if it has to retry due to incomplete records.
+    internal class AsyncIOContextCompletionEvent<Key, Value> : IDisposable
+    {
+        internal SemaphoreSlim semaphore;
+        internal Exception exception;
+        internal AsyncIOContext<Key, Value> request;
+
+        internal AsyncIOContextCompletionEvent()
+        {
+            this.semaphore = new SemaphoreSlim(0);
+            this.request.id = -1;
+            this.request.minAddress = Constants.kInvalidAddress;
+            this.request.completionEvent = this;
+        }
+
+        internal void Prepare(IHeapContainer<Key> request_key, long logicalAddress)
+        {
+            this.request.Dispose();
+            this.request.request_key = request_key;
+            this.request.logicalAddress = logicalAddress;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void Set(ref AsyncIOContext<Key, Value> ctx)
+        {
+            this.request.Dispose();
+            this.request = ctx;
+            this.exception = null;
+            this.semaphore.Release(1);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void SetException(Exception ex)
+        {
+            this.request.Dispose();
+            this.request = default;
+            this.exception = ex;
+            this.semaphore.Release(1);
+        }
+
+        internal void Wait(CancellationToken token = default) => this.semaphore.Wait(token);
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            this.request.Dispose();
+            this.semaphore?.Dispose();
         }
     }
 

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -361,15 +361,6 @@ namespace FASTER.core
             => new BlittableScanIterator<Key, Value>(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
 
         /// <summary>
-        /// Implementation for push-scanning FASTER log
-        /// </summary>
-        internal override bool Scan<Input, Output, Context, FasterSession, TScanFunctions>(FasterSession fasterSession, long beginAddress, long endAddress, ref TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode)
-        {
-            using BlittableScanIterator<Key, Value> iter = new(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
-            return PushScanImpl<Input, Output, Context, FasterSession, TScanFunctions, BlittableScanIterator<Key, Value>>(fasterSession, beginAddress, endAddress, ref scanFunctions, iter);
-        }
-
-        /// <summary>
         /// Implementation for push-scanning FASTER log, called from LogAccessor
         /// </summary>
         internal override bool Scan<TScanFunctions>(FasterKV<Key, Value> store, long beginAddress, long endAddress, ref TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode)

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -369,6 +369,15 @@ namespace FASTER.core
             return PushScanImpl(store, beginAddress, endAddress, ref scanFunctions, iter);
         }
 
+        /// <summary>
+        /// Implementation for push-iterating key versions, called from LogAccessor
+        /// </summary>
+        internal override bool IterateKeyVersions<TScanFunctions>(FasterKV<Key, Value> store, ref Key key, long beginAddress, ref TScanFunctions scanFunctions)
+        {
+            using BlittableScanIterator<Key, Value> iter = new(this, store.comparer, beginAddress, epoch, logger: logger);
+            return IterateKeyVersionsImpl(store, ref key, beginAddress, ref scanFunctions, iter);
+        }
+
         /// <inheritdoc />
         internal override void MemoryPageScan(long beginAddress, long endAddress, IObserver<IFasterScanIterator<Key, Value>> observer)
         {

--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace FASTER.core
 {
-    public unsafe sealed class BlittableAllocator<Key, Value> : AllocatorBase<Key, Value>
+    internal unsafe sealed class BlittableAllocator<Key, Value> : AllocatorBase<Key, Value>
     {
         // Circular buffer definition
         private readonly byte[][] values;

--- a/cs/src/core/Allocator/BlittableScanIterator.cs
+++ b/cs/src/core/Allocator/BlittableScanIterator.cs
@@ -30,7 +30,7 @@ namespace FASTER.core
         /// <param name="epoch">Epoch to use for protection; may be null if <paramref name="forceInMemory"/> is true.</param>
         /// <param name="forceInMemory">Provided address range is known by caller to be in memory, even if less than HeadAddress</param>
         /// <param name="logger"></param>
-        public BlittableScanIterator(BlittableAllocator<Key, Value> hlog, long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode, LightEpoch epoch, bool forceInMemory = false, ILogger logger = null)
+        internal BlittableScanIterator(BlittableAllocator<Key, Value> hlog, long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode, LightEpoch epoch, bool forceInMemory = false, ILogger logger = null)
             : base(beginAddress == 0 ? hlog.GetFirstValidLogicalAddress(0) : beginAddress, endAddress, scanBufferingMode, epoch, hlog.LogPageSizeBits, logger: logger)
         {
             this.hlog = hlog;

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -1064,6 +1064,15 @@ namespace FASTER.core
             return PushScanImpl(store, beginAddress, endAddress, ref scanFunctions, iter);
         }
 
+        /// <summary>
+        /// Implementation for push-iterating key versions, called from LogAccessor
+        /// </summary>
+        internal override bool IterateKeyVersions<TScanFunctions>(FasterKV<Key, Value> store, ref Key key, long beginAddress, ref TScanFunctions scanFunctions)
+        {
+            using GenericScanIterator<Key, Value> iter = new(this, store.comparer, beginAddress, epoch, logger: logger);
+            return IterateKeyVersionsImpl(store, ref key, beginAddress, ref scanFunctions, iter);
+        }
+
         /// <inheritdoc />
         internal override void MemoryPageScan(long beginAddress, long endAddress, IObserver<IFasterScanIterator<Key, Value>> observer)
         {

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -1055,6 +1055,47 @@ namespace FASTER.core
             return new GenericScanIterator<Key, Value>(this, beginAddress, endAddress, scanBufferingMode, epoch);
         }
 
+        /// <summary>
+        /// Implementation for push-scanning FASTER log
+        /// </summary>
+        internal override bool Scan<Input, Output, Context, FasterSession, TScanFunctions>(FasterSession fasterSession, long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode)
+        {
+            using GenericScanIterator<Key, Value> iter = new(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
+
+            if (!scanFunctions.OnStart(beginAddress, endAddress))
+                return false;
+
+            long numRecords = 1;
+            bool stop = true;
+            for (; !stop && iter.GetNext(out var recordInfo, out _, out _); ++numRecords)
+            {
+                OperationStackContext<Key, Value> stackCtx = default;
+                stackCtx.recSrc.ephemeralLockResult = EphemeralLockResult.Failed;
+                try
+                {
+                    if (iter.CurrentAddress >= this.ReadOnlyAddress)
+                    {
+                        fasterSession.Store.LockForScan<Input, Output, Context, FasterSession>(fasterSession, ref stackCtx, ref iter.GetKey(), ref iter.GetInfo());
+                        stop = !scanFunctions.ConcurrentReader(ref iter.GetKey(), ref iter.GetValue(), new RecordMetadata(recordInfo, iter.CurrentAddress), numRecords, iter.NextAddress);
+                    }
+                    else
+                        stop = !scanFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), new RecordMetadata(recordInfo, iter.CurrentAddress), numRecords, iter.NextAddress);
+                }
+                catch (Exception ex)
+                {
+                    scanFunctions.OnException(ex, numRecords);
+                    throw;
+                }
+                finally
+                {
+                    fasterSession.Store.UnlockForScan<Input, Output, Context, FasterSession>(fasterSession, ref stackCtx, ref iter.GetKey(), ref iter.GetInfo());
+                }
+            }
+
+            scanFunctions.OnStop(!stop, numRecords);
+            return true;
+        }
+
         /// <inheritdoc />
         internal override void MemoryPageScan(long beginAddress, long endAddress, IObserver<IFasterScanIterator<Key, Value>> observer)
         {

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -22,7 +22,7 @@ namespace FASTER.core
         public Value value;
     }
 
-    public unsafe sealed class GenericAllocator<Key, Value> : AllocatorBase<Key, Value>
+    internal unsafe sealed class GenericAllocator<Key, Value> : AllocatorBase<Key, Value>
     {
         // Circular buffer definition
         internal Record<Key, Value>[][] values;

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -1056,15 +1056,6 @@ namespace FASTER.core
         }
 
         /// <summary>
-        /// Implementation for push-scanning FASTER log
-        /// </summary>
-        internal override bool Scan<Input, Output, Context, FasterSession, TScanFunctions>(FasterSession fasterSession, long beginAddress, long endAddress, ref TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode)
-        {
-            using GenericScanIterator<Key, Value> iter = new(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
-            return PushScanImpl<Input, Output, Context, FasterSession, TScanFunctions, GenericScanIterator<Key, Value>>(fasterSession, beginAddress, endAddress, ref scanFunctions, iter);
-        }
-
-        /// <summary>
         /// Implementation for push-scanning FASTER log, called from LogAccessor
         /// </summary>
         internal override bool Scan<TScanFunctions>(FasterKV<Key, Value> store, long beginAddress, long endAddress, ref TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode)

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -1061,39 +1061,16 @@ namespace FASTER.core
         internal override bool Scan<Input, Output, Context, FasterSession, TScanFunctions>(FasterSession fasterSession, long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode)
         {
             using GenericScanIterator<Key, Value> iter = new(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
+            return PushScanImpl<Input, Output, Context, FasterSession, TScanFunctions, GenericScanIterator<Key, Value>>(fasterSession, beginAddress, endAddress, scanFunctions, iter);
+        }
 
-            if (!scanFunctions.OnStart(beginAddress, endAddress))
-                return false;
-
-            long numRecords = 1;
-            bool stop = true;
-            for (; !stop && iter.GetNext(out var recordInfo, out _, out _); ++numRecords)
-            {
-                OperationStackContext<Key, Value> stackCtx = default;
-                stackCtx.recSrc.ephemeralLockResult = EphemeralLockResult.Failed;
-                try
-                {
-                    if (iter.CurrentAddress >= this.ReadOnlyAddress)
-                    {
-                        fasterSession.Store.LockForScan<Input, Output, Context, FasterSession>(fasterSession, ref stackCtx, ref iter.GetKey(), ref iter.GetInfo());
-                        stop = !scanFunctions.ConcurrentReader(ref iter.GetKey(), ref iter.GetValue(), new RecordMetadata(recordInfo, iter.CurrentAddress), numRecords, iter.NextAddress);
-                    }
-                    else
-                        stop = !scanFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), new RecordMetadata(recordInfo, iter.CurrentAddress), numRecords, iter.NextAddress);
-                }
-                catch (Exception ex)
-                {
-                    scanFunctions.OnException(ex, numRecords);
-                    throw;
-                }
-                finally
-                {
-                    fasterSession.Store.UnlockForScan<Input, Output, Context, FasterSession>(fasterSession, ref stackCtx, ref iter.GetKey(), ref iter.GetInfo());
-                }
-            }
-
-            scanFunctions.OnStop(!stop, numRecords);
-            return true;
+        /// <summary>
+        /// Implementation for push-scanning FASTER log, called from LogAccessor
+        /// </summary>
+        internal override bool Scan<TScanFunctions>(FasterKV<Key, Value> store, long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode)
+        {
+            using GenericScanIterator<Key, Value> iter = new(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
+            return PushScanImpl(store, beginAddress, endAddress, scanFunctions, iter);
         }
 
         /// <inheritdoc />

--- a/cs/src/core/Allocator/GenericScanIterator.cs
+++ b/cs/src/core/Allocator/GenericScanIterator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 
@@ -11,9 +12,10 @@ namespace FASTER.core
     /// <summary>
     /// Scan iterator for hybrid log
     /// </summary>
-    internal sealed class GenericScanIterator<Key, Value> : ScanIteratorBase, IFasterScanIterator<Key, Value>, IPushScanIterator
+    internal sealed class GenericScanIterator<Key, Value> : ScanIteratorBase, IFasterScanIterator<Key, Value>, IPushScanIterator<Key>
     {
         private readonly GenericAllocator<Key, Value> hlog;
+        private readonly IFasterEqualityComparer<Key> comparer;
         private readonly GenericFrame<Key, Value> frame;
         private readonly int recordSize;
 
@@ -25,16 +27,23 @@ namespace FASTER.core
         /// <summary>
         /// Constructor
         /// </summary>
-        /// <param name="hlog"></param>
-        /// <param name="beginAddress"></param>
-        /// <param name="endAddress"></param>
-        /// <param name="scanBufferingMode"></param>
-        /// <param name="epoch"></param>
-        /// <param name="logger"></param>
         public GenericScanIterator(GenericAllocator<Key, Value> hlog, long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode, LightEpoch epoch, ILogger logger = null)
             : base(beginAddress == 0 ? hlog.GetFirstValidLogicalAddress(0) : beginAddress, endAddress, scanBufferingMode, epoch, hlog.LogPageSizeBits, logger: logger)
         {
             this.hlog = hlog;
+            recordSize = hlog.GetRecordSize(0).Item2;
+            if (frameSize > 0)
+                frame = new GenericFrame<Key, Value>(frameSize, hlog.PageSize);
+        }
+
+        /// <summary>
+        /// Constructor for use with tail-to-head push iteration of the passed key's record versions
+        /// </summary>
+        public GenericScanIterator(GenericAllocator<Key, Value> hlog, IFasterEqualityComparer<Key> comparer, long beginAddress, LightEpoch epoch, ILogger logger = null)
+            : base(beginAddress == 0 ? hlog.GetFirstValidLogicalAddress(0) : beginAddress, hlog.GetTailAddress(), ScanBufferingMode.SinglePageBuffering, epoch, hlog.LogPageSizeBits, logger: logger)
+        {
+            this.hlog = hlog;
+            this.comparer = comparer;
             recordSize = hlog.GetRecordSize(0).Item2;
             if (frameSize > 0)
                 frame = new GenericFrame<Key, Value>(frameSize, hlog.PageSize);
@@ -52,7 +61,7 @@ namespace FASTER.core
         /// <returns></returns>
         public ref Value GetValue() => ref currentValue;
 
-        ref RecordInfo IPushScanIterator.GetLockableInfo()
+        ref RecordInfo IPushScanIterator<Key>.GetLockableInfo()
         {
             Debug.Assert(currentFrame < 0, "GetLockableInfo() should be in-memory (i.e.should not have a frame)");
             Debug.Assert(epoch.ThisInstanceProtected(), "GetLockableInfo() should be called with the epoch held");
@@ -63,14 +72,13 @@ namespace FASTER.core
         /// Get next record in iterator
         /// </summary>
         /// <returns>True if record found, false if end of scan</returns>
-        public unsafe bool GetNext(out RecordInfo recordInfo) => ((IPushScanIterator)this).BeginGetNext(out recordInfo) && ((IPushScanIterator)this).EndGetNext();
+        public unsafe bool GetNext(out RecordInfo recordInfo) => ((IPushScanIterator<Key>)this).BeginGetNext(out recordInfo) && ((IPushScanIterator<Key>)this).EndGet();
 
         /// <summary>
-        /// Get next record in iterator
+        /// Get next record and keep the epoch held while we call the user's scan functions
         /// </summary>
-        /// <param name="recordInfo"></param>
-        /// <returns></returns>
-        bool IPushScanIterator.BeginGetNext(out RecordInfo recordInfo)
+        /// <returns>True if record found, false if end of scan</returns>
+        bool IPushScanIterator<Key>.BeginGetNext(out RecordInfo recordInfo)
         {
             recordInfo = default;
             currentKey = default;
@@ -116,46 +124,98 @@ namespace FASTER.core
 
                 if (currentAddress >= headAddress)
                 {
-                    // Read record from cached page memory
-                    currentPage %= hlog.BufferSize;
-                    currentFrame = -1;      // Frame is not used in this case.
-
-                    if (hlog.values[currentPage][currentOffset].info.SkipOnScan)
+                    if (!ReadRecordFromCachedPageMemory(out recordInfo))
                     {
                         epoch?.Suspend();
                         continue;
                     }
 
-                    // Copy the object values from cached page memory to data members; we have no ref into the log after the epoch.Suspend()
-                    // (except for GetLockableInfo which we know is safe). These are pointer-sized shallow copies.
-                    recordInfo = hlog.values[currentPage][currentOffset].info;
-                    currentKey = hlog.values[currentPage][currentOffset].key;
-                    currentValue = hlog.values[currentPage][currentOffset].value;
-
-                    // Success; defer epoch?.Suspend(); to EndGetNext
+                    // Success; defer epoch?.Suspend(); to EndGet
                     return true;
                 }
 
                 currentFrame = currentPage % frameSize;
-
-                if (frame.GetInfo(currentFrame, currentOffset).SkipOnScan)
+                recordInfo = frame.GetInfo(currentFrame, currentOffset);
+                if (recordInfo.SkipOnScan || recordInfo.IsNull())
                 {
                     epoch?.Suspend();
                     continue;
                 }
 
                 // Copy the object values from the frame to data members.
-                recordInfo = frame.GetInfo(currentFrame, currentOffset);
                 currentKey = frame.GetKey(currentFrame, currentOffset);
                 currentValue = frame.GetValue(currentFrame, currentOffset);
                 currentPage = currentOffset = -1; // We should no longer use these except for GetLockableInfo()
-                
-                // Success; defer epoch?.Suspend(); to EndGetNext
+
+                // Success; defer epoch?.Suspend(); to EndGet
                 return true;
             }
         }
 
-        bool IPushScanIterator.EndGetNext()
+        /// <summary>
+        /// Get previous record and keep the epoch held while we call the user's scan functions
+        /// </summary>
+        /// <returns>True if record found, false if end of scan</returns>
+        bool IPushScanIterator<Key>.BeginGetPrevInMemory(ref Key key, out RecordInfo recordInfo, out bool continueOnDisk)
+        {
+            recordInfo = default;
+            currentKey = default;
+            currentValue = default;
+            currentPage = currentOffset = currentFrame = -1;
+            continueOnDisk = false;
+
+            while (true)
+            {
+                // "nextAddress" is reused as "previous address" for this operation.
+                currentAddress = nextAddress;
+                if (currentAddress < hlog.HeadAddress)
+                {
+                    continueOnDisk = currentAddress >= hlog.BeginAddress;
+                    return false;
+                }
+
+                epoch?.Resume();
+
+                currentPage = currentAddress >> hlog.LogPageSizeBits;
+                currentOffset = (currentAddress & hlog.PageSizeMask) / recordSize;
+
+                nextAddress = currentAddress + recordSize;
+
+                bool success = ReadRecordFromCachedPageMemory(out recordInfo);
+                nextAddress = recordInfo.PreviousAddress;
+                if (!success)
+                {
+                    epoch?.Suspend();
+                    continue;
+                }
+
+                // Success; defer epoch?.Suspend(); to EndGet
+                return true;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        bool ReadRecordFromCachedPageMemory(out RecordInfo recordInfo)
+        {
+            // Read record from cached page memory
+            currentPage %= hlog.BufferSize;
+            currentFrame = -1;      // Frame is not used in this case.
+
+            recordInfo = hlog.values[currentPage][currentOffset].info;
+            if (recordInfo.SkipOnScan)
+                return false;
+
+            // Copy the object values from cached page memory to data members; we have no ref into the log after the epoch.Suspend()
+            // (except for GetLockableInfo which we know is safe). These are pointer-sized shallow copies.
+            recordInfo = hlog.values[currentPage][currentOffset].info;
+            currentKey = hlog.values[currentPage][currentOffset].key;
+            currentValue = hlog.values[currentPage][currentOffset].value;
+
+            // Success; defer epoch?.Suspend(); to EndGetNext
+            return true;
+        }
+
+        bool IPushScanIterator<Key>.EndGet()
         {
             epoch?.Suspend();
             return true;

--- a/cs/src/core/Allocator/GenericScanIterator.cs
+++ b/cs/src/core/Allocator/GenericScanIterator.cs
@@ -11,7 +11,7 @@ namespace FASTER.core
     /// <summary>
     /// Scan iterator for hybrid log
     /// </summary>
-    public sealed class GenericScanIterator<Key, Value> : ScanIteratorBase, IFasterScanIterator<Key, Value>, IPushScanIterator
+    internal sealed class GenericScanIterator<Key, Value> : ScanIteratorBase, IFasterScanIterator<Key, Value>, IPushScanIterator
     {
         private readonly GenericAllocator<Key, Value> hlog;
         private readonly GenericFrame<Key, Value> frame;

--- a/cs/src/core/Allocator/GenericScanIterator.cs
+++ b/cs/src/core/Allocator/GenericScanIterator.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using System.Threading;
-using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace FASTER.core
@@ -41,19 +40,13 @@ namespace FASTER.core
         /// Gets reference to current key
         /// </summary>
         /// <returns></returns>
-        public ref Key GetKey()
-        {
-            return ref currentKey;
-        }
+        public ref Key GetKey() => ref currentKey;
 
         /// <summary>
         /// Gets reference to current value
         /// </summary>
         /// <returns></returns>
-        public ref Value GetValue()
-        {
-            return ref currentValue;
-        }
+        public ref Value GetValue() => ref currentValue;
 
         /// <summary>
         /// Get next record in iterator
@@ -69,12 +62,8 @@ namespace FASTER.core
             while (true)
             {
                 currentAddress = nextAddress;
-
-                // Check for boundary conditions
                 if (currentAddress >= endAddress)
-                {
                     return false;
-                }
 
                 epoch?.Resume();
                 var headAddress = hlog.HeadAddress;
@@ -92,7 +81,6 @@ namespace FASTER.core
                 }
 
                 var currentPage = currentAddress >> hlog.LogPageSizeBits;
-
                 var offset = (currentAddress & hlog.PageSizeMask) / recordSize;
 
                 if (currentAddress < headAddress)
@@ -119,6 +107,8 @@ namespace FASTER.core
                         continue;
                     }
 
+                    // Copy the object values from cached page memory to data members; we have no ref into the log after the epoch.Suspend().
+                    // These are pointer-sized shallow copies.
                     recordInfo = hlog.values[page][offset].info;
                     currentKey = hlog.values[page][offset].key;
                     currentValue = hlog.values[page][offset].value;
@@ -134,6 +124,7 @@ namespace FASTER.core
                     continue;
                 }
 
+                // Copy the object values from the frame to data members.
                 recordInfo = frame.GetInfo(currentFrame, offset);
                 currentKey = frame.GetKey(currentFrame, offset);
                 currentValue = frame.GetValue(currentFrame, offset);
@@ -160,7 +151,6 @@ namespace FASTER.core
 
             key = default;
             value = default;
-
             return false;
         }
 

--- a/cs/src/core/Allocator/IScanIteratorFunctions.cs
+++ b/cs/src/core/Allocator/IScanIteratorFunctions.cs
@@ -6,13 +6,13 @@ using System;
 namespace FASTER.core
 {
     /// <summary>
-    /// Callback functions for log scan
+    /// Callback functions for log scan or key-version iteration
     /// </summary>
     public interface IScanIteratorFunctions<Key, Value>
     {
         /// <summary>Iteration is starting.</summary>
         /// <param name="beginAddress">Start address of the scan</param>
-        /// <param name="endAddress">End address of the scan</param>
+        /// <param name="endAddress">End address of the scan; if iterating key versions, this is <see cref="Constants.kInvalidAddress"/></param>
         /// <returns>True to continue iteration, else false</returns>
         bool OnStart(long beginAddress, long endAddress);
 
@@ -21,18 +21,16 @@ namespace FASTER.core
         /// <param name="value">Reference to the current record's Value</param>
         /// <param name="recordMetadata">Record metadata, including <see cref="RecordInfo"/> and the current record's logical address</param>
         /// <param name="numberOfRecords">The number of records returned so far, including the current one.</param>
-        /// <param name="nextAddress">The logical address of the next record in the scan</param>
         /// <returns>True to continue iteration, else false</returns>
-        bool SingleReader(ref Key key, ref Value value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress);
+        bool SingleReader(ref Key key, ref Value value, RecordMetadata recordMetadata, long numberOfRecords);
 
         /// <summary>Next record in iteration for a record in mutable log memory.</summary>
         /// <param name="key">Reference to the current record's key</param>
         /// <param name="value">Reference to the current record's Value</param>
         /// <param name="recordMetadata">Record metadata, including <see cref="RecordInfo"/> and the current record's logical address</param>
         /// <param name="numberOfRecords">The number of records returned so far, including the current one.</param>
-        /// <param name="nextAddress">The logical address of the next record in the scan</param>
         /// <returns>True to continue iteration, else false</returns>
-        bool ConcurrentReader(ref Key key, ref Value value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress);
+        bool ConcurrentReader(ref Key key, ref Value value, RecordMetadata recordMetadata, long numberOfRecords);
 
         /// <summary>Iteration is complete.</summary>
         /// <param name="completed">If true, the iteration completed; else scanFunctions.*Reader() returned false to stop the iteration.</param>
@@ -45,10 +43,11 @@ namespace FASTER.core
         void OnException(Exception exception, long numberOfRecords);
     }
 
-    internal interface IPushScanIterator
+    internal interface IPushScanIterator<Key>
     {
         bool BeginGetNext(out RecordInfo recordInfo);
+        bool BeginGetPrevInMemory(ref Key key, out RecordInfo recordInfo, out bool continueOnDisk);
+        bool EndGet();
         ref RecordInfo GetLockableInfo();
-        bool EndGetNext();
     }
 }

--- a/cs/src/core/Allocator/IScanIteratorFunctions.cs
+++ b/cs/src/core/Allocator/IScanIteratorFunctions.cs
@@ -44,4 +44,11 @@ namespace FASTER.core
         /// <param name="numberOfRecords">The number of records returned, including the current one, before the exception.</param>
         void OnException(Exception exception, long numberOfRecords);
     }
+
+    internal interface IPushScanIterator
+    {
+        bool BeginGetNext(out RecordInfo recordInfo);
+        ref RecordInfo GetLockableInfo();
+        bool EndGetNext();
+    }
 }

--- a/cs/src/core/Allocator/IScanIteratorFunctions.cs
+++ b/cs/src/core/Allocator/IScanIteratorFunctions.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+
+namespace FASTER.core
+{
+    /// <summary>
+    /// Callback functions for log scan
+    /// </summary>
+    public interface IScanIteratorFunctions<Key, Value>
+    {
+        /// <summary>Iteration is starting.</summary>
+        /// <param name="beginAddress">Start address of the scan</param>
+        /// <param name="endAddress">End address of the scan</param>
+        /// <returns>True to continue iteration, else false</returns>
+        bool OnStart(long beginAddress, long endAddress);
+
+        /// <summary>Next record in iteration for a record not in mutable log memory.</summary>
+        /// <param name="key">Reference to the current record's key</param>
+        /// <param name="value">Reference to the current record's Value</param>
+        /// <param name="recordMetadata">Record metadata, including <see cref="RecordInfo"/> and the current record's logical address</param>
+        /// <param name="numberOfRecords">The number of records returned so far, including the current one.</param>
+        /// <param name="nextAddress">The logical address of the next record in the scan</param>
+        /// <returns>True to continue iteration, else false</returns>
+        bool SingleReader(ref Key key, ref Value value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress);
+
+        /// <summary>Next record in iteration for a record in mutable log memory.</summary>
+        /// <param name="key">Reference to the current record's key</param>
+        /// <param name="value">Reference to the current record's Value</param>
+        /// <param name="recordMetadata">Record metadata, including <see cref="RecordInfo"/> and the current record's logical address</param>
+        /// <param name="numberOfRecords">The number of records returned so far, including the current one.</param>
+        /// <param name="nextAddress">The logical address of the next record in the scan</param>
+        /// <returns>True to continue iteration, else false</returns>
+        bool ConcurrentReader(ref Key key, ref Value value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress);
+
+        /// <summary>Iteration is complete.</summary>
+        /// <param name="completed">If true, the iteration completed; else scanFunctions.*Reader() returned false to stop the iteration.</param>
+        /// <param name="numberOfRecords">The number of records returned before the iteration stopped.</param>
+        void OnStop(bool completed, long numberOfRecords);
+
+        /// <summary>An exception was thrown on iteration (likely during <see name="SingleReader"/> or <see name="ConcurrentReader"/>.</summary>
+        /// <param name="exception">The exception that was thrown.</param>
+        /// <param name="numberOfRecords">The number of records returned, including the current one, before the exception.</param>
+        void OnException(Exception exception, long numberOfRecords);
+    }
+}

--- a/cs/src/core/Allocator/MemoryPageScanIterator.cs
+++ b/cs/src/core/Allocator/MemoryPageScanIterator.cs
@@ -3,13 +3,10 @@
 
 using System;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-
 namespace FASTER.core
 {
     /// <summary>
-    /// Lightweight iterator for memory page (copied to buffer).
-    /// Can be used outside epoch protection.
+    /// Lightweight iterator for memory page (copied to buffer). Can be used outside epoch protection.
     /// </summary>
     /// <typeparam name="Key"></typeparam>
     /// <typeparam name="Value"></typeparam>
@@ -20,7 +17,6 @@ namespace FASTER.core
         readonly int recordSize;
         readonly int start, end;
         int offset;
-        
 
         public MemoryPageScanIterator(Record<Key, Value>[] page, int start, int end, long pageStartAddress, int recordSize)
         {
@@ -45,10 +41,8 @@ namespace FASTER.core
         {
         }
 
-        public ref Key GetKey()
-        {
-            return ref page[offset].key;
-        }
+        public ref Key GetKey() => ref page[offset].key;
+        public ref Value GetValue() => ref page[offset].value;
 
         public bool GetNext(out RecordInfo recordInfo)
         {
@@ -82,11 +76,6 @@ namespace FASTER.core
                 value = default;
             }
             return r;
-        }
-
-        public ref Value GetValue()
-        {
-            return ref page[offset].value;
         }
 
         /// <inheritdoc/>

--- a/cs/src/core/Allocator/MemoryPageScanIterator.cs
+++ b/cs/src/core/Allocator/MemoryPageScanIterator.cs
@@ -6,7 +6,7 @@ using System;
 namespace FASTER.core
 {
     /// <summary>
-    /// Lightweight iterator for memory page (copied to buffer). Can be used outside epoch protection.
+    /// Lightweight iterator for memory page (copied to buffer). GetNext() can be used outside epoch protection but ctor must be called within epoch protection.
     /// </summary>
     /// <typeparam name="Key"></typeparam>
     /// <typeparam name="Value"></typeparam>

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -4,6 +4,9 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Runtime.CompilerServices;
+#if !NET5_0_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
 using System.Threading;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Threading;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
@@ -476,15 +475,51 @@ namespace FASTER.core
         }
 
         /// <summary>
-        /// Iterator interface for scanning FASTER log
+        /// Iterator interface for pull-scanning FASTER log
         /// </summary>
-        /// <param name="beginAddress"></param>
-        /// <param name="endAddress"></param>
-        /// <param name="scanBufferingMode"></param>
-        /// <returns></returns>
-        public override IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode)
+        public override IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode) 
+            => new VariableLengthBlittableScanIterator<Key, Value>(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
+
+        /// <summary>
+        /// Implementation for push-scanning FASTER log
+        /// </summary>
+        internal override bool Scan<Input, Output, Context, FasterSession, TScanFunctions>(FasterSession fasterSession, long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode)
         {
-            return new VariableLengthBlittableScanIterator<Key, Value>(this, beginAddress, endAddress, scanBufferingMode, epoch, logger:logger);
+            using VariableLengthBlittableScanIterator<Key, Value> iter = new(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
+
+            if (!scanFunctions.OnStart(beginAddress, endAddress))
+                return false;
+
+            long numRecords = 1;
+            bool stop = true;
+            for ( ; !stop && iter.BeginGetNext(out var recordInfo, out _, out _); ++numRecords)
+            {
+                OperationStackContext<Key, Value> stackCtx = default;
+                stackCtx.recSrc.ephemeralLockResult = EphemeralLockResult.Failed;
+                try
+                { 
+                    if (iter.CurrentAddress >= this.ReadOnlyAddress)
+                    {
+                        fasterSession.Store.LockForScan<Input, Output, Context, FasterSession>(fasterSession, ref stackCtx, ref iter.GetKey(), ref iter.GetInfo());
+                        stop = !scanFunctions.ConcurrentReader(ref iter.GetKey(), ref iter.GetValue(), new RecordMetadata(recordInfo, iter.CurrentAddress), numRecords, iter.NextAddress);
+                    }
+                    else
+                        stop = !scanFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), new RecordMetadata(recordInfo, iter.CurrentAddress), numRecords, iter.NextAddress);
+                }
+                catch (Exception ex)
+                {
+                    scanFunctions.OnException(ex, numRecords);
+                    throw;
+                }
+                finally
+                {
+                    fasterSession.Store.UnlockForScan<Input, Output, Context, FasterSession>(fasterSession, ref stackCtx, ref iter.GetKey(), ref iter.GetInfo());
+                    iter.EndGetNext();
+                }
+            }
+
+            scanFunctions.OnStop(!stop, numRecords);
+            return true;
         }
 
         /// <inheritdoc />

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -484,45 +484,21 @@ namespace FASTER.core
             => new VariableLengthBlittableScanIterator<Key, Value>(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
 
         /// <summary>
-        /// Implementation for push-scanning FASTER log
+        /// Implementation for push-scanning FASTER log, called from session
         /// </summary>
         internal override bool Scan<Input, Output, Context, FasterSession, TScanFunctions>(FasterSession fasterSession, long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode)
         {
             using VariableLengthBlittableScanIterator<Key, Value> iter = new(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
+            return PushScanImpl<Input, Output, Context, FasterSession, TScanFunctions, VariableLengthBlittableScanIterator<Key, Value>>(fasterSession, beginAddress, endAddress, scanFunctions, iter);
+        }
 
-            if (!scanFunctions.OnStart(beginAddress, endAddress))
-                return false;
-
-            long numRecords = 1;
-            bool stop = true;
-            for ( ; !stop && iter.BeginGetNext(out var recordInfo, out _, out _); ++numRecords)
-            {
-                OperationStackContext<Key, Value> stackCtx = default;
-                stackCtx.recSrc.ephemeralLockResult = EphemeralLockResult.Failed;
-                try
-                { 
-                    if (iter.CurrentAddress >= this.ReadOnlyAddress)
-                    {
-                        fasterSession.Store.LockForScan<Input, Output, Context, FasterSession>(fasterSession, ref stackCtx, ref iter.GetKey(), ref iter.GetInfo());
-                        stop = !scanFunctions.ConcurrentReader(ref iter.GetKey(), ref iter.GetValue(), new RecordMetadata(recordInfo, iter.CurrentAddress), numRecords, iter.NextAddress);
-                    }
-                    else
-                        stop = !scanFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), new RecordMetadata(recordInfo, iter.CurrentAddress), numRecords, iter.NextAddress);
-                }
-                catch (Exception ex)
-                {
-                    scanFunctions.OnException(ex, numRecords);
-                    throw;
-                }
-                finally
-                {
-                    fasterSession.Store.UnlockForScan<Input, Output, Context, FasterSession>(fasterSession, ref stackCtx, ref iter.GetKey(), ref iter.GetInfo());
-                    iter.EndGetNext();
-                }
-            }
-
-            scanFunctions.OnStop(!stop, numRecords);
-            return true;
+        /// <summary>
+        /// Implementation for push-scanning FASTER log, called from LogAccessor
+        /// </summary>
+        internal override bool Scan<TScanFunctions>(FasterKV<Key, Value> store, long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode)
+        {
+            using VariableLengthBlittableScanIterator<Key, Value> iter = new(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
+            return PushScanImpl(store, beginAddress, endAddress, scanFunctions, iter);
         }
 
         /// <inheritdoc />

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -13,7 +13,7 @@ using System.Threading;
 
 namespace FASTER.core
 {
-    public unsafe sealed class VariableLengthBlittableAllocator<Key, Value> : AllocatorBase<Key, Value>
+    internal unsafe sealed class VariableLengthBlittableAllocator<Key, Value> : AllocatorBase<Key, Value>
     {
         public const int kRecordAlignment = 8; // RecordInfo has a long field, so it should be aligned to 8-bytes
 

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -484,15 +484,6 @@ namespace FASTER.core
             => new VariableLengthBlittableScanIterator<Key, Value>(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
 
         /// <summary>
-        /// Implementation for push-scanning FASTER log, called from session
-        /// </summary>
-        internal override bool Scan<Input, Output, Context, FasterSession, TScanFunctions>(FasterSession fasterSession, long beginAddress, long endAddress, ref TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode)
-        {
-            using VariableLengthBlittableScanIterator<Key, Value> iter = new(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
-            return PushScanImpl<Input, Output, Context, FasterSession, TScanFunctions, VariableLengthBlittableScanIterator<Key, Value>>(fasterSession, beginAddress, endAddress, ref scanFunctions, iter);
-        }
-
-        /// <summary>
         /// Implementation for push-scanning FASTER log, called from LogAccessor
         /// </summary>
         internal override bool Scan<TScanFunctions>(FasterKV<Key, Value> store, long beginAddress, long endAddress, ref TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode)

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -492,6 +492,15 @@ namespace FASTER.core
             return PushScanImpl(store, beginAddress, endAddress, ref scanFunctions, iter);
         }
 
+        /// <summary>
+        /// Implementation for push-iterating key versions, called from LogAccessor
+        /// </summary>
+        internal override bool IterateKeyVersions<TScanFunctions>(FasterKV<Key, Value> store, ref Key key, long beginAddress, ref TScanFunctions scanFunctions)
+        {
+            using VariableLengthBlittableScanIterator<Key, Value> iter = new(this, store.comparer, beginAddress, epoch, logger: logger);
+            return IterateKeyVersionsImpl(store, ref key, beginAddress, ref scanFunctions, iter);
+        }
+
         /// <inheritdoc />
         internal override void MemoryPageScan(long beginAddress, long endAddress, IObserver<IFasterScanIterator<Key, Value>> observer)
         {

--- a/cs/src/core/Allocator/VarLenBlittableScanIterator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableScanIterator.cs
@@ -31,7 +31,7 @@ namespace FASTER.core
         /// <param name="epoch">Epoch to use for protection; may be null if <paramref name="forceInMemory"/> is true.</param>
         /// <param name="forceInMemory">Provided address range is known by caller to be in memory, even if less than HeadAddress</param>
         /// <param name="logger"></param>
-        public VariableLengthBlittableScanIterator(VariableLengthBlittableAllocator<Key, Value> hlog, long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode, LightEpoch epoch, bool forceInMemory = false, ILogger logger = null)
+        internal VariableLengthBlittableScanIterator(VariableLengthBlittableAllocator<Key, Value> hlog, long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode, LightEpoch epoch, bool forceInMemory = false, ILogger logger = null)
             : base(beginAddress == 0 ? hlog.GetFirstValidLogicalAddress(0) : beginAddress, endAddress, scanBufferingMode, epoch, hlog.LogPageSizeBits, logger: logger)
         {
             this.hlog = hlog;

--- a/cs/src/core/Async/CompletePendingAsync.cs
+++ b/cs/src/core/Async/CompletePendingAsync.cs
@@ -28,7 +28,7 @@ namespace FASTER.core
         /// </summary>
         /// <returns></returns>
         internal async ValueTask CompletePendingAsync<Input, Output, Context, FasterSession>(FasterSession fasterSession,
-                                      CancellationToken token, CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs)
+                                      CancellationToken token, CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool orderedResponses)
             where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
         {
             while (true)
@@ -36,7 +36,7 @@ namespace FASTER.core
                 fasterSession.UnsafeResumeThread();
                 try
                 {
-                    InternalCompletePendingRequests(fasterSession, completedOutputs);
+                    InternalCompletePendingRequests(fasterSession, completedOutputs, orderedResponses);
                 }
                 finally
                 {

--- a/cs/src/core/Async/CompletePendingAsync.cs
+++ b/cs/src/core/Async/CompletePendingAsync.cs
@@ -28,7 +28,7 @@ namespace FASTER.core
         /// </summary>
         /// <returns></returns>
         internal async ValueTask CompletePendingAsync<Input, Output, Context, FasterSession>(FasterSession fasterSession,
-                                      CancellationToken token, CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool orderedResponses)
+                                      CancellationToken token, CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs)
             where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
         {
             while (true)
@@ -36,7 +36,7 @@ namespace FASTER.core
                 fasterSession.UnsafeResumeThread();
                 try
                 {
-                    InternalCompletePendingRequests(fasterSession, completedOutputs, orderedResponses);
+                    InternalCompletePendingRequests(fasterSession, completedOutputs);
                 }
                 finally
                 {

--- a/cs/src/core/ClientSession/BasicContext.cs
+++ b/cs/src/core/ClientSession/BasicContext.cs
@@ -36,20 +36,20 @@ namespace FASTER.core
         #region IFasterContext
 
         /// <inheritdoc/>
-        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
-            => clientSession.CompletePending(wait, spinWaitForCommit, orderedResponses);
+        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false)
+            => clientSession.CompletePending(wait, spinWaitForCommit);
 
         /// <inheritdoc/>
-        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
-            => clientSession.CompletePendingWithOutputs(out completedOutputs, wait, spinWaitForCommit, orderedResponses);
+        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
+            => clientSession.CompletePendingWithOutputs(out completedOutputs, wait, spinWaitForCommit);
 
         /// <inheritdoc/>
-        public ValueTask CompletePendingAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
-            => clientSession.CompletePendingAsync(waitForCommit, orderedResponses, token);
+        public ValueTask CompletePendingAsync(bool waitForCommit = false, CancellationToken token = default)
+            => clientSession.CompletePendingAsync(waitForCommit, token);
 
         /// <inheritdoc/>
-        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
-            => clientSession.CompletePendingWithOutputsAsync(waitForCommit, orderedResponses, token);
+        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, CancellationToken token = default)
+            => clientSession.CompletePendingWithOutputsAsync(waitForCommit, token);
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/cs/src/core/ClientSession/BasicContext.cs
+++ b/cs/src/core/ClientSession/BasicContext.cs
@@ -36,20 +36,20 @@ namespace FASTER.core
         #region IFasterContext
 
         /// <inheritdoc/>
-        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false)
-            => clientSession.CompletePending(wait, spinWaitForCommit);
+        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
+            => clientSession.CompletePending(wait, spinWaitForCommit, orderedResponses);
 
         /// <inheritdoc/>
-        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
-            => clientSession.CompletePendingWithOutputs(out completedOutputs, wait, spinWaitForCommit);
+        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
+            => clientSession.CompletePendingWithOutputs(out completedOutputs, wait, spinWaitForCommit, orderedResponses);
 
         /// <inheritdoc/>
-        public ValueTask CompletePendingAsync(bool waitForCommit = false, CancellationToken token = default)
-            => clientSession.CompletePendingAsync(waitForCommit, token);
+        public ValueTask CompletePendingAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
+            => clientSession.CompletePendingAsync(waitForCommit, orderedResponses, token);
 
         /// <inheritdoc/>
-        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, CancellationToken token = default)
-            => clientSession.CompletePendingWithOutputsAsync(waitForCommit, token);
+        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
+            => clientSession.CompletePendingWithOutputsAsync(waitForCommit, orderedResponses, token);
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/cs/src/core/ClientSession/BasicContext.cs
+++ b/cs/src/core/ClientSession/BasicContext.cs
@@ -217,6 +217,11 @@ namespace FASTER.core
             => clientSession.DeleteAsync(key, userContext, serialNo, token);
 
         /// <inheritdoc/>
+        public bool Scan<TScanFunctions>(long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering)
+            where TScanFunctions : IScanIteratorFunctions<Key, Value>
+            => clientSession.Scan(beginAddress, endAddress, scanFunctions, scanBufferingMode);
+
+        /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ResetModified(ref Key key)
             => clientSession.ResetModified(ref key);

--- a/cs/src/core/ClientSession/BasicContext.cs
+++ b/cs/src/core/ClientSession/BasicContext.cs
@@ -217,11 +217,6 @@ namespace FASTER.core
             => clientSession.DeleteAsync(key, userContext, serialNo, token);
 
         /// <inheritdoc/>
-        public bool Scan<TScanFunctions>(long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering)
-            where TScanFunctions : IScanIteratorFunctions<Key, Value>
-            => clientSession.Scan(beginAddress, endAddress, scanFunctions, scanBufferingMode);
-
-        /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ResetModified(ref Key key)
             => clientSession.ResetModified(ref key);

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -545,14 +545,6 @@ namespace FASTER.core
         public ValueTask<FasterKV<Key, Value>.DeleteAsyncResult<Input, Output, Context>> DeleteAsync(Key key, Context userContext = default, long serialNo = 0, CancellationToken token = default)
             => DeleteAsync(ref key, userContext, serialNo, token);
 
-        /// <summary>
-        /// Scan the log given address range, calling <paramref name="scanFunctions"/> for each record.
-        /// </summary>
-        /// <returns>True if Scan completed; false if Scan ended early due to one of the TScanIterator reader functions returning false</returns>
-        public bool Scan<TScanFunctions>(long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering)
-            where TScanFunctions : IScanIteratorFunctions<Key, Value>
-            => fht.hlog.Scan<Input, Output, Context, InternalFasterSession, TScanFunctions>(FasterSession, beginAddress, endAddress, scanFunctions, scanBufferingMode);
-
         /// <inheritdoc/>
         public void Refresh()
         {

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -901,7 +901,8 @@ namespace FASTER.core
         /// </summary>
         /// <param name="untilAddress">Report records until this address (tail by default)</param>
         /// <returns>FASTER iterator</returns>
-        public IFasterScanIterator<Key, Value> Iterate(long untilAddress = -1) => fht.Iterate<Input, Output, Context, Functions>(functions, untilAddress);
+        public IFasterScanIterator<Key, Value> Iterate(long untilAddress = -1) 
+            => fht.Iterate<Input, Output, Context, Functions>(functions, untilAddress);
 
         /// <summary>
         /// Push iteration of all (distinct) live key-values stored in FASTER

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -610,14 +610,14 @@ namespace FASTER.core
         }
 
         /// <inheritdoc/>
-        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false)
-            => CompletePending(false, wait, spinWaitForCommit);
+        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
+            => CompletePending(false, wait, spinWaitForCommit, orderedResponses);
 
         /// <inheritdoc/>
-        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
+        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
         {
             InitializeCompletedOutputs();
-            var result = CompletePending(true, wait, spinWaitForCommit);
+            var result = CompletePending(true, wait, spinWaitForCommit, orderedResponses);
             completedOutputs = this.completedOutputs;
             return result;
         }
@@ -626,11 +626,11 @@ namespace FASTER.core
         /// Synchronously complete outstanding pending synchronous operations, returning outputs for the completed operations.
         /// Assumes epoch protection is managed by user. Async operations must be completed individually.
         /// </summary>
-        internal bool UnsafeCompletePendingWithOutputs<FasterSession>(FasterSession fasterSession, out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
+        internal bool UnsafeCompletePendingWithOutputs<FasterSession>(FasterSession fasterSession, out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
             where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
         {
             InitializeCompletedOutputs();
-            var result = UnsafeCompletePending(fasterSession, true, wait, spinWaitForCommit);
+            var result = UnsafeCompletePending(fasterSession, true, wait, spinWaitForCommit, orderedResponses);
             completedOutputs = this.completedOutputs;
             return result;
         }
@@ -643,12 +643,12 @@ namespace FASTER.core
                 this.completedOutputs.Dispose();
         }
 
-        internal bool CompletePending(bool getOutputs, bool wait, bool spinWaitForCommit)
+        internal bool CompletePending(bool getOutputs, bool wait, bool spinWaitForCommit, bool orderedResponses)
         {
             UnsafeResumeThread();
             try
             {
-                return UnsafeCompletePending(FasterSession, getOutputs, wait, spinWaitForCommit);
+                return UnsafeCompletePending(FasterSession, getOutputs, wait, spinWaitForCommit, orderedResponses);
             }
             finally
             {
@@ -656,21 +656,21 @@ namespace FASTER.core
             }
         }
 
-        internal bool UnsafeCompletePending<FasterSession>(FasterSession fasterSession, bool getOutputs, bool wait, bool spinWaitForCommit)
+        internal bool UnsafeCompletePending<FasterSession>(FasterSession fasterSession, bool getOutputs, bool wait, bool spinWaitForCommit, bool orderedResponses)
             where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
         {
             var requestedOutputs = getOutputs ? this.completedOutputs : default;
-            var result = fht.InternalCompletePending(fasterSession, wait, requestedOutputs);
+            var result = fht.InternalCompletePending(fasterSession, wait, requestedOutputs, orderedResponses);
             if (spinWaitForCommit)
             {
                 if (!wait)
                     throw new FasterException("Can spin-wait for commit (checkpoint completion) only if wait is true");
                 do
                 {
-                    fht.InternalCompletePending(fasterSession, wait, requestedOutputs);
+                    fht.InternalCompletePending(fasterSession, wait, requestedOutputs, orderedResponses);
                     if (fht.InRestPhase())
                     {
-                        fht.InternalCompletePending(fasterSession, wait, requestedOutputs);
+                        fht.InternalCompletePending(fasterSession, wait, requestedOutputs, orderedResponses);
                         return true;
                     }
                 } while (wait);
@@ -679,18 +679,18 @@ namespace FASTER.core
         }
 
         /// <inheritdoc/>
-        public ValueTask CompletePendingAsync(bool waitForCommit = false, CancellationToken token = default)
-            => CompletePendingAsync(false, waitForCommit, token);
+        public ValueTask CompletePendingAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
+            => CompletePendingAsync(false, waitForCommit, orderedResponses, token);
 
         /// <inheritdoc/>
-        public async ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, CancellationToken token = default)
+        public async ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
         {
             InitializeCompletedOutputs();
-            await CompletePendingAsync(true, waitForCommit, token).ConfigureAwait(false);
+            await CompletePendingAsync(true, waitForCommit, orderedResponses, token).ConfigureAwait(false);
             return this.completedOutputs;
         }
 
-        private async ValueTask CompletePendingAsync(bool getOutputs, bool waitForCommit = false, CancellationToken token = default)
+        private async ValueTask CompletePendingAsync(bool getOutputs, bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
         {
             token.ThrowIfCancellationRequested();
 
@@ -698,7 +698,7 @@ namespace FASTER.core
                 throw new NotSupportedException("Async operations not supported over protected epoch");
 
             // Complete all pending operations on session
-            await fht.CompletePendingAsync(this.FasterSession, token, getOutputs ? this.completedOutputs : null).ConfigureAwait(false);
+            await fht.CompletePendingAsync(this.FasterSession, token, getOutputs ? this.completedOutputs : null, orderedResponses).ConfigureAwait(false);
 
             // Wait for commit if necessary
             if (waitForCommit)
@@ -1381,8 +1381,8 @@ namespace FASTER.core
 
             public void UnsafeSuspendThread() => _clientSession.UnsafeSuspendThread();
 
-            public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
-                => _clientSession.CompletePendingWithOutputs(out completedOutputs, wait, spinWaitForCommit);
+            public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
+                => _clientSession.CompletePendingWithOutputs(out completedOutputs, wait, spinWaitForCommit, orderedResponses);
 
             public FasterKV<Key, Value>.FasterExecutionContext<Input, Output, Context> Ctx => this._clientSession.ctx;
             #endregion Internal utilities

--- a/cs/src/core/ClientSession/IFasterContext.cs
+++ b/cs/src/core/ClientSession/IFasterContext.cs
@@ -511,6 +511,13 @@ namespace FASTER.core
         ValueTask<FasterKV<Key, Value>.DeleteAsyncResult<Input, Output, Context>> DeleteAsync(Key key, Context userContext = default, long serialNo = 0, CancellationToken token = default);
 
         /// <summary>
+        /// Scan the log given address range, calling <paramref name="scanFunctions"/> for each record.
+        /// </summary>
+        /// <returns>True if Scan completed; false if Scan ended early due to one of the TScanIterator reader functions returning false</returns>
+        public bool Scan<TScanFunctions>(long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering)
+            where TScanFunctions : IScanIteratorFunctions<Key, Value>;
+
+        /// <summary>
         /// Reset the modified bit of a record (for in memory records)
         /// </summary>
         /// <param name="key"></param>

--- a/cs/src/core/ClientSession/IFasterContext.cs
+++ b/cs/src/core/ClientSession/IFasterContext.cs
@@ -511,13 +511,6 @@ namespace FASTER.core
         ValueTask<FasterKV<Key, Value>.DeleteAsyncResult<Input, Output, Context>> DeleteAsync(Key key, Context userContext = default, long serialNo = 0, CancellationToken token = default);
 
         /// <summary>
-        /// Scan the log given address range, calling <paramref name="scanFunctions"/> for each record.
-        /// </summary>
-        /// <returns>True if Scan completed; false if Scan ended early due to one of the TScanIterator reader functions returning false</returns>
-        public bool Scan<TScanFunctions>(long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering)
-            where TScanFunctions : IScanIteratorFunctions<Key, Value>;
-
-        /// <summary>
         /// Reset the modified bit of a record (for in memory records)
         /// </summary>
         /// <param name="key"></param>

--- a/cs/src/core/ClientSession/IFasterContext.cs
+++ b/cs/src/core/ClientSession/IFasterContext.cs
@@ -17,8 +17,9 @@ namespace FASTER.core
         /// </summary>
         /// <param name="wait">Wait for all pending operations on session to complete</param>
         /// <param name="spinWaitForCommit">Spin-wait until ongoing commit/checkpoint, if any, completes</param>
+        /// <param name="orderedResponses">Whether responses are process in the order of IO issue</param>
         /// <returns>True if all pending operations have completed, false otherwise</returns>
-        bool CompletePending(bool wait = false, bool spinWaitForCommit = false);
+        bool CompletePending(bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false);
 
         /// <summary>
         /// Synchronously complete outstanding pending synchronous operations, returning outputs for the completed operations.
@@ -27,22 +28,23 @@ namespace FASTER.core
         /// <param name="completedOutputs">Outputs completed by this operation</param>
         /// <param name="wait">Wait for all pending operations on session to complete</param>
         /// <param name="spinWaitForCommit">Spin-wait until ongoing commit/checkpoint, if any, completes</param>
+        /// <param name="orderedResponses">Whether responses are process in the order of IO issue</param>
         /// <returns>True if all pending operations have completed, false otherwise</returns>
-        bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false);
+        bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false);
 
         /// <summary>
         /// Complete all pending synchronous FASTER operations.
         /// Async operations must be completed individually.
         /// </summary>
         /// <returns></returns>
-        ValueTask CompletePendingAsync(bool waitForCommit = false, CancellationToken token = default);
+        ValueTask CompletePendingAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default);
 
         /// <summary>
         /// Complete all pending synchronous FASTER operations, returning outputs for the completed operations.
         /// Async operations must be completed individually.
         /// </summary>
         /// <returns>Outputs completed by this operation</returns>
-        ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, CancellationToken token = default);
+        ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default);
 
         /// <summary>
         /// Read operation

--- a/cs/src/core/ClientSession/IFasterContext.cs
+++ b/cs/src/core/ClientSession/IFasterContext.cs
@@ -17,9 +17,8 @@ namespace FASTER.core
         /// </summary>
         /// <param name="wait">Wait for all pending operations on session to complete</param>
         /// <param name="spinWaitForCommit">Spin-wait until ongoing commit/checkpoint, if any, completes</param>
-        /// <param name="orderedResponses">Whether responses are process in the order of IO issue</param>
         /// <returns>True if all pending operations have completed, false otherwise</returns>
-        bool CompletePending(bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false);
+        bool CompletePending(bool wait = false, bool spinWaitForCommit = false);
 
         /// <summary>
         /// Synchronously complete outstanding pending synchronous operations, returning outputs for the completed operations.
@@ -28,23 +27,22 @@ namespace FASTER.core
         /// <param name="completedOutputs">Outputs completed by this operation</param>
         /// <param name="wait">Wait for all pending operations on session to complete</param>
         /// <param name="spinWaitForCommit">Spin-wait until ongoing commit/checkpoint, if any, completes</param>
-        /// <param name="orderedResponses">Whether responses are process in the order of IO issue</param>
         /// <returns>True if all pending operations have completed, false otherwise</returns>
-        bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false);
+        bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false);
 
         /// <summary>
         /// Complete all pending synchronous FASTER operations.
         /// Async operations must be completed individually.
         /// </summary>
         /// <returns></returns>
-        ValueTask CompletePendingAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default);
+        ValueTask CompletePendingAsync(bool waitForCommit = false, CancellationToken token = default);
 
         /// <summary>
         /// Complete all pending synchronous FASTER operations, returning outputs for the completed operations.
         /// Async operations must be completed individually.
         /// </summary>
         /// <returns>Outputs completed by this operation</returns>
-        ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default);
+        ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, CancellationToken token = default);
 
         /// <summary>
         /// Read operation

--- a/cs/src/core/ClientSession/LockableContext.cs
+++ b/cs/src/core/ClientSession/LockableContext.cs
@@ -170,13 +170,13 @@ namespace FASTER.core
         #region IFasterContext
 
         /// <inheritdoc/>
-        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
+        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false)
         {
             Debug.Assert(!clientSession.fht.epoch.ThisInstanceProtected());
             clientSession.UnsafeResumeThread();
             try
             {
-                return this.clientSession.UnsafeCompletePending(this.FasterSession, false, wait, spinWaitForCommit, orderedResponses);
+                return this.clientSession.UnsafeCompletePending(this.FasterSession, false, wait, spinWaitForCommit);
             }
             finally
             {
@@ -185,13 +185,13 @@ namespace FASTER.core
         }
 
         /// <inheritdoc/>
-        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
+        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
         {
             Debug.Assert(!clientSession.fht.epoch.ThisInstanceProtected());
             clientSession.UnsafeResumeThread();
             try
             {
-                return this.clientSession.UnsafeCompletePendingWithOutputs(this.FasterSession, out completedOutputs, wait, spinWaitForCommit, orderedResponses);
+                return this.clientSession.UnsafeCompletePendingWithOutputs(this.FasterSession, out completedOutputs, wait, spinWaitForCommit);
             }
             finally
             {
@@ -200,12 +200,12 @@ namespace FASTER.core
         }
 
         /// <inheritdoc/>
-        public ValueTask CompletePendingAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
-            => this.clientSession.CompletePendingAsync(waitForCommit, orderedResponses, token);
+        public ValueTask CompletePendingAsync(bool waitForCommit = false, CancellationToken token = default)
+            => this.clientSession.CompletePendingAsync(waitForCommit, token);
 
         /// <inheritdoc/>
-        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
-            => this.clientSession.CompletePendingWithOutputsAsync(waitForCommit, orderedResponses, token);
+        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, CancellationToken token = default)
+            => this.clientSession.CompletePendingWithOutputsAsync(waitForCommit, token);
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -750,8 +750,8 @@ namespace FASTER.core
 
             public void UnsafeSuspendThread() => _clientSession.UnsafeSuspendThread();
 
-            public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
-                => _clientSession.CompletePendingWithOutputs(out completedOutputs, wait, spinWaitForCommit, orderedResponses);
+            public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
+                => _clientSession.CompletePendingWithOutputs(out completedOutputs, wait, spinWaitForCommit);
 
             public FasterKV<Key, Value>.FasterExecutionContext<Input, Output, Context> Ctx => this._clientSession.ctx;
             #endregion Internal utilities

--- a/cs/src/core/ClientSession/LockableContext.cs
+++ b/cs/src/core/ClientSession/LockableContext.cs
@@ -517,11 +517,6 @@ namespace FASTER.core
             => DeleteAsync(ref key, userContext, serialNo, token);
 
         /// <inheritdoc/>
-        public bool Scan<TScanFunctions>(long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering)
-            where TScanFunctions : IScanIteratorFunctions<Key, Value>
-            => clientSession.Scan(beginAddress, endAddress, scanFunctions, scanBufferingMode);
-
-        /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ResetModified(ref Key key)
             => clientSession.ResetModified(ref key);

--- a/cs/src/core/ClientSession/LockableContext.cs
+++ b/cs/src/core/ClientSession/LockableContext.cs
@@ -170,13 +170,13 @@ namespace FASTER.core
         #region IFasterContext
 
         /// <inheritdoc/>
-        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false)
+        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
         {
             Debug.Assert(!clientSession.fht.epoch.ThisInstanceProtected());
             clientSession.UnsafeResumeThread();
             try
             {
-                return this.clientSession.UnsafeCompletePending(this.FasterSession, false, wait, spinWaitForCommit);
+                return this.clientSession.UnsafeCompletePending(this.FasterSession, false, wait, spinWaitForCommit, orderedResponses);
             }
             finally
             {
@@ -185,13 +185,13 @@ namespace FASTER.core
         }
 
         /// <inheritdoc/>
-        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
+        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
         {
             Debug.Assert(!clientSession.fht.epoch.ThisInstanceProtected());
             clientSession.UnsafeResumeThread();
             try
             {
-                return this.clientSession.UnsafeCompletePendingWithOutputs(this.FasterSession, out completedOutputs, wait, spinWaitForCommit);
+                return this.clientSession.UnsafeCompletePendingWithOutputs(this.FasterSession, out completedOutputs, wait, spinWaitForCommit, orderedResponses);
             }
             finally
             {
@@ -200,12 +200,12 @@ namespace FASTER.core
         }
 
         /// <inheritdoc/>
-        public ValueTask CompletePendingAsync(bool waitForCommit = false, CancellationToken token = default)
-            => this.clientSession.CompletePendingAsync(waitForCommit, token);
+        public ValueTask CompletePendingAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
+            => this.clientSession.CompletePendingAsync(waitForCommit, orderedResponses, token);
 
         /// <inheritdoc/>
-        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, CancellationToken token = default)
-            => this.clientSession.CompletePendingWithOutputsAsync(waitForCommit, token);
+        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
+            => this.clientSession.CompletePendingWithOutputsAsync(waitForCommit, orderedResponses, token);
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -750,8 +750,8 @@ namespace FASTER.core
 
             public void UnsafeSuspendThread() => _clientSession.UnsafeSuspendThread();
 
-            public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
-                => _clientSession.CompletePendingWithOutputs(out completedOutputs, wait, spinWaitForCommit);
+            public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
+                => _clientSession.CompletePendingWithOutputs(out completedOutputs, wait, spinWaitForCommit, orderedResponses);
 
             public FasterKV<Key, Value>.FasterExecutionContext<Input, Output, Context> Ctx => this._clientSession.ctx;
             #endregion Internal utilities

--- a/cs/src/core/ClientSession/LockableUnsafeContext.cs
+++ b/cs/src/core/ClientSession/LockableUnsafeContext.cs
@@ -112,26 +112,26 @@ namespace FASTER.core
         #region IFasterContext
 
         /// <inheritdoc/>
-        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false)
+        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
         {
             Debug.Assert(clientSession.fht.epoch.ThisInstanceProtected());
-            return this.clientSession.UnsafeCompletePending(this.FasterSession, false, wait, spinWaitForCommit);
+            return this.clientSession.UnsafeCompletePending(this.FasterSession, false, wait, spinWaitForCommit, orderedResponses);
         }
 
         /// <inheritdoc/>
-        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
+        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
         {
             Debug.Assert(clientSession.fht.epoch.ThisInstanceProtected());
-            return this.clientSession.UnsafeCompletePendingWithOutputs(this.FasterSession, out completedOutputs, wait, spinWaitForCommit);
+            return this.clientSession.UnsafeCompletePendingWithOutputs(this.FasterSession, out completedOutputs, wait, spinWaitForCommit, orderedResponses);
         }
 
         /// <inheritdoc/>
-        public ValueTask CompletePendingAsync(bool waitForCommit = false, CancellationToken token = default)
-            => this.clientSession.CompletePendingAsync(waitForCommit, token);
+        public ValueTask CompletePendingAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
+            => this.clientSession.CompletePendingAsync(waitForCommit, orderedResponses, token);
 
         /// <inheritdoc/>
-        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, CancellationToken token = default)
-            => this.clientSession.CompletePendingWithOutputsAsync(waitForCommit, token);
+        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
+            => this.clientSession.CompletePendingWithOutputsAsync(waitForCommit, orderedResponses, token);
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Status Read(ref Key key, ref Input input, ref Output output, Context userContext = default, long serialNo = 0)

--- a/cs/src/core/ClientSession/LockableUnsafeContext.cs
+++ b/cs/src/core/ClientSession/LockableUnsafeContext.cs
@@ -390,6 +390,11 @@ namespace FASTER.core
             => DeleteAsync(ref key, userContext, serialNo, token);
 
         /// <inheritdoc/>
+        public bool Scan<TScanFunctions>(long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering)
+            where TScanFunctions : IScanIteratorFunctions<Key, Value>
+            => clientSession.Scan(beginAddress, endAddress, scanFunctions, scanBufferingMode);
+
+        /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ResetModified(ref Key key)
             => clientSession.UnsafeResetModified(ref key);

--- a/cs/src/core/ClientSession/LockableUnsafeContext.cs
+++ b/cs/src/core/ClientSession/LockableUnsafeContext.cs
@@ -112,26 +112,26 @@ namespace FASTER.core
         #region IFasterContext
 
         /// <inheritdoc/>
-        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
+        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false)
         {
             Debug.Assert(clientSession.fht.epoch.ThisInstanceProtected());
-            return this.clientSession.UnsafeCompletePending(this.FasterSession, false, wait, spinWaitForCommit, orderedResponses);
+            return this.clientSession.UnsafeCompletePending(this.FasterSession, false, wait, spinWaitForCommit);
         }
 
         /// <inheritdoc/>
-        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
+        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
         {
             Debug.Assert(clientSession.fht.epoch.ThisInstanceProtected());
-            return this.clientSession.UnsafeCompletePendingWithOutputs(this.FasterSession, out completedOutputs, wait, spinWaitForCommit, orderedResponses);
+            return this.clientSession.UnsafeCompletePendingWithOutputs(this.FasterSession, out completedOutputs, wait, spinWaitForCommit);
         }
 
         /// <inheritdoc/>
-        public ValueTask CompletePendingAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
-            => this.clientSession.CompletePendingAsync(waitForCommit, orderedResponses, token);
+        public ValueTask CompletePendingAsync(bool waitForCommit = false, CancellationToken token = default)
+            => this.clientSession.CompletePendingAsync(waitForCommit, token);
 
         /// <inheritdoc/>
-        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
-            => this.clientSession.CompletePendingWithOutputsAsync(waitForCommit, orderedResponses, token);
+        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, CancellationToken token = default)
+            => this.clientSession.CompletePendingWithOutputsAsync(waitForCommit, token);
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Status Read(ref Key key, ref Input input, ref Output output, Context userContext = default, long serialNo = 0)

--- a/cs/src/core/ClientSession/LockableUnsafeContext.cs
+++ b/cs/src/core/ClientSession/LockableUnsafeContext.cs
@@ -390,11 +390,6 @@ namespace FASTER.core
             => DeleteAsync(ref key, userContext, serialNo, token);
 
         /// <inheritdoc/>
-        public bool Scan<TScanFunctions>(long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering)
-            where TScanFunctions : IScanIteratorFunctions<Key, Value>
-            => clientSession.Scan(beginAddress, endAddress, scanFunctions, scanBufferingMode);
-
-        /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ResetModified(ref Key key)
             => clientSession.UnsafeResetModified(ref key);

--- a/cs/src/core/ClientSession/UnsafeContext.cs
+++ b/cs/src/core/ClientSession/UnsafeContext.cs
@@ -320,11 +320,6 @@ namespace FASTER.core
             => DeleteAsync(ref key, userContext, serialNo, token);
 
         /// <inheritdoc/>
-        public bool Scan<TScanFunctions>(long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering)
-            where TScanFunctions : IScanIteratorFunctions<Key, Value>
-            => clientSession.Scan(beginAddress, endAddress, scanFunctions, scanBufferingMode);
-
-        /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ResetModified(ref Key key)
             => clientSession.UnsafeResetModified(ref key);

--- a/cs/src/core/ClientSession/UnsafeContext.cs
+++ b/cs/src/core/ClientSession/UnsafeContext.cs
@@ -41,26 +41,26 @@ namespace FASTER.core
         #region IFasterContext
 
         /// <inheritdoc/>
-        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false)
+        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
         {
             Debug.Assert(clientSession.fht.epoch.ThisInstanceProtected());
-            return this.clientSession.UnsafeCompletePending(this.FasterSession, false, wait, spinWaitForCommit);
+            return this.clientSession.UnsafeCompletePending(this.FasterSession, false, wait, spinWaitForCommit, orderedResponses);
         }
 
         /// <inheritdoc/>
-        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
+        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
         {
             Debug.Assert(clientSession.fht.epoch.ThisInstanceProtected());
-            return this.clientSession.UnsafeCompletePendingWithOutputs(this.FasterSession, out completedOutputs, wait, spinWaitForCommit);
+            return this.clientSession.UnsafeCompletePendingWithOutputs(this.FasterSession, out completedOutputs, wait, spinWaitForCommit, orderedResponses);
         }
 
         /// <inheritdoc/>
-        public ValueTask CompletePendingAsync(bool waitForCommit = false, CancellationToken token = default)
-            => this.clientSession.CompletePendingAsync(waitForCommit, token);
+        public ValueTask CompletePendingAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
+            => this.clientSession.CompletePendingAsync(waitForCommit, orderedResponses, token);
 
         /// <inheritdoc/>
-        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, CancellationToken token = default)
-            => this.clientSession.CompletePendingWithOutputsAsync(waitForCommit, token);
+        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
+            => this.clientSession.CompletePendingWithOutputsAsync(waitForCommit, orderedResponses, token);
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/cs/src/core/ClientSession/UnsafeContext.cs
+++ b/cs/src/core/ClientSession/UnsafeContext.cs
@@ -320,6 +320,11 @@ namespace FASTER.core
             => DeleteAsync(ref key, userContext, serialNo, token);
 
         /// <inheritdoc/>
+        public bool Scan<TScanFunctions>(long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering)
+            where TScanFunctions : IScanIteratorFunctions<Key, Value>
+            => clientSession.Scan(beginAddress, endAddress, scanFunctions, scanBufferingMode);
+
+        /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ResetModified(ref Key key)
             => clientSession.UnsafeResetModified(ref key);

--- a/cs/src/core/ClientSession/UnsafeContext.cs
+++ b/cs/src/core/ClientSession/UnsafeContext.cs
@@ -41,26 +41,26 @@ namespace FASTER.core
         #region IFasterContext
 
         /// <inheritdoc/>
-        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
+        public bool CompletePending(bool wait = false, bool spinWaitForCommit = false)
         {
             Debug.Assert(clientSession.fht.epoch.ThisInstanceProtected());
-            return this.clientSession.UnsafeCompletePending(this.FasterSession, false, wait, spinWaitForCommit, orderedResponses);
+            return this.clientSession.UnsafeCompletePending(this.FasterSession, false, wait, spinWaitForCommit);
         }
 
         /// <inheritdoc/>
-        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false)
+        public bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false)
         {
             Debug.Assert(clientSession.fht.epoch.ThisInstanceProtected());
-            return this.clientSession.UnsafeCompletePendingWithOutputs(this.FasterSession, out completedOutputs, wait, spinWaitForCommit, orderedResponses);
+            return this.clientSession.UnsafeCompletePendingWithOutputs(this.FasterSession, out completedOutputs, wait, spinWaitForCommit);
         }
 
         /// <inheritdoc/>
-        public ValueTask CompletePendingAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
-            => this.clientSession.CompletePendingAsync(waitForCommit, orderedResponses, token);
+        public ValueTask CompletePendingAsync(bool waitForCommit = false, CancellationToken token = default)
+            => this.clientSession.CompletePendingAsync(waitForCommit, token);
 
         /// <inheritdoc/>
-        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, bool orderedResponses = false, CancellationToken token = default)
-            => this.clientSession.CompletePendingWithOutputsAsync(waitForCommit, orderedResponses, token);
+        public ValueTask<CompletedOutputIterator<Key, Value, Input, Output, Context>> CompletePendingWithOutputsAsync(bool waitForCommit = false, CancellationToken token = default)
+            => this.clientSession.CompletePendingWithOutputsAsync(waitForCommit, token);
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -64,8 +64,8 @@ namespace FASTER.core
         RETRY_LATER,
 
         /// <summary>
-        /// I/O has been enqueued and the caller must go through <see cref="IFasterContext{Key, Value, Input, Output, Context}.CompletePending(bool, bool, bool)"/> or
-        /// <see cref="IFasterContext{Key, Value, Input, Output, Context}.CompletePendingWithOutputs(out CompletedOutputIterator{Key, Value, Input, Output, Context}, bool, bool, bool)"/>,
+        /// I/O has been enqueued and the caller must go through <see cref="IFasterContext{Key, Value, Input, Output, Context}.CompletePending(bool, bool)"/> or
+        /// <see cref="IFasterContext{Key, Value, Input, Output, Context}.CompletePendingWithOutputs(out CompletedOutputIterator{Key, Value, Input, Output, Context}, bool, bool)"/>,
         /// or one of the Async forms.
         /// </summary>
         RECORD_ON_DISK,
@@ -238,14 +238,6 @@ namespace FASTER.core
             }
         }
 
-        internal class AsyncIoContextComparer : IComparer<AsyncIOContext<Key, Value>>
-        {
-            public int Compare(AsyncIOContext<Key, Value> x, AsyncIOContext<Key, Value> y)
-            {
-                return x.id.CompareTo(y.id);
-            }
-        }
-
         internal sealed class FasterExecutionContext<Input, Output, Context>
         {
             internal int sessionID;
@@ -263,12 +255,6 @@ namespace FASTER.core
             public Dictionary<long, PendingContext<Input, Output, Context>> ioPendingRequests;
             public AsyncCountDown pendingReads;
             public AsyncQueue<AsyncIOContext<Key, Value>> readyResponses;
-#if NET5_0_OR_GREATER
-            public PriorityQueue<AsyncIOContext<Key, Value>, long> orderedResponses;
-#else
-            public SortedSet<AsyncIOContext<Key, Value>> orderedResponses;
-            public static readonly AsyncIoContextComparer asyncIoContextComparer = new();
-#endif
             public List<long> excludedSerialNos;
             public int asyncPendingCount;
             public ISynchronizationStateMachine threadStateMachine;

--- a/cs/src/core/Index/Common/RecordInfo.cs
+++ b/cs/src/core/Index/Common/RecordInfo.cs
@@ -141,7 +141,7 @@ namespace FASTER.core
             for (; ; Thread.Yield())
             {
                 long expected_word = word;
-                Debug.Assert(!IsClosedWord(expected_word), "Should not be X locking readcache records, pt 1");
+                Debug.Assert(!IsClosedWord(expected_word), "Should not be X locking closed records, pt 1");
                 if ((expected_word & kExclusiveLockBitMask) == 0)
                 {
                     if (expected_word == Interlocked.CompareExchange(ref word, expected_word | kExclusiveLockBitMask, expected_word))
@@ -198,7 +198,7 @@ namespace FASTER.core
             for (; ; Thread.Yield())
             {
                 long expected_word = word;
-                Debug.Assert(!IsClosedWord(expected_word), "Should not be S locking readcache records");
+                Debug.Assert(!IsClosedWord(expected_word), "Should not be S locking closed records");
                 if (((expected_word & kExclusiveLockBitMask) == 0) // not exclusively locked
                     && (expected_word & kSharedLockMaskInWord) != kSharedLockMaskInWord) // shared lock is not full
                 {

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -14,8 +14,7 @@ using System.Threading.Tasks;
 
 namespace FASTER.core
 {
-    public partial class FasterKV<Key, Value> : FasterBase,
-        IFasterKV<Key, Value>
+    public partial class FasterKV<Key, Value> : FasterBase, IFasterKV<Key, Value>
     {
         internal readonly AllocatorBase<Key, Value> hlog;
         internal readonly AllocatorBase<Key, Value> readcache;

--- a/cs/src/core/Index/FASTER/FASTER.cs
+++ b/cs/src/core/Index/FASTER/FASTER.cs
@@ -65,6 +65,7 @@ namespace FASTER.core
 
         internal readonly bool DoTransientLocking;  // uses LockTable
         internal readonly bool DoEphemeralLocking;  // uses RecordInfo
+        internal bool IsLocking => DoTransientLocking || DoEphemeralLocking;
         internal readonly OverflowBucketLockTable<Key, Value> LockTable;
 
         internal void IncrementNumLockingSessions()

--- a/cs/src/core/Index/FASTER/FASTERThread.cs
+++ b/cs/src/core/Index/FASTER/FASTERThread.cs
@@ -111,12 +111,13 @@ namespace FASTER.core
         }
 
         internal bool InternalCompletePending<Input, Output, Context, FasterSession>(FasterSession fasterSession, bool wait = false, 
-                                                                                     CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs = null)
+                                                                                     CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs = null,
+                                                                                     bool orderedResponses = false)
             where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
         {
             while (true)
             {
-                InternalCompletePendingRequests(fasterSession, completedOutputs);
+                InternalCompletePendingRequests(fasterSession, completedOutputs, orderedResponses);
                 if (wait) fasterSession.Ctx.WaitPending(epoch);
 
                 if (fasterSession.Ctx.HasNoPendingRequests) return true;
@@ -132,16 +133,62 @@ namespace FASTER.core
 
         #region Complete Pending Requests
         internal void InternalCompletePendingRequests<Input, Output, Context, FasterSession>(FasterSession fasterSession, 
-                                                                                             CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs)
+                                                                                             CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs,
+                                                                                             bool orderedResponses)
             where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
         {
             hlog.TryComplete();
 
             if (fasterSession.Ctx.readyResponses.Count == 0) return;
 
-            while (fasterSession.Ctx.readyResponses.TryDequeue(out AsyncIOContext<Key, Value> request))
+            if (orderedResponses)
             {
-                InternalCompletePendingRequest(fasterSession, request, completedOutputs);
+                long firstId = fasterSession.Ctx.totalPending - fasterSession.Ctx.ioPendingRequests.Count;
+
+                while (fasterSession.Ctx.readyResponses.TryDequeue(out AsyncIOContext<Key, Value> request))
+                {
+                    if (request.id == firstId)
+                    {
+                        InternalCompletePendingRequest(fasterSession, request, completedOutputs);
+                        firstId++;
+                    }
+                    else
+                    {
+#if NET5_0_OR_GREATER
+                        if (fasterSession.Ctx.orderedResponses == null)
+                            fasterSession.Ctx.orderedResponses = new PriorityQueue<AsyncIOContext<Key, Value>, long>();
+                        fasterSession.Ctx.orderedResponses.Enqueue(request, request.id);
+                        while (fasterSession.Ctx.orderedResponses != null && 
+                            fasterSession.Ctx.orderedResponses.TryPeek(out request, out _) && 
+                            request.id == firstId)
+                        {
+                            var success = fasterSession.Ctx.orderedResponses.TryDequeue(out _, out _);
+                            Debug.Assert(success);
+                            InternalCompletePendingRequest(fasterSession, request, completedOutputs);
+                            firstId++;
+                        }
+#else
+                        if (fasterSession.Ctx.orderedResponses == null)
+                            fasterSession.Ctx.orderedResponses = new SortedSet<AsyncIOContext<Key, Value>>(FasterExecutionContext<Input, Output, Context>.asyncIoContextComparer);
+                        fasterSession.Ctx.orderedResponses.Add(request);
+                        while (fasterSession.Ctx.orderedResponses != null &&
+                            fasterSession.Ctx.orderedResponses.Min.id == firstId)
+                        {
+                            var success = fasterSession.Ctx.orderedResponses.Remove(fasterSession.Ctx.orderedResponses.Min);
+                            Debug.Assert(success);
+                            InternalCompletePendingRequest(fasterSession, request, completedOutputs);
+                            firstId++;
+                        }
+#endif
+                    }
+                }
+            }
+            else
+            {
+                while (fasterSession.Ctx.readyResponses.TryDequeue(out AsyncIOContext<Key, Value> request))
+                {
+                    InternalCompletePendingRequest(fasterSession, request, completedOutputs);
+                }
             }
         }
 
@@ -221,6 +268,6 @@ namespace FASTER.core
             request.Dispose();
             return status;
         }
-        #endregion
+#endregion
     }
 }

--- a/cs/src/core/Index/FASTER/Implementation/Locking/TransientLocking.cs
+++ b/cs/src/core/Index/FASTER/Implementation/Locking/TransientLocking.cs
@@ -55,7 +55,7 @@ namespace FASTER.core
             {
                 stackCtx = new(comparer.GetHashCode64(ref key));
                 fasterSession.Store.FindTag(ref stackCtx.hei);
-                stackCtx.SetRecordSourceToHashEntry(this);
+                stackCtx.SetRecordSourceToHashEntry(this.hlog);
                 while (!fasterSession.Store.TryTransientSLock<Input, Output, Context, FasterSession>(fasterSession, ref key, ref stackCtx, out OperationStatus status))
                     fasterSession.Store.HandleImmediateNonPendingRetryStatus<Input, Output, Context, FasterSession>(status, fasterSession);
             }

--- a/cs/src/core/Index/FASTER/Implementation/Locking/TransientLocking.cs
+++ b/cs/src/core/Index/FASTER/Implementation/Locking/TransientLocking.cs
@@ -48,29 +48,6 @@ namespace FASTER.core
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void LockForScan<Input, Output, Context, FasterSession>(FasterSession fasterSession, ref OperationStackContext<Key, Value> stackCtx, ref Key key, ref RecordInfo recordInfo)
-            where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
-        {
-            stackCtx.recSrc.ephemeralLockResult = EphemeralLockResult.None;
-            stackCtx.recSrc.HasTransientLock = false;
-            if (fasterSession.Store.DoTransientLocking)
-            {
-                stackCtx = new(comparer.GetHashCode64(ref key));
-                fasterSession.Store.FindTag(ref stackCtx.hei);
-                stackCtx.SetRecordSourceToHashEntry(this.hlog);
-                while (!fasterSession.Store.TryTransientSLock<Input, Output, Context, FasterSession>(fasterSession, ref key, ref stackCtx, out OperationStatus status))
-                    fasterSession.Store.HandleImmediateNonPendingRetryStatus<Input, Output, Context, FasterSession>(status, fasterSession);
-                stackCtx.recSrc.HasTransientLock = true;
-            }
-            else if (fasterSession.Store.DoEphemeralLocking)
-            {
-                while (!recordInfo.TryLockShared())
-                    fasterSession.Store.HandleImmediateNonPendingRetryStatus<Input, Output, Context, FasterSession>(OperationStatus.RETRY_LATER, fasterSession);
-                stackCtx.recSrc.ephemeralLockResult = EphemeralLockResult.Success;
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void LockForScan(ref OperationStackContext<Key, Value> stackCtx, ref Key key, ref RecordInfo recordInfo)
         {
             stackCtx.recSrc.ephemeralLockResult = EphemeralLockResult.None;
@@ -91,19 +68,6 @@ namespace FASTER.core
                 while (!recordInfo.TryLockShared())
                     this.epoch.ProtectAndDrain();
                 stackCtx.recSrc.ephemeralLockResult = EphemeralLockResult.Success;
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void UnlockForScan<Input, Output, Context, FasterSession>(FasterSession fasterSession, ref OperationStackContext<Key, Value> stackCtx, ref Key key, ref RecordInfo recordInfo)
-            where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
-        {
-            if (stackCtx.recSrc.HasTransientLock)
-                fasterSession.Store.TransientSUnlock<Input, Output, Context, FasterSession>(fasterSession, ref key, ref stackCtx);
-            else if (stackCtx.recSrc.ephemeralLockResult == EphemeralLockResult.Success)
-            { 
-                recordInfo.UnlockShared();
-                stackCtx.recSrc.ephemeralLockResult = EphemeralLockResult.None;
             }
         }
 

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -253,14 +253,9 @@ namespace FASTER.core
         /// <summary>
         /// Scan the log given address range, returns all records with address less than endAddress
         /// </summary>
-        /// <param name="beginAddress"></param>
-        /// <param name="endAddress"></param>
-        /// <param name="scanBufferingMode"></param>
         /// <returns></returns>
-        public IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering)
-        {
-            return allocator.Scan(beginAddress, endAddress, scanBufferingMode);
-        }
+        public IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering) 
+            => allocator.Scan(beginAddress, endAddress, scanBufferingMode);
 
         /// <summary>
         /// Flush log until current tail (records are still retained in memory)

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -253,9 +253,17 @@ namespace FASTER.core
         /// <summary>
         /// Scan the log given address range, returns all records with address less than endAddress
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Scan iterator instance</returns>
         public IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering) 
             => allocator.Scan(beginAddress, endAddress, scanBufferingMode);
+
+        /// <summary>
+        /// Scan the log given address range, returns all records with address less than endAddress
+        /// </summary>
+        /// <returns>True if Scan completed; false if Scan ended early due to one of the TScanIterator reader functions returning false</returns>
+        public bool Scan<TScanFunctions>(long beginAddress, long endAddress, TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering)
+            where TScanFunctions : IScanIteratorFunctions<Key, Value>
+            => allocator.Scan(fht, beginAddress, endAddress, scanFunctions, scanBufferingMode);
 
         /// <summary>
         /// Flush log until current tail (records are still retained in memory)

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -276,6 +276,14 @@ namespace FASTER.core
             => allocator.Scan(fht, beginAddress, endAddress, ref scanFunctions, scanBufferingMode);
 
         /// <summary>
+        /// Iterate versions of the specified key, starting with most recent
+        /// </summary>
+        /// <returns>True if Scan completed; false if Scan ended early due to one of the TScanIterator reader functions returning false</returns>
+        public bool IterateKeyVersions<TScanFunctions>(ref TScanFunctions scanFunctions, ref Key key)
+            where TScanFunctions : IScanIteratorFunctions<Key, Value>
+            => allocator.IterateKeyVersions(fht, ref key, ref scanFunctions);
+
+        /// <summary>
         /// Flush log until current tail (records are still retained in memory)
         /// </summary>
         /// <param name="wait">Synchronous wait for operation to complete</param>

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -23,7 +23,7 @@ namespace FASTER.core
         /// </summary>
         /// <param name="fht"></param>
         /// <param name="allocator"></param>
-        public LogAccessor(FasterKV<Key, Value> fht, AllocatorBase<Key, Value> allocator)
+        internal LogAccessor(FasterKV<Key, Value> fht, AllocatorBase<Key, Value> allocator)
         {
             this.fht = fht;
             this.allocator = allocator;

--- a/cs/src/core/Index/Interfaces/IFasterSession.cs
+++ b/cs/src/core/Index/Interfaces/IFasterSession.cs
@@ -27,6 +27,7 @@ namespace FASTER.core
     internal interface IFasterSession<Key, Value, Input, Output, Context> : IFasterSession, IVariableLengthStruct<Value, Input>
     {
         bool IsManualLocking { get; }
+        FasterKV<Key, Value> Store { get; }
 
         #region Reads
         bool SingleReader(ref Key key, ref Input input, ref Value value, ref Output dst, ref RecordInfo recordInfo, ref ReadInfo readInfo);

--- a/cs/src/core/Index/Interfaces/IFasterSession.cs
+++ b/cs/src/core/Index/Interfaces/IFasterSession.cs
@@ -81,7 +81,7 @@ namespace FASTER.core
         void UnlockTransientShared(ref Key key, ref OperationStackContext<Key, Value> stackCtx);
         #endregion 
 
-        bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false);
+        bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false);
 
         public FasterKV<Key, Value>.FasterExecutionContext<Input, Output, Context> Ctx { get; }
 

--- a/cs/src/core/Index/Interfaces/IFasterSession.cs
+++ b/cs/src/core/Index/Interfaces/IFasterSession.cs
@@ -81,7 +81,7 @@ namespace FASTER.core
         void UnlockTransientShared(ref Key key, ref OperationStackContext<Key, Value> stackCtx);
         #endregion 
 
-        bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false);
+        bool CompletePendingWithOutputs(out CompletedOutputIterator<Key, Value, Input, Output, Context> completedOutputs, bool wait = false, bool spinWaitForCommit = false, bool orderedResponses = false);
 
         public FasterKV<Key, Value>.FasterExecutionContext<Input, Output, Context> Ctx { get; }
 

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -996,7 +996,7 @@ namespace FASTER.core
         }
     }
 
-    public abstract partial class AllocatorBase<Key, Value> : IDisposable
+    internal abstract partial class AllocatorBase<Key, Value> : IDisposable
     {
         /// <summary>
         /// Restore log

--- a/cs/test/BlittableIterationTests.cs
+++ b/cs/test/BlittableIterationTests.cs
@@ -4,6 +4,8 @@
 using FASTER.core;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using static FASTER.test.TestUtils;
 
 namespace FASTER.test
@@ -38,6 +40,7 @@ namespace FASTER.test
         {
             internal int keyMultToValue;
             internal long numRecords;
+            internal int stopAt;
 
             public bool OnStart(long beginAddress, long endAddress) => true;
 
@@ -48,9 +51,7 @@ namespace FASTER.test
             {
                 if (keyMultToValue > 0)
                     Assert.AreEqual(key.kfield1 * keyMultToValue, value.vfield1);
-
-                ++numRecords;
-                return true;
+                return stopAt != ++numRecords;
             }
 
             public void OnException(Exception exception, long numberOfRecords) { }
@@ -59,14 +60,14 @@ namespace FASTER.test
         }
 
         [Test]
-        [Category("FasterKV")]
-        [Category("Smoke")]
+        [Category(FasterKVTestCategory)]
+        [Category(SmokeTestCategory)]
         public void BlittableIterationBasicTest([Values] DeviceType deviceType, [Values] ScanIteratorType scanIteratorType)
         {
-            string filename = path + "BlittableIterationTest1" + deviceType.ToString() + ".log";
-            log = CreateTestDevice(deviceType, filename);
+            log = CreateTestDevice(deviceType, $"{path}{deviceType}.log");
             fht = new FasterKV<KeyStruct, ValueStruct>
-                 (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 9, SegmentSizeBits = 22 });
+                 (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 9, SegmentSizeBits = 22 },
+                 lockingMode: scanIteratorType == ScanIteratorType.Pull ? LockingMode.None : LockingMode.Standard);
 
             using var session = fht.For(new FunctionsCompaction()).NewSession<FunctionsCompaction>();
             BlittablePushIterationTestFunctions scanIteratorFunctions = new();
@@ -86,64 +87,158 @@ namespace FASTER.test
                         scanIteratorFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), default, default, default);
                 }
                 else
-                    Assert.IsTrue(session.Iterate(ref scanIteratorFunctions), "Failed to complete push iteration");
+                    Assert.IsTrue(session.Iterate(ref scanIteratorFunctions), $"Failed to complete push iteration; numRecords = {scanIteratorFunctions.numRecords}");
 
                 Assert.AreEqual(expectedRecs, scanIteratorFunctions.numRecords);
             }
 
+            // Initial population
             for (int i = 0; i < totalRecords; i++)
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
                 var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
-                session.Upsert(ref key1, ref value, 0, 0);
+                session.Upsert(ref key1, ref value);
             }
-
             iterateAndVerify(1, totalRecords);
 
             for (int i = 0; i < totalRecords; i++)
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
                 var value = new ValueStruct { vfield1 = 2 * i, vfield2 = i + 1 };
-                session.Upsert(ref key1, ref value, 0);
+                session.Upsert(ref key1, ref value);
             }
-
             iterateAndVerify(2, totalRecords);
 
             for (int i = totalRecords/2; i < totalRecords; i++)
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
                 var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
-                session.Upsert(ref key1, ref value, 0);
+                session.Upsert(ref key1, ref value);
             }
-
             iterateAndVerify(0, totalRecords);
 
             for (int i = 0; i < totalRecords; i+=2)
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
                 var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
-                session.Upsert(ref key1, ref value, 0);
+                session.Upsert(ref key1, ref value);
             }
-
             iterateAndVerify(0, totalRecords);
 
             for (int i = 0; i < totalRecords; i += 2)
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
-                var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
-                session.Delete(ref key1, 0);
+                session.Delete(ref key1);
             }
-
             iterateAndVerify(0, totalRecords / 2);
 
             for (int i = 0; i < totalRecords; i++)
             {
                 var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
                 var value = new ValueStruct { vfield1 = 3 * i, vfield2 = i + 1 };
-                session.Upsert(ref key1, ref value, 0);
+                session.Upsert(ref key1, ref value);
+            }
+            iterateAndVerify(3, totalRecords);
+
+            fht.Log.FlushAndEvict(wait: true);
+            iterateAndVerify(3, totalRecords);
+        }
+
+        [Test]
+        [Category(FasterKVTestCategory)]
+        [Category(SmokeTestCategory)]
+        public void BlittableIterationPushStopTest()
+        {
+            log = Devices.CreateLogDevice($"{path}stop_test.log");
+            fht = new FasterKV<KeyStruct, ValueStruct>
+                 (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 9, SegmentSizeBits = 22 });
+
+            using var session = fht.For(new FunctionsCompaction()).NewSession<FunctionsCompaction>();
+            BlittablePushIterationTestFunctions scanIteratorFunctions = new();
+
+            const int totalRecords = 2000;
+            var start = fht.Log.TailAddress;
+
+            void scanAndVerify(int stopAt, bool useScan)
+            {
+                scanIteratorFunctions.numRecords = 0;
+                scanIteratorFunctions.stopAt = stopAt;
+                if (useScan)
+                    Assert.IsFalse(fht.Log.Scan(ref scanIteratorFunctions, start, fht.Log.TailAddress), $"Failed to terminate push iteration early; numRecords = {scanIteratorFunctions.numRecords}");
+                else
+                    Assert.IsFalse(session.Iterate(ref scanIteratorFunctions), $"Failed to terminate push iteration early; numRecords = {scanIteratorFunctions.numRecords}");
+                Assert.AreEqual(stopAt, scanIteratorFunctions.numRecords);
             }
 
-            iterateAndVerify(3, totalRecords);
+            // Initial population
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
+                var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
+                session.Upsert(ref key1, ref value);
+            }
+
+            scanAndVerify(42, useScan: true);
+            scanAndVerify(42, useScan: false);
+        }
+
+        [Test]
+        [Category(FasterKVTestCategory)]
+        [Category(SmokeTestCategory)]
+        public unsafe void BlittableIterationPushLockTest([Values(1, 4)] int scanThreads, [Values(1, 4)] int updateThreads, [Values] LockingMode lockingMode, [Values] ScanMode scanMode)
+        {
+            log = Devices.CreateLogDevice($"{path}lock_test.log");
+            fht = new FasterKV<KeyStruct, ValueStruct>(1L << 20,
+                 // Must be large enough to contain all records in memory to exercise locking
+                 new LogSettings { LogDevice = log, MemorySizeBits = 25, PageSizeBits = 20, SegmentSizeBits = 22 },
+                 lockingMode: lockingMode);
+
+            const int totalRecords = 2000;
+            var start = fht.Log.TailAddress;
+
+            void LocalScan(int i)
+            {
+                using var session = fht.For(new FunctionsCompaction()).NewSession<FunctionsCompaction>();
+                BlittablePushIterationTestFunctions scanIteratorFunctions = new();
+                if (scanMode == ScanMode.Scan)
+                    Assert.IsTrue(fht.Log.Scan(ref scanIteratorFunctions, start, fht.Log.TailAddress), $"Failed to complete push scan; numRecords = {scanIteratorFunctions.numRecords}");
+                else
+                    Assert.IsTrue(session.Iterate(ref scanIteratorFunctions), $"Failed to complete push iteration; numRecords = {scanIteratorFunctions.numRecords}");
+                Assert.AreEqual(totalRecords, scanIteratorFunctions.numRecords);
+            }
+
+            void LocalUpdate(int tid)
+            {
+                using var session = fht.For(new FunctionsCompaction()).NewSession<FunctionsCompaction>();
+                for (int i = 0; i < totalRecords; i++)
+                {
+                    var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
+                    var value = new ValueStruct { vfield1 = (tid + 1) * i, vfield2 = i + 1 };
+                    session.Upsert(ref key1, ref value, 0);
+                }
+            }
+
+            { // Initial population
+                using var session = fht.For(new FunctionsCompaction()).NewSession<FunctionsCompaction>();
+                for (int i = 0; i < totalRecords; i++)
+                {
+                    var key1 = new KeyStruct { kfield1 = i, kfield2 = i + 1 };
+                    var value = new ValueStruct { vfield1 = i, vfield2 = i + 1 };
+                    session.Upsert(ref key1, ref value);
+                }
+            }
+
+            List<Task> tasks = new();   // Task rather than Thread for propagation of exception.
+            var numThreads = scanThreads + updateThreads;
+            for (int t = 0; t < numThreads; t++)
+            {
+                var tid = t;
+                if (t < scanThreads)
+                    tasks.Add(Task.Factory.StartNew(() => LocalScan(tid)));
+                else
+                    tasks.Add(Task.Factory.StartNew(() => LocalUpdate(tid)));
+            }
+            Task.WaitAll(tasks.ToArray());
         }
     }
 }

--- a/cs/test/BlittableIterationTests.cs
+++ b/cs/test/BlittableIterationTests.cs
@@ -44,10 +44,10 @@ namespace FASTER.test
 
             public bool OnStart(long beginAddress, long endAddress) => true;
 
-            public bool ConcurrentReader(ref KeyStruct key, ref ValueStruct value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress) 
-                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords, nextAddress);
+            public bool ConcurrentReader(ref KeyStruct key, ref ValueStruct value, RecordMetadata recordMetadata, long numberOfRecords) 
+                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords);
 
-            public bool SingleReader(ref KeyStruct key, ref ValueStruct value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress)
+            public bool SingleReader(ref KeyStruct key, ref ValueStruct value, RecordMetadata recordMetadata, long numberOfRecords)
             {
                 if (keyMultToValue > 0)
                     Assert.AreEqual(key.kfield1 * keyMultToValue, value.vfield1);
@@ -84,7 +84,7 @@ namespace FASTER.test
                 {
                     using var iter = session.Iterate();
                     while (iter.GetNext(out var recordInfo))
-                        scanIteratorFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), default, default, default);
+                        scanIteratorFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), default, default);
                 }
                 else
                     Assert.IsTrue(session.Iterate(ref scanIteratorFunctions), $"Failed to complete push iteration; numRecords = {scanIteratorFunctions.numRecords}");

--- a/cs/test/BlittableLogScanTests.cs
+++ b/cs/test/BlittableLogScanTests.cs
@@ -22,7 +22,7 @@ namespace FASTER.test
             DeleteDirectory(MethodTestDir, wait:true);
             log = Devices.CreateLogDevice(MethodTestDir + "/BlittableFASTERScanTests.log", deleteOnClose: true);
             fht = new FasterKV<KeyStruct, ValueStruct>
-                (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 9 });
+                (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 9 }, lockingMode: LockingMode.None);
         }
 
         [TearDown]
@@ -37,7 +37,6 @@ namespace FASTER.test
 
         internal struct BlittablePushScanTestFunctions : IScanIteratorFunctions<KeyStruct, ValueStruct>
         {
-            internal int keyMultToValue;
             internal long numRecords;
 
             public bool OnStart(long beginAddress, long endAddress) => true;

--- a/cs/test/BlittableLogScanTests.cs
+++ b/cs/test/BlittableLogScanTests.cs
@@ -41,10 +41,10 @@ namespace FASTER.test
 
             public bool OnStart(long beginAddress, long endAddress) => true;
 
-            public bool ConcurrentReader(ref KeyStruct key, ref ValueStruct value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress)
-                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords, nextAddress);
+            public bool ConcurrentReader(ref KeyStruct key, ref ValueStruct value, RecordMetadata recordMetadata, long numberOfRecords)
+                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords);
 
-            public bool SingleReader(ref KeyStruct key, ref ValueStruct value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress)
+            public bool SingleReader(ref KeyStruct key, ref ValueStruct value, RecordMetadata recordMetadata, long numberOfRecords)
             {
                 Assert.AreEqual(numRecords, key.kfield1);
                 Assert.AreEqual(numRecords + 1, key.kfield2);
@@ -88,7 +88,7 @@ namespace FASTER.test
                 {
                     using var iter = fht.Log.Scan(start, fht.Log.TailAddress, sbm);
                     while (iter.GetNext(out var recordInfo))
-                        scanIteratorFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), default, default, default);
+                        scanIteratorFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), default, default);
                 }
                 else
                     Assert.IsTrue(fht.Log.Scan(ref scanIteratorFunctions, start, fht.Log.TailAddress, sbm), "Failed to complete push iteration");

--- a/cs/test/EphemeralLockingTests.cs
+++ b/cs/test/EphemeralLockingTests.cs
@@ -130,10 +130,10 @@ namespace FASTER.test.EphemeralLocking
 
             public bool OnStart(long beginAddress, long endAddress) => true;
 
-            public bool ConcurrentReader(ref long key, ref long value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress) 
-                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords, nextAddress);
+            public bool ConcurrentReader(ref long key, ref long value, RecordMetadata recordMetadata, long numberOfRecords) 
+                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords);
 
-            public bool SingleReader(ref long key, ref long value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress)
+            public bool SingleReader(ref long key, ref long value, RecordMetadata recordMetadata, long numberOfRecords)
             {
                 ++count;
                 Assert.False(recordMetadata.RecordInfo.IsLocked, $"Unexpected Locked record for key {key}: {(recordMetadata.RecordInfo.IsLockedShared ? "S" : "")} {(recordMetadata.RecordInfo.IsLockedExclusive ? "X" : "")}");

--- a/cs/test/GenericDiskDeleteTests.cs
+++ b/cs/test/GenericDiskDeleteTests.cs
@@ -17,15 +17,15 @@ namespace FASTER.test
         [SetUp]
         public void Setup()
         {
-            TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait:true);
-            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/GenericDiskDeleteTests.log", deleteOnClose: true);
-            objlog = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/GenericDiskDeleteTests.obj.log", deleteOnClose: true);
+            DeleteDirectory(MethodTestDir, wait:true);
+            log = Devices.CreateLogDevice(MethodTestDir + "/GenericDiskDeleteTests.log", deleteOnClose: true);
+            objlog = Devices.CreateLogDevice(MethodTestDir + "/GenericDiskDeleteTests.obj.log", deleteOnClose: true);
 
             fht = new FasterKV<MyKey, MyValue>
                 (128,
                 logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 14, PageSizeBits = 9 },
-                serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() }
-                );
+                serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() },
+                lockingMode: LockingMode.None);
             session = fht.For(new MyFunctionsDelete()).NewSession<MyFunctionsDelete>();
         }
 
@@ -41,7 +41,7 @@ namespace FASTER.test
             objlog?.Dispose();
             objlog = null;
 
-            TestUtils.DeleteDirectory(TestUtils.MethodTestDir);
+            DeleteDirectory(MethodTestDir);
         }
 
         [Test]

--- a/cs/test/GenericIterationTests.cs
+++ b/cs/test/GenericIterationTests.cs
@@ -4,6 +4,8 @@
 using FASTER.core;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using static FASTER.test.TestUtils;
 
 namespace FASTER.test
@@ -19,15 +21,27 @@ namespace FASTER.test
         public void Setup()
         {
             DeleteDirectory(MethodTestDir, wait: true);
+            // Tests call InternalSetup()
+        }
 
-            log ??= Devices.CreateLogDevice(MethodTestDir + "/GenericIterationTests.log", deleteOnClose: true);
+        private void InternalSetup(ScanIteratorType scanIteratorType, bool largeMemory)
+        {
+            // Default lockingMode for this iterator type.
+            var lockingMode = scanIteratorType == ScanIteratorType.Pull ? LockingMode.None : LockingMode.Standard;
+            InternalSetup(lockingMode, largeMemory);
+        }
+
+        private void InternalSetup(LockingMode lockingMode, bool largeMemory)
+        {
+            // Broke this out as we have different requirements by test.
+            log = Devices.CreateLogDevice(MethodTestDir + "/GenericIterationTests.log", deleteOnClose: true);
             objlog = Devices.CreateLogDevice(MethodTestDir + "/GenericIterationTests.obj.log", deleteOnClose: true);
 
             fht = new FasterKV<MyKey, MyValue>
                 (128,
-                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 14, PageSizeBits = 9 },
-                serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() }
-                );
+                logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = largeMemory ? 25 : 14, PageSizeBits = largeMemory ? 20 : 9 },
+                serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() },
+                lockingMode: lockingMode);
             session = fht.For(new MyFunctionsDelete()).NewSession<MyFunctionsDelete>();
         }
 
@@ -50,6 +64,7 @@ namespace FASTER.test
         {
             internal int keyMultToValue;
             internal long numRecords;
+            internal int stopAt;
 
             public bool OnStart(long beginAddress, long endAddress) => true;
 
@@ -60,9 +75,7 @@ namespace FASTER.test
             {
                 if (keyMultToValue > 0)
                     Assert.AreEqual(key.key * keyMultToValue, value.value);
-
-                ++numRecords;
-                return true;
+                return stopAt != ++numRecords;
             }
 
             public void OnException(Exception exception, long numberOfRecords) { }
@@ -71,11 +84,12 @@ namespace FASTER.test
         }
 
         [Test]
-        [Category("FasterKV")]
-        [Category("Smoke")]
+        [Category(FasterKVTestCategory)]
+        [Category(SmokeTestCategory)]
 
         public void GenericIterationBasicTest([Values] ScanIteratorType scanIteratorType)
         {
+            InternalSetup(scanIteratorType, largeMemory: false);
             GenericPushIterationTestFunctions scanIteratorFunctions = new();
 
             const int totalRecords = 2000;
@@ -93,64 +107,151 @@ namespace FASTER.test
                         scanIteratorFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), default, default, default);
                 }
                 else
-                    Assert.IsTrue(session.Iterate(ref scanIteratorFunctions), "Failed to complete push iteration");
+                    Assert.IsTrue(session.Iterate(ref scanIteratorFunctions), $"Failed to complete push iteration; numRecords = {scanIteratorFunctions.numRecords}");
 
                 Assert.AreEqual(expectedRecs, scanIteratorFunctions.numRecords);
             }
 
+            // Initial population
             for (int i = 0; i < totalRecords; i++)
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = i };
-                session.Upsert(ref key1, ref value, 0);
+                session.Upsert(ref key1, ref value);
             }
-
             iterateAndVerify(1, totalRecords);
 
             for (int i = 0; i < totalRecords; i++)
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = 2 * i };
-                session.Upsert(ref key1, ref value, 0);
+                session.Upsert(ref key1, ref value);
             }
-
             iterateAndVerify(2, totalRecords);
 
             for (int i = totalRecords / 2; i < totalRecords; i++)
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = i };
-                session.Upsert(ref key1, ref value, 0);
+                session.Upsert(ref key1, ref value);
             }
-
             iterateAndVerify(0, totalRecords);
 
             for (int i = 0; i < totalRecords; i += 2)
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = i };
-                session.Upsert(ref key1, ref value, 0);
+                session.Upsert(ref key1, ref value);
             }
-
             iterateAndVerify(0, totalRecords);
 
             for (int i = 0; i < totalRecords; i += 2)
             {
                 var key1 = new MyKey { key = i };
-                var value = new MyValue { value = i };
-                session.Delete(ref key1, 0);
+                session.Delete(ref key1);
             }
-
             iterateAndVerify(0, totalRecords / 2);
 
             for (int i = 0; i < totalRecords; i++)
             {
                 var key1 = new MyKey { key = i };
                 var value = new MyValue { value = 3 * i };
-                session.Upsert(ref key1, ref value, 0);
+                session.Upsert(ref key1, ref value);
+            }
+            iterateAndVerify(3, totalRecords);
+
+            fht.Log.FlushAndEvict(wait: true);
+            iterateAndVerify(3, totalRecords);
+        }
+
+        [Test]
+        [Category(FasterKVTestCategory)]
+        [Category(SmokeTestCategory)]
+
+        public void GenericIterationPushStopTest()
+        {
+            InternalSetup(ScanIteratorType.Push, largeMemory: false);
+            GenericPushIterationTestFunctions scanIteratorFunctions = new();
+
+            const int totalRecords = 2000;
+            var start = fht.Log.TailAddress;
+
+            void scanAndVerify(int stopAt, bool useScan)
+            {
+                scanIteratorFunctions.numRecords = 0;
+                scanIteratorFunctions.stopAt = stopAt;
+                if (useScan)
+                    Assert.IsFalse(fht.Log.Scan(ref scanIteratorFunctions, start, fht.Log.TailAddress), $"Failed to terminate push iteration early; numRecords = {scanIteratorFunctions.numRecords}");
+                else
+                    Assert.IsFalse(session.Iterate(ref scanIteratorFunctions), $"Failed to terminate push iteration early; numRecords = {scanIteratorFunctions.numRecords}");
+                Assert.AreEqual(stopAt, scanIteratorFunctions.numRecords);
             }
 
-            iterateAndVerify(3, totalRecords);
+            // Initial population
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var key1 = new MyKey { key = i };
+                var value = new MyValue { value = i };
+                session.Upsert(ref key1, ref value);
+            }
+
+            scanAndVerify(42, useScan: true);
+            scanAndVerify(42, useScan: false);
+        }
+
+        [Test]
+        [Category(FasterKVTestCategory)]
+        [Category(SmokeTestCategory)]
+        public unsafe void GenericIterationPushLockTest([Values(1, 4)] int scanThreads, [Values(1, 4)] int updateThreads, [Values] LockingMode lockingMode, [Values] ScanMode scanMode)
+        {
+            InternalSetup(lockingMode, largeMemory: true);
+
+            const int totalRecords = 2000;
+            var start = fht.Log.TailAddress;
+
+            void LocalScan(int i)
+            {
+                using var session = fht.For(new MyFunctionsDelete()).NewSession<MyFunctionsDelete>();
+                GenericPushIterationTestFunctions scanIteratorFunctions = new();
+
+                if (scanMode == ScanMode.Scan)
+                    Assert.IsTrue(fht.Log.Scan(ref scanIteratorFunctions, start, fht.Log.TailAddress), $"Failed to complete push scan; numRecords = {scanIteratorFunctions.numRecords}");
+                else
+                    Assert.IsTrue(session.Iterate(ref scanIteratorFunctions), $"Failed to complete push iteration; numRecords = {scanIteratorFunctions.numRecords}");
+                Assert.AreEqual(totalRecords, scanIteratorFunctions.numRecords);
+            }
+
+            void LocalUpdate(int tid)
+            {
+                using var session = fht.For(new MyFunctionsDelete()).NewSession<MyFunctionsDelete>();
+                for (int i = 0; i < totalRecords; i++)
+                {
+                    var key1 = new MyKey { key = i };
+                    var value = new MyValue { value = (tid + 1) * i };
+                    session.Upsert(ref key1, ref value);
+                }
+            }
+
+            { // Initial population
+                for (int i = 0; i < totalRecords; i++)
+                {
+                    var key1 = new MyKey { key = i };
+                    var value = new MyValue { value = i };
+                    session.Upsert(ref key1, ref value);
+                }
+            }
+
+            List<Task> tasks = new();   // Task rather than Thread for propagation of exception.
+            var numThreads = scanThreads + updateThreads;
+            for (int t = 0; t < numThreads; t++)
+            {
+                var tid = t;
+                if (t < scanThreads)
+                    tasks.Add(Task.Factory.StartNew(() => LocalScan(tid)));
+                else
+                    tasks.Add(Task.Factory.StartNew(() => LocalUpdate(tid)));
+            }
+            Task.WaitAll(tasks.ToArray());
         }
     }
 }

--- a/cs/test/GenericIterationTests.cs
+++ b/cs/test/GenericIterationTests.cs
@@ -68,10 +68,10 @@ namespace FASTER.test
 
             public bool OnStart(long beginAddress, long endAddress) => true;
 
-            public bool ConcurrentReader(ref MyKey key, ref MyValue value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress)
-                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords, nextAddress);
+            public bool ConcurrentReader(ref MyKey key, ref MyValue value, RecordMetadata recordMetadata, long numberOfRecords)
+                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords);
 
-            public bool SingleReader(ref MyKey key, ref MyValue value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress)
+            public bool SingleReader(ref MyKey key, ref MyValue value, RecordMetadata recordMetadata, long numberOfRecords)
             {
                 if (keyMultToValue > 0)
                     Assert.AreEqual(key.key * keyMultToValue, value.value);
@@ -104,7 +104,7 @@ namespace FASTER.test
                 {
                     using var iter = session.Iterate();
                     while (iter.GetNext(out var recordInfo))
-                        scanIteratorFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), default, default, default);
+                        scanIteratorFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), default, default);
                 }
                 else
                     Assert.IsTrue(session.Iterate(ref scanIteratorFunctions), $"Failed to complete push iteration; numRecords = {scanIteratorFunctions.numRecords}");

--- a/cs/test/GenericLogScanTests.cs
+++ b/cs/test/GenericLogScanTests.cs
@@ -71,7 +71,8 @@ namespace FASTER.test
             objlog = CreateTestDevice(deviceType, $"{path}DiskWriteScanBasicTest_{deviceType}.obj.log");
             fht = new (128,
                       logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 15, PageSizeBits = 9, SegmentSizeBits = 22 },
-                      serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() }
+                      serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() },
+                      lockingMode: scanIteratorType == ScanIteratorType.Pull ? LockingMode.None : LockingMode.Standard
                       );
 
             using var session = fht.For(new MyFunctions()).NewSession<MyFunctions>();

--- a/cs/test/GenericLogScanTests.cs
+++ b/cs/test/GenericLogScanTests.cs
@@ -45,10 +45,10 @@ namespace FASTER.test
 
             public bool OnStart(long beginAddress, long endAddress) => true;
 
-            public bool ConcurrentReader(ref MyKey key, ref MyValue value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress)
-                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords, nextAddress);
+            public bool ConcurrentReader(ref MyKey key, ref MyValue value, RecordMetadata recordMetadata, long numberOfRecords)
+                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords);
 
-            public bool SingleReader(ref MyKey key, ref MyValue value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress)
+            public bool SingleReader(ref MyKey key, ref MyValue value, RecordMetadata recordMetadata, long numberOfRecords)
             {
                 Assert.AreEqual(numRecords, key.key, $"log scan 1: key");
                 Assert.AreEqual(numRecords, value.value, $"log scan 1: value");
@@ -99,7 +99,7 @@ namespace FASTER.test
                 {
                     using var iter = fht.Log.Scan(start, fht.Log.TailAddress, sbm);
                     while (iter.GetNext(out var recordInfo))
-                        scanIteratorFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), default, default, default);
+                        scanIteratorFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), default, default);
                 }
                 else
                     Assert.IsTrue(fht.Log.Scan(ref scanIteratorFunctions, start, fht.Log.TailAddress, sbm), "Failed to complete push iteration");

--- a/cs/test/MiscFASTERTests.cs
+++ b/cs/test/MiscFASTERTests.cs
@@ -112,7 +112,7 @@ namespace FASTER.test
             {
                 log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/hlog1.log", deleteOnClose: true);
                 using var fht = new FasterKV<KeyStruct, ValueStruct>
-                    (128, new LogSettings { LogDevice = log, MemorySizeBits = 29 });
+                    (128, new LogSettings { LogDevice = log, MemorySizeBits = 29 }, lockingMode: LockingMode.None);
                 using var session = fht.NewSession(copyOnWrite);
 
                 var key = default(KeyStruct);

--- a/cs/test/TestUtils.cs
+++ b/cs/test/TestUtils.cs
@@ -19,6 +19,7 @@ namespace FASTER.test
         internal const string SmokeTestCategory = "Smoke";
         internal const string StressTestCategory = "Stress";
         internal const string FasterKVTestCategory = "FasterKV";
+        internal const string ReadTestCategory = "Read";
         internal const string LockableUnsafeContextTestCategory = "LockableUnsafeContext";
         internal const string ReadCacheTestCategory = "ReadCache";
         internal const string LockTestCategory = "Locking";

--- a/cs/test/TestUtils.cs
+++ b/cs/test/TestUtils.cs
@@ -208,6 +208,8 @@ namespace FASTER.test
 
         public enum ScanIteratorType { Pull, Push };
 
+        public enum ScanMode { Scan, Iterate };
+
         internal static (Status status, TOutput output) GetSinglePendingResult<TKey, TValue, TInput, TOutput, TContext>(CompletedOutputIterator<TKey, TValue, TInput, TOutput, TContext> completedOutputs)
             => GetSinglePendingResult(completedOutputs, out _);
 

--- a/cs/test/VarLenBlittableIterationTests.cs
+++ b/cs/test/VarLenBlittableIterationTests.cs
@@ -48,10 +48,10 @@ namespace FASTER.test
 
             public bool OnStart(long beginAddress, long endAddress) => true;
 
-            public bool ConcurrentReader(ref Key key, ref VLValue value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress)
-                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords, nextAddress);
+            public bool ConcurrentReader(ref Key key, ref VLValue value, RecordMetadata recordMetadata, long numberOfRecords)
+                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords);
 
-            public bool SingleReader(ref Key key, ref VLValue value, RecordMetadata recordMetadata, long numberOfRecords, long nextAddress)
+            public bool SingleReader(ref Key key, ref VLValue value, RecordMetadata recordMetadata, long numberOfRecords)
             {
                 if (keyMultToValue > 0)
                     Assert.AreEqual(key.key * keyMultToValue, value.field1);
@@ -88,7 +88,7 @@ namespace FASTER.test
                 {
                     using var iter = session.Iterate();
                     while (iter.GetNext(out var recordInfo))
-                        scanIteratorFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), default, default, default);
+                        scanIteratorFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), default, default);
                 }
                 else
                     Assert.IsTrue(session.Iterate(ref scanIteratorFunctions), $"Failed to complete push iteration; numRecords = {scanIteratorFunctions.numRecords}");

--- a/cs/test/VarLenBlittableIterationTests.cs
+++ b/cs/test/VarLenBlittableIterationTests.cs
@@ -4,6 +4,9 @@
 using FASTER.core;
 using NUnit.Framework;
 using System;
+using static FASTER.test.BlittableIterationTests;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using static FASTER.test.TestUtils;
 
 namespace FASTER.test
@@ -14,6 +17,9 @@ namespace FASTER.test
         private FasterKV<Key, VLValue> fht;
         private IDevice log;
         private string path;
+
+        // Note: We always set value.length to 2, which includes both VLValue members; we are not exercising the "Variable Length" aspect here.
+        private const int ValueLength = 2;
 
         [SetUp]
         public void Setup()
@@ -38,6 +44,7 @@ namespace FASTER.test
         {
             internal int keyMultToValue;
             internal long numRecords;
+            internal int stopAt;
 
             public bool OnStart(long beginAddress, long endAddress) => true;
 
@@ -48,9 +55,7 @@ namespace FASTER.test
             {
                 if (keyMultToValue > 0)
                     Assert.AreEqual(key.key * keyMultToValue, value.field1);
-
-                ++numRecords;
-                return true;
+                return stopAt != ++numRecords;
             }
 
             public void OnException(Exception exception, long numberOfRecords) { }
@@ -59,14 +64,14 @@ namespace FASTER.test
         }
 
         [Test]
-        [Category("FasterKV")]
-        [Category("Smoke")]
+        [Category(FasterKVTestCategory)]
+        [Category(SmokeTestCategory)]
         public void VarLenBlittableIterationBasicTest([Values] DeviceType deviceType, [Values] ScanIteratorType scanIteratorType)
         {
-            string filename = path + "VarLenBlittableIterationTest1" + deviceType.ToString() + ".log";
-            log = CreateTestDevice(deviceType, filename);
+            log = CreateTestDevice(deviceType, $"{path}{deviceType}.log");
             fht = new FasterKV<Key, VLValue>
-                 (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 9, SegmentSizeBits = 22 });
+                 (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 9, SegmentSizeBits = 22 },
+                 lockingMode: scanIteratorType == ScanIteratorType.Pull ? LockingMode.None : LockingMode.Standard);
 
             using var session = fht.NewSession(new VLFunctions());
             VarLenBlittablePushIterationTestFunctions scanIteratorFunctions = new();
@@ -86,66 +91,159 @@ namespace FASTER.test
                         scanIteratorFunctions.SingleReader(ref iter.GetKey(), ref iter.GetValue(), default, default, default);
                 }
                 else
-                    Assert.IsTrue(session.Iterate(ref scanIteratorFunctions), "Failed to complete push iteration");
+                    Assert.IsTrue(session.Iterate(ref scanIteratorFunctions), $"Failed to complete push iteration; numRecords = {scanIteratorFunctions.numRecords}");
 
                 Assert.AreEqual(expectedRecs, scanIteratorFunctions.numRecords);
             }
 
             // Note: We always set value.length to 2, which includes both VLValue members; we are not exercising the "Variable Length" aspect here.
 
+            // Initial population
             for (int i = 0; i < totalRecords; i++)
             {
                 var key1 = new Key { key = i };
-                var value = new VLValue { field1 = i, length = 2 };
+                var value = new VLValue { field1 = i, length = ValueLength };
                 session.Upsert(ref key1, ref value);
             }
-
             iterateAndVerify(1, totalRecords);
 
             for (int i = 0; i < totalRecords; i++)
             {
                 var key1 = new Key { key = i };
-                var value = new VLValue { field1 = 2 * i, length = 2 };
+                var value = new VLValue { field1 = 2 * i, length = ValueLength };
                 session.Upsert(ref key1, ref value);
             }
-
             iterateAndVerify(2, totalRecords);
 
             for (int i = totalRecords / 2; i < totalRecords; i++)
             {
                 var key1 = new Key { key = i };
-                var value = new VLValue { field1 = i, length = 2 };
+                var value = new VLValue { field1 = i, length = ValueLength };
                 session.Upsert(ref key1, ref value);
             }
-
             iterateAndVerify(0, totalRecords);
 
             for (int i = 0; i < totalRecords; i += 2)
             {
                 var key1 = new Key { key = i };
-                var value = new VLValue { field1 = i, length = 2 };
+                var value = new VLValue { field1 = i, length = ValueLength };
                 session.Upsert(ref key1, ref value);
             }
-
             iterateAndVerify(0, totalRecords);
 
             for (int i = 0; i < totalRecords; i += 2)
             {
                 var key1 = new Key { key = i };
-                var value = new VLValue { field1 = i, length = 2 };
                 session.Delete(ref key1);
             }
-
             iterateAndVerify(0, totalRecords / 2);
 
             for (int i = 0; i < totalRecords; i++)
             {
                 var key1 = new Key { key = i };
-                var value = new VLValue { field1 = 3 * i, length = 2 };
+                var value = new VLValue { field1 = 3 * i, length = ValueLength };
+                session.Upsert(ref key1, ref value);
+            }
+            iterateAndVerify(3, totalRecords);
+
+            fht.Log.FlushAndEvict(wait: true);
+            iterateAndVerify(3, totalRecords);
+        }
+
+        [Test]
+        [Category(FasterKVTestCategory)]
+        [Category(SmokeTestCategory)]
+        public void VarLenBlittableIterationPushStopTest([Values] DeviceType deviceType, [Values] ScanIteratorType scanIteratorType)
+        {
+            log = CreateTestDevice(deviceType, $"{path}{deviceType}.log");
+            fht = new FasterKV<Key, VLValue>
+                 (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 15, PageSizeBits = 9, SegmentSizeBits = 22 });
+
+            using var session = fht.NewSession(new VLFunctions());
+            VarLenBlittablePushIterationTestFunctions scanIteratorFunctions = new();
+
+            const int totalRecords = 2000;
+            var start = fht.Log.TailAddress;
+
+            void scanAndVerify(int stopAt, bool useScan)
+            {
+                scanIteratorFunctions.numRecords = 0;
+                scanIteratorFunctions.stopAt = stopAt;
+                if (useScan)
+                    Assert.IsFalse(fht.Log.Scan(ref scanIteratorFunctions, start, fht.Log.TailAddress), $"Failed to terminate push iteration early; numRecords = {scanIteratorFunctions.numRecords}");
+                else
+                    Assert.IsFalse(session.Iterate(ref scanIteratorFunctions), $"Failed to terminate push iteration early; numRecords = {scanIteratorFunctions.numRecords}");
+                Assert.AreEqual(stopAt, scanIteratorFunctions.numRecords);
+            }
+
+            // Initial population
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var key1 = new Key { key = i };
+                var value = new VLValue { field1 = i, length = ValueLength };
                 session.Upsert(ref key1, ref value);
             }
 
-            iterateAndVerify(3, totalRecords);
+            scanAndVerify(42, useScan: true);
+            scanAndVerify(42, useScan: false);
+        }
+
+        [Test]
+        [Category(FasterKVTestCategory)]
+        [Category(SmokeTestCategory)]
+        public unsafe void VarLenBlittableIterationPushLockTest([Values(1, 4)] int scanThreads, [Values(1, 4)] int updateThreads, [Values] LockingMode lockingMode, [Values] ScanMode scanMode)
+        {
+            log = Devices.CreateLogDevice($"{path}lock_test.log");
+            fht = new FasterKV<Key, VLValue>
+                 // Must be large enough to contain all records in memory to exercise locking
+                 (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 25, PageSizeBits = 19, SegmentSizeBits = 22 });
+
+            const int totalRecords = 2000;
+            var start = fht.Log.TailAddress;
+
+            void LocalScan(int i)
+            {
+                using var session = fht.NewSession(new VLFunctions());
+                VarLenBlittablePushIterationTestFunctions scanIteratorFunctions = new();
+                if (scanMode == ScanMode.Scan)
+                    Assert.IsTrue(fht.Log.Scan(ref scanIteratorFunctions, start, fht.Log.TailAddress), $"Failed to complete push scan; numRecords = {scanIteratorFunctions.numRecords}");
+                else
+                    Assert.IsTrue(session.Iterate(ref scanIteratorFunctions), $"Failed to complete push iteration; numRecords = {scanIteratorFunctions.numRecords}");
+                Assert.AreEqual(totalRecords, scanIteratorFunctions.numRecords);
+            }
+
+            void LocalUpdate(int tid)
+            {
+                using var session = fht.NewSession(new VLFunctions());
+                for (int i = 0; i < totalRecords; i++)
+                {
+                    var key1 = new Key { key = i };
+                    var value = new VLValue { field1 = (tid + 1) * i, length = ValueLength };
+                    session.Upsert(ref key1, ref value);
+                }
+            }
+
+            { // Initial population
+                using var session = fht.NewSession(new VLFunctions());
+                for (int i = 0; i < totalRecords; i++)
+                {
+                    var key1 = new Key { key = i };
+                    var value = new VLValue { field1 = i, length = ValueLength };
+                    session.Upsert(ref key1, ref value);
+                }
+            }
+
+            List<Task> tasks = new();   // Task rather than Thread for propagation of exception.
+            var numThreads = scanThreads + updateThreads;
+            for (int t = 0; t < numThreads; t++)
+            {
+                var tid = t;
+                if (t < scanThreads)
+                    tasks.Add(Task.Factory.StartNew(() => LocalScan(tid)));
+                else
+                    tasks.Add(Task.Factory.StartNew(() => LocalUpdate(tid)));
+            }
+            Task.WaitAll(tasks.ToArray());
         }
     }
 }

--- a/cs/test/VariableLengthIteratorTests.cs
+++ b/cs/test/VariableLengthIteratorTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 namespace FASTER.test
 {
     [TestFixture]
-    public class IteratorTests
+    public class VariableLengthIteratorTests
     {
         [Test]
         [Category("FasterKV")]
@@ -23,8 +23,8 @@ namespace FASTER.test
             var fht = new FasterKV<Key, VLValue>
                 (128,
                 new LogSettings { LogDevice = log, MemorySizeBits = 17, PageSizeBits = 10 }, // 1KB page
-                null, null, null, new VariableLengthStructSettings<Key, VLValue> { valueLength = vlLength }
-                );
+                null, null, null, new VariableLengthStructSettings<Key, VLValue> { valueLength = vlLength },
+                lockingMode: LockingMode.None);
 
             var session = fht.NewSession(new VLFunctions());
 


### PR DESCRIPTION
- Implement push-based scan/iteration: caller supplies IScanIterationFunctions which are called in a loop by FASTER. This allows FASTER to control key locking as needed.
- Limit pull-based scan/iteration (caller calls GetNext()) untilAddress to be below ReadOnlyAddress (due to locking requirements).
