### PR TITLE
use IsReferenceOrContainsReferences for .NET Standard 2.1+ and 6_0+

### DIFF
--- a/cs/src/core/Utilities/Utility.cs
+++ b/cs/src/core/Utilities/Utility.cs
@@ -154,6 +154,10 @@ namespace FASTER.core
         /// <returns></returns>
         internal static bool IsBlittable<T>()
         {
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+            return !RuntimeHelpers.IsReferenceOrContainsReferences<T>();
+#else
+
             if (default(T) == null)
                 return false;
 
@@ -168,6 +172,7 @@ namespace FASTER.core
                 return false;
             }
             return true;
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
This ports the change done by @paulusparssinen done in https://github.com/microsoft/garnet/pull/36 to FASTER.
This only applies to the builds for .NET STANDARD 2.1 and 6_0+ as otherwise the helper method is not available, the reflection method is also still used in the code. 