### PR TITLE
[C#] Fix Delete record elision

### DIFF
--- a/cs/src/core/Allocator/BlittableScanIterator.cs
+++ b/cs/src/core/Allocator/BlittableScanIterator.cs
@@ -93,10 +93,7 @@ namespace FASTER.core
                 var headAddress = hlog.HeadAddress;
 
                 if (currentAddress < hlog.BeginAddress && !forceInMemory)
-                {
-                    epoch?.Suspend();
-                    throw new FasterException("Iterator address is less than log BeginAddress " + hlog.BeginAddress);
-                }
+                    currentAddress = hlog.BeginAddress;
 
                 // If currentAddress < headAddress and we're not buffering and not guaranteeing the records are in memory, fail.
                 if (frameSize == 0 && currentAddress < headAddress && !forceInMemory)

--- a/cs/src/core/Allocator/GenericScanIterator.cs
+++ b/cs/src/core/Allocator/GenericScanIterator.cs
@@ -90,10 +90,7 @@ namespace FASTER.core
                 var headAddress = hlog.HeadAddress;
 
                 if (currentAddress < hlog.BeginAddress)
-                {
-                    epoch?.Suspend();
-                    throw new FasterException("Iterator address is less than log BeginAddress " + hlog.BeginAddress);
-                }
+                    currentAddress = hlog.BeginAddress;
 
                 // If currentAddress < headAddress and we're not buffering, fail.
                 if (frameSize == 0 && currentAddress < headAddress)

--- a/cs/src/core/Allocator/VarLenBlittableScanIterator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableScanIterator.cs
@@ -96,10 +96,7 @@ namespace FASTER.core
                 long headAddress = hlog.HeadAddress;
 
                 if (currentAddress < hlog.BeginAddress && !forceInMemory)
-                {
-                    epoch?.Suspend();
-                    throw new FasterException("Iterator address is less than log BeginAddress " + hlog.BeginAddress);
-                }
+                    currentAddress = hlog.BeginAddress;
 
                 // If currentAddress < headAddress and we're not buffering and not guaranteeing the records are in memory, fail.
                 if (frameSize == 0 && currentAddress < headAddress && !forceInMemory)

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
-using FASTER.core;
 using Microsoft.Extensions.Logging;
 
 namespace FASTER.core
@@ -251,18 +250,6 @@ namespace FASTER.core
             }
         }
 
-        public bool Pending
-        {
-            readonly get => (word & Constants.kPendingBitMask) != 0;
-            set
-            {
-                if (value)
-                    word |= Constants.kPendingBitMask;
-                else
-                    word &= ~Constants.kPendingBitMask;
-            }
-        }
-
         public bool Tentative
         {
             readonly get => (word & Constants.kTentativeBitMask) != 0;
@@ -291,7 +278,7 @@ namespace FASTER.core
         {
             var addrRC = this.ReadCache ? "(rc)" : string.Empty;
             static string bstr(bool value) => value ? "T" : "F";
-            return $"addr {this.AbsoluteAddress}{addrRC}, tag {Tag}, tent {bstr(Tentative)}, pend {bstr(Pending)}";
+            return $"addr {this.AbsoluteAddress}{addrRC}, tag {Tag}, tent {bstr(Tentative)}";
         }
     }
 
@@ -486,7 +473,6 @@ namespace FASTER.core
                 hei.entry = default;
                 hei.entry.Tag = hei.tag;
                 hei.entry.Address = Constants.kTempInvalidAddress;
-                hei.entry.Pending = false;
                 hei.entry.Tentative = true;
 
                 // Insert the tag into this slot. Failure means another session inserted a key into that slot, so continue the loop to find another free slot.

--- a/cs/src/core/Index/FASTER/Implementation/HashEntryInfo.cs
+++ b/cs/src/core/Index/FASTER/Implementation/HashEntryInfo.cs
@@ -86,7 +86,6 @@ namespace FASTER.core
             {
                 Tag = tag,
                 Address = newLogicalAddress & Constants.kAddressMask,
-                Pending = this.entry.Pending,
                 Tentative = false
                 // .ReadCache is included in newLogicalAddress
             };

--- a/cs/src/core/Index/FASTER/Implementation/InternalDelete.cs
+++ b/cs/src/core/Index/FASTER/Implementation/InternalDelete.cs
@@ -111,13 +111,12 @@ namespace FASTER.core
                         if (WriteDefaultOnDelete)
                             recordValue = default;
 
-                        // Try to update hash chain and completely elide record iff previous address points to invalid address, to avoid re-enabling a prior version of this record.
-                        if (stackCtx.hei.Address == stackCtx.recSrc.LogicalAddress && !fasterSession.IsManualLocking && srcRecordInfo.PreviousAddress < hlog.BeginAddress)
+                        // Try to update hash chain to elide record iff previous address points to invalid address, to avoid re-enabling a prior version of this record.
+                        if (stackCtx.hei.Address == stackCtx.recSrc.LogicalAddress && srcRecordInfo.PreviousAddress < hlog.BeginAddress)
                         {
                             // Ignore return value; this is a performance optimization to keep the hash table clean if we can, so if we fail it just means
-                            // the hashtable entry has already been updated by someone else.
-                            var address = (srcRecordInfo.PreviousAddress == Constants.kTempInvalidAddress) ? Constants.kInvalidAddress : srcRecordInfo.PreviousAddress;
-                            stackCtx.hei.TryCAS(address, tag: 0);
+                            // the hashtable entry has already been updated by someone else. Set the entry.word to zero.
+                            stackCtx.hei.TryCAS(Constants.kInvalidAddress, tag: 0);
                         }
 
                         status = OperationStatusUtils.AdvancedOpCode(OperationStatus.SUCCESS, StatusCode.InPlaceUpdatedRecord);

--- a/cs/src/core/Index/FASTER/Implementation/RecordSource.cs
+++ b/cs/src/core/Index/FASTER/Implementation/RecordSource.cs
@@ -30,7 +30,7 @@ namespace FASTER.core
         internal long PhysicalAddress;
 
         /// <summary>
-        /// The highest logical address (in the main log, i.e. below readcache) for this key; if we have a readcache prefix chain, this is the splice point.
+        /// The highest logical address in the main log (i.e. below readcache) for this key; if we have a readcache prefix chain, this is the splice point.
         /// </summary>
         internal long LatestLogicalAddress;
 

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -971,7 +971,6 @@ namespace FASTER.core
                     {
                         hei.entry.Address = pageLogicalAddress + pointer;
                         hei.entry.Tag = hei.tag;
-                        hei.entry.Pending = false;
                         hei.entry.Tentative = false;
                         hei.bucket->bucket_entries[hei.slot] = hei.entry.word;
                     }
@@ -983,7 +982,6 @@ namespace FASTER.core
                         {
                             hei.entry.Address = info.PreviousAddress;
                             hei.entry.Tag = hei.tag;
-                            hei.entry.Pending = false;
                             hei.entry.Tentative = false;
                             hei.bucket->bucket_entries[hei.slot] = hei.entry.word;
                         }

--- a/cs/test/GenericLogScanTests.cs
+++ b/cs/test/GenericLogScanTests.cs
@@ -134,5 +134,58 @@ namespace FASTER.test
                 }
             }
         }
+
+        [Test]
+        [Category("FasterKV")]
+        [Category("Smoke")]
+
+        public void BlittableScanJumpToBeginAddressTest()
+        {
+            log = Devices.CreateLogDevice($"{MethodTestDir}/test.log");
+            objlog = Devices.CreateLogDevice($"{MethodTestDir}/test.obj.log");
+            fht = new(128,
+                      logSettings: new LogSettings { LogDevice = log, ObjectLogDevice = objlog, MutableFraction = 0.1, MemorySizeBits = 20, PageSizeBits = 15, SegmentSizeBits = 18 },
+                      serializerSettings: new SerializerSettings<MyKey, MyValue> { keySerializer = () => new MyKeySerializer(), valueSerializer = () => new MyValueSerializer() },
+                      lockingMode: LockingMode.None);
+
+            using var session = fht.For(new MyFunctions()).NewSession<MyFunctions>();
+
+            const int numRecords = 200;
+            const int numTailRecords = 10;
+            long shiftBeginAddressTo = 0;
+            int shiftToKey = 0;
+            for (int i = 0; i < numRecords; i++)
+            {
+                if (i == numRecords - numTailRecords)
+                {
+                    shiftBeginAddressTo = fht.Log.TailAddress;
+                    shiftToKey = i;
+                }
+                var key = new MyKey { key = i };
+                var value = new MyValue { value = i };
+                session.Upsert(ref key, ref value, Empty.Default, 0);
+            }
+
+            using var iter = fht.Log.Scan(fht.Log.HeadAddress, fht.Log.TailAddress);
+
+            for (int i = 0; i < 100; ++i)
+            {
+                Assert.IsTrue(iter.GetNext(out var recordInfo));
+                Assert.AreEqual(i, iter.GetKey().key);
+                Assert.AreEqual(i, iter.GetValue().value);
+            }
+
+            fht.Log.ShiftBeginAddress(shiftBeginAddressTo);
+
+            for (int i = 0; i < numTailRecords; ++i)
+            {
+                Assert.IsTrue(iter.GetNext(out var recordInfo));
+                if (i == 0)
+                    Assert.AreEqual(fht.Log.BeginAddress, iter.CurrentAddress);
+                var expectedKey = numRecords - numTailRecords + i;
+                Assert.AreEqual(expectedKey, iter.GetKey().key);
+                Assert.AreEqual(expectedKey, iter.GetValue().value);
+            }
+        }
     }
 }

--- a/cs/test/RecoverContinueTests.cs
+++ b/cs/test/RecoverContinueTests.cs
@@ -8,7 +8,7 @@ using System.IO;
 using NUnit.Framework;
 using System.Threading.Tasks;
 
-namespace FASTER.test.recovery.sumstore.recover_continue
+namespace FASTER.test.recovery.sumstore.cntinue
 {
     [TestFixture]
     internal class RecoverContinueTests
@@ -24,7 +24,7 @@ namespace FASTER.test.recovery.sumstore.recover_continue
         public void Setup()
         {
             TestUtils.DeleteDirectory(TestUtils.MethodTestDir, wait: true);
-            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/RecoverContinueTests.log", deleteOnClose: true);
+            log = Devices.CreateLogDevice(TestUtils.MethodTestDir + "/test.log", deleteOnClose: true);
             checkpointDir = TestUtils.MethodTestDir + "/checkpoints3";
             Directory.CreateDirectory(checkpointDir);
 

--- a/cs/test/SpanByteLogScanTests.cs
+++ b/cs/test/SpanByteLogScanTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using FASTER.core;
+using NUnit.Framework;
+using System.Runtime.InteropServices;
+using System;
+using static FASTER.test.TestUtils;
+
+namespace FASTER.test
+{
+    [TestFixture]
+    internal class SpanByteLogScanTests
+    {
+        private FasterKV<SpanByte, SpanByte> fht;
+        private IDevice log;
+        const int numRecords = 200;
+
+        [SetUp]
+        public void Setup()
+        {
+            DeleteDirectory(MethodTestDir, wait: true);
+            log = Devices.CreateLogDevice(MethodTestDir + "/test.log", deleteOnClose: true);
+            fht = new FasterKV<SpanByte, SpanByte>
+                (1L << 20, new LogSettings { LogDevice = log, MemorySizeBits = 20, PageSizeBits = 15 }, lockingMode: LockingMode.None);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            fht?.Dispose();
+            fht = null;
+            log?.Dispose();
+            log = null;
+            DeleteDirectory(MethodTestDir);
+        }
+
+        [Test]
+        [Category("FasterKV")]
+        [Category("Smoke")]
+
+        public unsafe void BlittableScanJumpToBeginAddressTest()
+        {
+            using var session = fht.For(new SpanByteFunctions<Empty>()).NewSession<SpanByteFunctions<Empty>>();
+
+            const int numRecords = 200;
+            const int numTailRecords = 10;
+            long shiftBeginAddressTo = 0;
+            int shiftToKey = 0;
+            for (int i = 0; i < numRecords; i++)
+            {
+                if (i == numRecords - numTailRecords)
+                {
+                    shiftBeginAddressTo = fht.Log.TailAddress;
+                    shiftToKey = i;
+                }
+
+                var key = MemoryMarshal.Cast<char, byte>($"{i}".AsSpan());
+                var value = MemoryMarshal.Cast<char, byte>($"{i}".AsSpan());
+                session.Upsert(key, value);
+            }
+
+            using var iter = fht.Log.Scan(fht.Log.HeadAddress, fht.Log.TailAddress);
+
+            for (int i = 0; i < 100; ++i)
+            {
+                Assert.IsTrue(iter.GetNext(out var recordInfo));
+                Assert.AreEqual(i, int.Parse(MemoryMarshal.Cast<byte, char>(iter.GetKey().AsSpan())));
+                Assert.AreEqual(i, int.Parse(MemoryMarshal.Cast<byte, char>(iter.GetValue().AsSpan())));
+            }
+
+            fht.Log.ShiftBeginAddress(shiftBeginAddressTo);
+
+            for (int i = 0; i < numTailRecords; ++i)
+            {
+                Assert.IsTrue(iter.GetNext(out var recordInfo));
+                if (i == 0)
+                    Assert.AreEqual(fht.Log.BeginAddress, iter.CurrentAddress);
+                var expectedKey = numRecords - numTailRecords + i;
+                Assert.AreEqual(expectedKey, int.Parse(MemoryMarshal.Cast<byte, char>(iter.GetKey().AsSpan())));
+                Assert.AreEqual(expectedKey, int.Parse(MemoryMarshal.Cast<byte, char>(iter.GetValue().AsSpan())));
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Fix InternalDelete elision from HashBucketEntry (set entire word to 0)
- Fix iterators to jump ahead to BeginAddress if they're below it, rather than throw
- Remove unused HashBucketEntry.Pending
- Remove unnecessary ReadCacheEvictChain call in DetachAndReattachReadCacheChain