### PR TITLE
Port the Unsafe.SizeOf Fixes from garnet

### DIFF
--- a/cs/src/core/Allocator/BlittableAllocator.cs
+++ b/cs/src/core/Allocator/BlittableAllocator.cs
@@ -24,10 +24,10 @@ namespace FASTER.core
         private readonly long* nativePointers;
 
         // Record sizes
-        private static readonly int recordSize = Utility.GetSize(default(Record<Key, Value>));
-        private static readonly int recordInfoSize = Utility.GetSize(default(RecordInfo));
-        private static readonly int keySize = Utility.GetSize(default(Key));
-        private static readonly int valueSize = Utility.GetSize(default(Value));
+        private static readonly int recordSize = Unsafe.SizeOf<Record<Key, Value>>();
+        private static readonly int recordInfoSize = Unsafe.SizeOf<RecordInfo>();
+        private static readonly int keySize = Unsafe.SizeOf<Key>();
+        private static readonly int valueSize = Unsafe.SizeOf<Value>();
 
         private readonly OverflowPool<PageUnit> overflowPagePool;
 

--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -34,7 +34,7 @@ namespace FASTER.core
         // Tail offsets per segment, in object log
         public readonly long[] segmentOffsets;
         // Record sizes
-        private static readonly int recordSize = Utility.GetSize(default(Record<Key, Value>));
+        private static readonly int recordSize = Unsafe.SizeOf<Record<Key, Value>>();
         private readonly SerializerSettings<Key, Value> SerializerSettings;
         private readonly bool keyBlittable = Utility.IsBlittable<Key>();
         private readonly bool valueBlittable = Utility.IsBlittable<Value>();

--- a/cs/src/core/Allocator/GenericFrame.cs
+++ b/cs/src/core/Allocator/GenericFrame.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace FASTER.core
 {
@@ -12,7 +13,7 @@ namespace FASTER.core
     {
         private readonly Record<Key, Value>[][] frame;
         public readonly int frameSize, pageSize;
-        private readonly int recordSize = Utility.GetSize(default(Record<Key, Value>));
+        private readonly int recordSize = Unsafe.SizeOf<Record<Key, Value>>();
 
         public GenericFrame(int frameSize, int pageSize)
         {

--- a/cs/src/core/Allocator/GenericFrame.cs
+++ b/cs/src/core/Allocator/GenericFrame.cs
@@ -13,7 +13,7 @@ namespace FASTER.core
     {
         private readonly Record<Key, Value>[][] frame;
         public readonly int frameSize, pageSize;
-        private readonly int recordSize = Unsafe.SizeOf<Record<Key, Value>>();
+        private static readonly int recordSize = Unsafe.SizeOf<Record<Key, Value>>();
 
         public GenericFrame(int frameSize, int pageSize)
         {

--- a/cs/src/core/Utilities/Utility.cs
+++ b/cs/src/core/Utilities/Utility.cs
@@ -27,18 +27,6 @@ namespace FASTER.core
     /// </summary>
     public static class Utility
     {
-        /// <summary>
-        /// Get size of type
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        internal static unsafe int GetSize<T>(this T value)
-        {
-            T[] arr = new T[2];
-            return (int)((long)Unsafe.AsPointer(ref arr[1]) - (long)Unsafe.AsPointer(ref arr[0]));
-        }
-
         internal static bool IsBlittableType(Type t)
         {
             var mi = typeof(Utility).GetMethod("IsBlittable", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.InvokeMethod);

--- a/cs/src/core/VarLen/FixedLengthStruct.cs
+++ b/cs/src/core/VarLen/FixedLengthStruct.cs
@@ -12,7 +12,7 @@ namespace FASTER.core
     /// <typeparam name="T"></typeparam>
     internal readonly struct FixedLengthStruct<T> : IVariableLengthStruct<T>
     {
-        private static readonly int size = Utility.GetSize(default(T));
+        private static readonly int size = Unsafe.SizeOf<T>();
 
         /// <summary>
         /// Get average length

--- a/cs/stress/TestLoader.cs
+++ b/cs/stress/TestLoader.cs
@@ -5,7 +5,7 @@ using CommandLine;
 using FASTER.core;
 using NUnit.Framework;
 using System.Diagnostics;
-using System.Transactions;
+using System.Runtime.CompilerServices;
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
@@ -133,7 +133,7 @@ namespace FASTER.stress
         internal string MissingValueTypeHandler => $"Missing DataType handler for value type {this.Options.ValueType}";
 
         // Averages for initial record size estimation
-        internal int AverageStringLength => Utility.GetSize(default(string));
+        internal int AverageStringLength => Unsafe.SizeOf<string>();
         internal int AverageSpanByteLength => sizeof(int) + (this.UseRandom ? this.Options.ValueLength / 2 : this.Options.ValueLength);
 
         // Actual value lengths on a per-operation basis


### PR DESCRIPTION
This ports the changes done by @PaulusParssinen in https://github.com/microsoft/garnet/pull/39 to FASTER

The changes are a bit simpler as in Garnet as many of those fields are not internal, so I skipped the property conversion.