### PR TITLE
Remove OutputPath from .csproj files

### DIFF
--- a/cs/benchmark/FASTER.benchmark.csproj
+++ b/cs/benchmark/FASTER.benchmark.csproj
@@ -21,13 +21,11 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\x64\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/playground/SumStore/SumStore.csproj
+++ b/cs/playground/SumStore/SumStore.csproj
@@ -18,13 +18,11 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\x64\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/remote/benchmark/FASTER.benchmark/FASTER.benchmark.csproj
+++ b/cs/remote/benchmark/FASTER.benchmark/FASTER.benchmark.csproj
@@ -11,13 +11,11 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
-    <OutputPath>bin\$(Platform)\Debug\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
-    <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/remote/samples/FixedLenClient/FixedLenClient.csproj
+++ b/cs/remote/samples/FixedLenClient/FixedLenClient.csproj
@@ -11,13 +11,11 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
-    <OutputPath>bin\$(Platform)\Debug\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
-    <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/remote/samples/FixedLenServer/FixedLenServer.csproj
+++ b/cs/remote/samples/FixedLenServer/FixedLenServer.csproj
@@ -12,13 +12,11 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
-    <OutputPath>bin\$(Platform)\Debug\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
-    <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/remote/samples/VarLenClient/VarLenClient.csproj
+++ b/cs/remote/samples/VarLenClient/VarLenClient.csproj
@@ -11,13 +11,11 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
-    <OutputPath>bin\$(Platform)\Debug\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
-    <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/remote/samples/VarLenServer/VarLenServer.csproj
+++ b/cs/remote/samples/VarLenServer/VarLenServer.csproj
@@ -12,13 +12,11 @@
 	<PropertyGroup Condition="'$(Configuration)' == 'Debug'">
 		<DefineConstants>TRACE;DEBUG</DefineConstants>
 		<DebugType>full</DebugType>
-		<OutputPath>bin\$(Platform)\Debug\</OutputPath>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
 		<DefineConstants>TRACE</DefineConstants>
 		<Optimize>true</Optimize>
-		<OutputPath>bin\$(Platform)\Release\</OutputPath>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/cs/remote/src/FASTER.client/FASTER.client.csproj
+++ b/cs/remote/src/FASTER.client/FASTER.client.csproj
@@ -18,13 +18,11 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>DEBUG</DefineConstants>
     <DebugType>full</DebugType>
-    <OutputPath>bin\$(Platform)\Debug\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants></DefineConstants>
     <Optimize>true</Optimize>
-    <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">

--- a/cs/remote/src/FASTER.common/FASTER.common.csproj
+++ b/cs/remote/src/FASTER.common/FASTER.common.csproj
@@ -18,13 +18,11 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>DEBUG</DefineConstants>
     <DebugType>full</DebugType>
-    <OutputPath>bin\$(Platform)\Debug\</OutputPath>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants></DefineConstants>
     <Optimize>true</Optimize>
-    <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/remote/src/FASTER.server/FASTER.server.csproj
+++ b/cs/remote/src/FASTER.server/FASTER.server.csproj
@@ -18,13 +18,11 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>DEBUG</DefineConstants>
     <DebugType>full</DebugType>
-    <OutputPath>bin\$(Platform)\Debug\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants></DefineConstants>
     <Optimize>true</Optimize>
-    <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/remote/test/FASTER.remote.test/FASTER.remote.test.csproj
+++ b/cs/remote/test/FASTER.remote.test/FASTER.remote.test.csproj
@@ -27,14 +27,12 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
-    <OutputPath>bin\$(Platform)\Debug\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/cs/samples/AzureBackedStore/AzureBackedStore.csproj
+++ b/cs/samples/AzureBackedStore/AzureBackedStore.csproj
@@ -18,13 +18,11 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\x64\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Generated\**" />

--- a/cs/samples/FasterLogPubSub/FasterLogPubSub.csproj
+++ b/cs/samples/FasterLogPubSub/FasterLogPubSub.csproj
@@ -18,13 +18,11 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\x64\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/samples/FasterLogSample/FasterLogSample.csproj
+++ b/cs/samples/FasterLogSample/FasterLogSample.csproj
@@ -18,13 +18,11 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\x64\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/samples/HelloWorld/HelloWorld.csproj
+++ b/cs/samples/HelloWorld/HelloWorld.csproj
@@ -18,13 +18,11 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\x64\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/samples/StoreAsyncApi/StoreAsyncApi.csproj
+++ b/cs/samples/StoreAsyncApi/StoreAsyncApi.csproj
@@ -18,13 +18,11 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\x64\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/samples/StoreCheckpointRecover/StoreCheckpointRecover.csproj
+++ b/cs/samples/StoreCheckpointRecover/StoreCheckpointRecover.csproj
@@ -18,13 +18,11 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\x64\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Generated\**" />

--- a/cs/samples/StoreCustomTypes/StoreCustomTypes.csproj
+++ b/cs/samples/StoreCustomTypes/StoreCustomTypes.csproj
@@ -18,13 +18,11 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\x64\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Generated\**" />

--- a/cs/samples/StoreDiskReadBenchmark/StoreDiskReadBenchmark.csproj
+++ b/cs/samples/StoreDiskReadBenchmark/StoreDiskReadBenchmark.csproj
@@ -18,13 +18,11 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\x64\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/samples/StoreVarLenTypes/StoreVarLenTypes.csproj
+++ b/cs/samples/StoreVarLenTypes/StoreVarLenTypes.csproj
@@ -18,13 +18,11 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\x64\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cs/src/core/FASTER.core.csproj
+++ b/cs/src/core/FASTER.core.csproj
@@ -27,13 +27,11 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>DEBUG</DefineConstants>
     <DebugType>full</DebugType>
-    <OutputPath>bin\$(Platform)\Debug\</OutputPath>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants></DefineConstants>
     <Optimize>true</Optimize>
-    <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'&#xD;&#xA;				 Or '$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0|AnyCPU'">

--- a/cs/src/devices/AzureStorageDevice/FASTER.devices.AzureStorageDevice.csproj
+++ b/cs/src/devices/AzureStorageDevice/FASTER.devices.AzureStorageDevice.csproj
@@ -27,13 +27,11 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
-    <OutputPath>bin\$(Platform)\Debug\</OutputPath>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
-    <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/cs/test/FASTER.test.csproj
+++ b/cs/test/FASTER.test.csproj
@@ -27,14 +27,12 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
-    <OutputPath>bin\$(Platform)\Debug\</OutputPath>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\$(Platform)\Release\</OutputPath>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
Remove the OutputPath element in .csproj files so they can be specified elsewhere.