### PR TITLE
allow reading v4 checkpoints for compatibility

### DIFF
--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -437,7 +437,9 @@ namespace FASTER.core
             string value = reader.ReadLine();
             var cversion = int.Parse(value);
 
-            if (cversion != CheckpointVersion)
+            bool translateV4toV5 = (cversion == 4 && CheckpointVersion == 5);
+
+            if (cversion != CheckpointVersion && !translateV4toV5)
                 throw new FasterException($"Invalid checkpoint version {cversion} encountered, current version is {CheckpointVersion}, cannot recover with this checkpoint");
 
             value = reader.ReadLine();
@@ -458,8 +460,15 @@ namespace FASTER.core
             value = reader.ReadLine();
             flushedLogicalAddress = long.Parse(value);
 
-            value = reader.ReadLine();
-            snapshotStartFlushedLogicalAddress = long.Parse(value);
+            if (!translateV4toV5)
+            {
+                value = reader.ReadLine();
+                snapshotStartFlushedLogicalAddress = long.Parse(value);
+            }
+            else
+            {
+                snapshotStartFlushedLogicalAddress = flushedLogicalAddress;
+            }
 
             value = reader.ReadLine();
             startLogicalAddress = long.Parse(value);


### PR DESCRIPTION
Based on our conversation and the changes in #838 it appears to me that it is relatively easy to remain compatible with the v4 checkpoint version by using the same value for `snapshotStartFlushedLogicalAddress` and `flushedLogicalAddress`.

If that is indeed the case, this PR should make it possible to load older checkpoints, thus not breaking storage compatibility.