### PR TITLE
[C#] Fix Infinite loop on EmptyPageCount in CacheSizeTracker

### DIFF
--- a/cs/samples/ResizableCacheStore/LogSizeTracker.cs
+++ b/cs/samples/ResizableCacheStore/LogSizeTracker.cs
@@ -86,7 +86,7 @@ namespace ResizableCacheStore
             const long Delta = 1L << 15;
             if (TotalSizeBytes > TargetSizeBytes + Delta)
             {
-                while (TotalSizeBytes > TargetSizeBytes + Delta)
+                while (TotalSizeBytes > TargetSizeBytes + Delta && Log.EmptyPageCount < Log.MaxEmptyPageCount)
                 {
                     if (Log.AllocatedPageCount > Log.BufferSize - Log.EmptyPageCount + 1)
                     {
@@ -99,7 +99,7 @@ namespace ResizableCacheStore
             }
             else if (TotalSizeBytes < TargetSizeBytes - Delta)
             {
-                while (TotalSizeBytes < TargetSizeBytes - Delta)
+                while (TotalSizeBytes < TargetSizeBytes - Delta && Log.EmptyPageCount > 0)
                 {
                     if (Log.AllocatedPageCount < Log.BufferSize - Log.EmptyPageCount - 1)
                     {

--- a/cs/src/core/Allocator/AllocatorBase.cs
+++ b/cs/src/core/Allocator/AllocatorBase.cs
@@ -1199,6 +1199,11 @@ namespace FASTER.core
         public int AllocatedPageCount;
 
         /// <summary>
+        /// Maximum possible number of empty pages in circular buffer
+        /// </summary>
+        public int MaxEmptyPageCount => BufferSize - 1;
+
+        /// <summary>
         /// How many pages do we leave empty in the in-memory buffer (between 0 and BufferSize-1)
         /// </summary>
         public int EmptyPageCount
@@ -1208,7 +1213,7 @@ namespace FASTER.core
             set
             {
                 // HeadOffset lag (from tail).
-                var headOffsetLagSize = BufferSize - 1;
+                var headOffsetLagSize = MaxEmptyPageCount;
                 if (value > headOffsetLagSize) return;
                 if (value < 0) return;
 

--- a/cs/src/core/Index/FASTER/Implementation/ConditionalCopyToTail.cs
+++ b/cs/src/core/Index/FASTER/Implementation/ConditionalCopyToTail.cs
@@ -12,9 +12,11 @@ namespace FASTER.core
         private OperationStatus ConditionalCopyToTail<Input, Output, Context, FasterSession>(FasterSession fasterSession,
                 ref PendingContext<Input, Output, Context> pendingContext,
                 ref Key key, ref Input input, ref Value value, ref Output output, ref Context userContext, long lsn,
-                ref OperationStackContext<Key, Value> stackCtx, WriteReason writeReason, bool callerHasLock = false)
+                ref OperationStackContext<Key, Value> stackCtx, WriteReason writeReason, bool wantIO = true)
             where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
         {
+            bool callerHasLock = stackCtx.recSrc.HasTransientLock;
+
             // We are called by one of ReadFromImmutable, CompactionConditionalCopyToTail, or ContinueConditionalCopyToTail, and stackCtx is set up for the first try.
             // minAddress is the stackCtx.recSrc.LatestLogicalAddress; by the time we get here, any IO below that has been done due to PrepareConditionalCopyToTailIO,
             // which then went to ContinueConditionalCopyToTail, which evaluated whether the record was found at that level.
@@ -36,20 +38,29 @@ namespace FASTER.core
                             TransientSUnlock<Input, Output, Context, FasterSession>(fasterSession, ref key, ref stackCtx);
                     }
                 }
+
+                // We're here we failed TryCopyToTail, probably a failed CAS due to another record insertion.
                 if (!HandleImmediateRetryStatus(status, fasterSession, ref pendingContext))
                     return status;
 
-                // Failed TryCopyToTail, probably a failed CAS due to another record insertion. Re-traverse from the tail to the highest point we just searched
-                // (which may have gone below HeadAddress). +1 to LatestLogicalAddress because we have examined that already.
+                // HandleImmediateRetryStatus may have been refreshed the epoch which means HeadAddress etc. may have changed. Re-traverse from the tail to the highest
+                // point we just searched (which may have gone below HeadAddress). +1 to LatestLogicalAddress because we have examined that already. Use stackCtx2 to
+                // preserve stacKCtx, both for retrying the Insert if needed and for preserving the caller's lock status, etc.
                 var minAddress = stackCtx.recSrc.LatestLogicalAddress + 1;
-                stackCtx = new(stackCtx.hei.hash);
-                if (TryFindRecordInMainLogForConditionalCopyToTail(ref key, ref stackCtx, minAddress, out bool needIO))
+                OperationStackContext<Key, Value> stackCtx2 = new(stackCtx.hei.hash);
+                if (TryFindRecordInMainLogForConditionalCopyToTail(ref key, ref stackCtx2, minAddress, out bool needIO))
                     return OperationStatus.SUCCESS;
 
-                // Issue IO if necessary, else loop back up and retry the insert.
-                if (needIO)
+                // Issue IO if necessary and desired (for ReadFromImmutable, it isn't; just exit in that case), else loop back up and retry the insert.
+                if (!wantIO)
+                {
+                    // Caller (e.g. ReadFromImmutable) called this to keep read-hot records in memory. That's already failed, so give up and we'll read it when we have to.
+                    if (stackCtx.recSrc.LogicalAddress < hlog.HeadAddress)
+                        return OperationStatus.SUCCESS;
+                }
+                else if (needIO)
                     return PrepareIOForConditionalCopyToTail(fasterSession, ref pendingContext, ref key, ref input, ref value, ref output, ref userContext, lsn,
-                                                      ref stackCtx, minAddress, WriteReason.Compaction);
+                                                      ref stackCtx2, minAddress, WriteReason.Compaction);
             }
         }
 

--- a/cs/src/core/Index/FASTER/Implementation/ContinuePending.cs
+++ b/cs/src/core/Index/FASTER/Implementation/ContinuePending.cs
@@ -114,7 +114,7 @@ namespace FASTER.core
                         {
                             if (pendingContext.readCopyOptions.CopyTo == ReadCopyTo.MainLog)
                                 status = ConditionalCopyToTail(fasterSession, ref pendingContext, ref key, ref pendingContext.input.Get(), ref value, ref pendingContext.output,
-                                                               ref pendingContext.userContext, pendingContext.serialNum, ref stackCtx, WriteReason.CopyToTail, callerHasLock: true);
+                                                               ref pendingContext.userContext, pendingContext.serialNum, ref stackCtx, WriteReason.CopyToTail);
                             else if (pendingContext.readCopyOptions.CopyTo == ReadCopyTo.ReadCache && !stackCtx.recSrc.HasReadCacheSrc
                                     && TryCopyToReadCache(fasterSession, ref pendingContext, ref key, ref pendingContext.input.Get(), ref value, ref stackCtx))
                                 status |= OperationStatus.COPIED_RECORD_TO_READ_CACHE;

--- a/cs/src/core/Index/FASTER/Implementation/InternalRead.cs
+++ b/cs/src/core/Index/FASTER/Implementation/InternalRead.cs
@@ -287,7 +287,7 @@ namespace FASTER.core
                         return OperationStatus.SUCCESS;
                     if (pendingContext.readCopyOptions.CopyTo == ReadCopyTo.MainLog)
                         return ConditionalCopyToTail(fasterSession, ref pendingContext, ref key, ref input, ref recordValue, ref output, ref userContext, lsn, ref stackCtx,
-                                                     WriteReason.CopyToTail, callerHasLock: true);
+                                                     WriteReason.CopyToTail, wantIO: false);
                     if (pendingContext.readCopyOptions.CopyTo == ReadCopyTo.ReadCache
                             && TryCopyToReadCache(fasterSession, ref pendingContext, ref key, ref input, ref recordValue, ref stackCtx))
                         return OperationStatus.SUCCESS | OperationStatus.COPIED_RECORD_TO_READ_CACHE;

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -71,6 +71,11 @@ namespace FASTER.core
         }
 
         /// <summary>
+        /// Maximum possible number of empty pages in Allocator
+        /// </summary>
+        public int MaxEmptyPageCount => allocator.MaxEmptyPageCount;
+
+        /// <summary>
         /// Set empty page count in allocator
         /// </summary>
         /// <param name="pageCount">New empty page count</param>


### PR DESCRIPTION
Also make ConditionalCopyToTail check for headAddress if doing retry intstead of I/O