### PR TITLE
use MemoryMarshal.GetReference to implement FromFixedSpan

### DIFF
--- a/cs/src/core/VarLen/SpanByte.cs
+++ b/cs/src/core/VarLen/SpanByte.cs
@@ -278,7 +278,8 @@ namespace FASTER.core
         /// <returns></returns>
         public static SpanByte FromFixedSpan(Span<byte> span)
         {
-            return new SpanByte(span.Length, (IntPtr)Unsafe.AsPointer(ref span[0]));
+            var ptr = Unsafe.AsPointer(ref MemoryMarshal.GetReference(span));
+            return new SpanByte(span.Length, (IntPtr)ptr);
         }
 
         /// <summary>
@@ -288,10 +289,8 @@ namespace FASTER.core
         /// <returns></returns>
         public static SpanByte FromFixedSpan(ReadOnlySpan<byte> span)
         {
-            fixed (byte* ptr = span)
-            {
-                return new SpanByte(span.Length, (IntPtr)ptr);
-            }
+            var ptr = Unsafe.AsPointer(ref MemoryMarshal.GetReference(span));
+            return new SpanByte(span.Length, (IntPtr)ptr);
         }
 
         /// <summary>


### PR DESCRIPTION
Note:

- makes the `Span<byte>` and `ReadOnlySpan<byte>` paths consistent
- avoids `fixed` stack gynmastics overheads (minor but non-zero)
- works correctly for zero-length spans (i.e. doesn't give `IndexOutOfRangeException`)