### PR TITLE
[C#] BumpCurrentEpoch calling threads must be protected

### DIFF
--- a/cs/src/core/Epochs/LightEpoch.cs
+++ b/cs/src/core/Epochs/LightEpoch.cs
@@ -225,6 +225,7 @@ namespace FASTER.core
         /// <returns></returns>
         long BumpCurrentEpoch()
         {
+            Debug.Assert(this.ThisInstanceProtected(), "BumpCurrentEpoch must be called on a protected thread");
             long nextEpoch = Interlocked.Increment(ref CurrentEpoch);
 
             if (drainCount > 0)

--- a/cs/src/core/Index/Synchronization/IndexResizeStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/IndexResizeStateMachine.cs
@@ -53,7 +53,18 @@ namespace FASTER.core
             switch (next.Phase)
             {
                 case Phase.PREPARE_GROW:
-                    faster.epoch.BumpCurrentEpoch(() => allThreadsInPrepareGrow = true);
+                    bool isProtected = faster.epoch.ThisInstanceProtected();
+                    if (!isProtected)
+                        faster.epoch.Resume();
+                    try
+                    {
+                        faster.epoch.BumpCurrentEpoch(() => allThreadsInPrepareGrow = true);
+                    }
+                    finally
+                    {
+                        if (!isProtected)
+                            faster.epoch.Suspend();
+                    }
                     break;
                 case Phase.IN_PROGRESS_GROW:
                 case Phase.REST:


### PR DESCRIPTION
- Ensure threads calling BumpCurrentEpoch are protected
- Back out change for shared bucket lock to wait for writer