### PR TITLE
Use Azure-Functions-compatible Microsoft.Extensions.Logging

### DIFF
--- a/cs/src/core/FASTER.core.csproj
+++ b/cs/src/core/FASTER.core.csproj
@@ -58,6 +58,11 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.26" />
 	  </ItemGroup>
 	</When>
+    <When Condition="'$(TargetFramework)' == 'net6.0'">
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+      </ItemGroup>
+    </When>
     <Otherwise>
 	  <ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />

--- a/cs/src/core/FASTER.core.nuspec
+++ b/cs/src/core/FASTER.core.nuspec
@@ -32,7 +32,7 @@
       <group targetFramework="net6.0">
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" />
         <dependency id="System.Interactive.Async" version="6.0.1" />
-		<dependency id="Microsoft.Extensions.Logging" version="7.0.0" />
+		<dependency id="Microsoft.Extensions.Logging" version="6.0.0" />
 	  </group>
       <group targetFramework="net7.0">
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" />


### PR DESCRIPTION
When using the net6.0 target of FASTER with Netherite on a Durable Functions host, it is not possible to load version 7.0.0 of Microsoft.Extensions.Logging.
 
To fix this we can add a condition in the project file which uses the 6.0.0 version when building the net6.0 target. 

For reference: we had this same problem for earlier versions and targets (see #717) and are adopting the same solution.  