### PR TITLE
patch bug in clearing of index bits during recovery

### DIFF
--- a/cs/src/core/Index/Recovery/IndexRecovery.cs
+++ b/cs/src/core/Index/Recovery/IndexRecovery.cs
@@ -164,18 +164,19 @@ namespace FASTER.core
 
             for (long bucket = 0; bucket < table_size_; ++bucket)
             {
-                HashBucket b = *(ptable_ + bucket);
+                HashBucket* b = ptable_ + bucket;
                 while (true)
                 {
                     for (int bucket_entry = 0; bucket_entry < Constants.kOverflowBucketIndex; ++bucket_entry)
                     {
-                        entry.word = b.bucket_entries[bucket_entry];
+                        entry.word = b->bucket_entries[bucket_entry];
                         if (entry.Tentative)
-                            b.bucket_entries[bucket_entry] = 0;
+                            b->bucket_entries[bucket_entry] = 0;
                     }
-
-                    if (b.bucket_entries[Constants.kOverflowBucketIndex] == 0) break;
-                    b = *((HashBucket*)overflowBucketsAllocator.GetPhysicalAddress((b.bucket_entries[Constants.kOverflowBucketIndex])));
+                    // Reset any ephemeral bucket level locks
+                    b->bucket_entries[Constants.kOverflowBucketIndex] &= Constants.kAddressMask;
+                    if (b->bucket_entries[Constants.kOverflowBucketIndex] == 0) break;
+                    b = (HashBucket*)overflowBucketsAllocator.GetPhysicalAddress(b->bucket_entries[Constants.kOverflowBucketIndex]);
                 }
             }
         }


### PR DESCRIPTION
This bug was already fixed in the latest release, but Netherite is still on an older release. 
We confirmed that this fix does resolve a hang we were able to repro after receiving details from this customer: 
https://github.com/Azure/azure-functions-durable-extension/issues/2603

The original fix is here: https://github.com/microsoft/FASTER/commit/a6c0dfa5f96dc0349987b3035e73fe90faddbfa4