### PR TITLE
first pass at readonly / static cleanup

### DIFF
--- a/cs/benchmark/Functions.cs
+++ b/cs/benchmark/Functions.cs
@@ -9,48 +9,48 @@ namespace FASTER.benchmark
 {
     public struct Functions : IFunctions<Key, Value, Input, Output, Empty>
     {
-        public void RMWCompletionCallback(ref Key key, ref Input input, ref Output output, Empty ctx, Status status, RecordMetadata recordMetadata)
+        public readonly void RMWCompletionCallback(ref Key key, ref Input input, ref Output output, Empty ctx, Status status, RecordMetadata recordMetadata)
         {
         }
 
-        public void ReadCompletionCallback(ref Key key, ref Input input, ref Output output, Empty ctx, Status status, RecordMetadata recordMetadata)
+        public readonly void ReadCompletionCallback(ref Key key, ref Input input, ref Output output, Empty ctx, Status status, RecordMetadata recordMetadata)
         {
         }
 
-        public void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
+        public readonly void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
         {
             Debug.WriteLine($"Session {sessionID} ({(sessionName ?? "null")}) reports persistence until {commitPoint.UntilSerialNo}");
         }
 
         // Read functions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool SingleReader(ref Key key, ref Input input, ref Value value, ref Output dst, ref ReadInfo readInfo)
+        public readonly bool SingleReader(ref Key key, ref Input input, ref Value value, ref Output dst, ref ReadInfo readInfo)
         {
             dst.value = value;
             return true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool ConcurrentReader(ref Key key, ref Input input, ref Value value, ref Output dst, ref ReadInfo readInfo)
+        public readonly bool ConcurrentReader(ref Key key, ref Input input, ref Value value, ref Output dst, ref ReadInfo readInfo)
         {
             dst.value = value;
             return true;
         }
 
-        public bool SingleDeleter(ref Key key, ref Value value, ref DeleteInfo deleteInfo) { value = default; return true; }
+        public readonly bool SingleDeleter(ref Key key, ref Value value, ref DeleteInfo deleteInfo) { value = default; return true; }
 
-        public bool ConcurrentDeleter(ref Key key, ref Value value, ref DeleteInfo deleteInfo) => true;
+        public readonly bool ConcurrentDeleter(ref Key key, ref Value value, ref DeleteInfo deleteInfo) => true;
 
         // Upsert functions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool SingleWriter(ref Key key, ref Input input, ref Value src, ref Value dst, ref Output output, ref UpsertInfo upsertInfo, WriteReason reason)
+        public readonly bool SingleWriter(ref Key key, ref Input input, ref Value src, ref Value dst, ref Output output, ref UpsertInfo upsertInfo, WriteReason reason)
         {
             dst = src;
             return true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool ConcurrentWriter(ref Key key, ref Input input, ref Value src, ref Value dst, ref Output output, ref UpsertInfo upsertInfo)
+        public readonly bool ConcurrentWriter(ref Key key, ref Input input, ref Value src, ref Value dst, ref Output output, ref UpsertInfo upsertInfo)
         {
             dst = src;
             return true;
@@ -58,42 +58,42 @@ namespace FASTER.benchmark
 
         // RMW functions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool InitialUpdater(ref Key key, ref Input input, ref Value value, ref Output output, ref RMWInfo rmwInfo)
+        public readonly bool InitialUpdater(ref Key key, ref Input input, ref Value value, ref Output output, ref RMWInfo rmwInfo)
         {
             value.value = input.value;
             return true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool InPlaceUpdater(ref Key key, ref Input input, ref Value value, ref Output output, ref RMWInfo rmwInfo)
+        public readonly bool InPlaceUpdater(ref Key key, ref Input input, ref Value value, ref Output output, ref RMWInfo rmwInfo)
         {
             value.value += input.value;
             return true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue, ref Output output, ref RMWInfo rmwInfo)
+        public readonly bool CopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue, ref Output output, ref RMWInfo rmwInfo)
         {
             newValue.value = input.value + oldValue.value;
             return true;
         }
 
-        public void PostCopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue, ref Output output, ref RMWInfo rmwInfo) { }
+        public readonly void PostCopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue, ref Output output, ref RMWInfo rmwInfo) { }
 
-        public bool NeedInitialUpdate(ref Key key, ref Input input, ref Output output, ref RMWInfo rmwInfo) => true;
+        public readonly bool NeedInitialUpdate(ref Key key, ref Input input, ref Output output, ref RMWInfo rmwInfo) => true;
 
-        public void PostInitialUpdater(ref Key key, ref Input input, ref Value value, ref Output output, ref RMWInfo rmwInfo) { }
+        public readonly void PostInitialUpdater(ref Key key, ref Input input, ref Value value, ref Output output, ref RMWInfo rmwInfo) { }
 
-        public bool NeedCopyUpdate(ref Key key, ref Input input, ref Value oldValue, ref Output output, ref RMWInfo rmwInfo) => true;
+        public readonly bool NeedCopyUpdate(ref Key key, ref Input input, ref Value oldValue, ref Output output, ref RMWInfo rmwInfo) => true;
 
-        public void PostSingleDeleter(ref Key key, ref DeleteInfo deleteInfo) { }
+        public readonly void PostSingleDeleter(ref Key key, ref DeleteInfo deleteInfo) { }
 
-        public void PostSingleWriter(ref Key key, ref Input input, ref Value src, ref Value dst, ref Output output, ref UpsertInfo upsertInfo, WriteReason reason) { }
+        public readonly void PostSingleWriter(ref Key key, ref Input input, ref Value src, ref Value dst, ref Output output, ref UpsertInfo upsertInfo, WriteReason reason) { }
 
-        public void DisposeSingleWriter(ref Key key, ref Input input, ref Value src, ref Value dst, ref Output output, ref UpsertInfo upsertInfo, WriteReason reason) { }
-        public void DisposeCopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue, ref Output output, ref RMWInfo rmwInfo) { }
-        public void DisposeInitialUpdater(ref Key key, ref Input input, ref Value value, ref Output output, ref RMWInfo rmwInfo) { }
-        public void DisposeSingleDeleter(ref Key key, ref Value value, ref DeleteInfo deleteInfo) { }
-        public void DisposeDeserializedFromDisk(ref Key key, ref Value value) { }
+        public readonly void DisposeSingleWriter(ref Key key, ref Input input, ref Value src, ref Value dst, ref Output output, ref UpsertInfo upsertInfo, WriteReason reason) { }
+        public readonly void DisposeCopyUpdater(ref Key key, ref Input input, ref Value oldValue, ref Value newValue, ref Output output, ref RMWInfo rmwInfo) { }
+        public readonly void DisposeInitialUpdater(ref Key key, ref Input input, ref Value value, ref Output output, ref RMWInfo rmwInfo) { }
+        public readonly void DisposeSingleDeleter(ref Key key, ref Value value, ref DeleteInfo deleteInfo) { }
+        public readonly void DisposeDeserializedFromDisk(ref Key key, ref Value value) { }
     }
 }

--- a/cs/benchmark/Key.cs
+++ b/cs/benchmark/Key.cs
@@ -18,19 +18,19 @@ namespace FASTER.benchmark
         public long value;
 
 
-        public override string ToString()
+        public override readonly string ToString()
         {
             return "{ " + value + " }";
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long GetHashCode64(ref Key k)
+        public readonly long GetHashCode64(ref Key k)
         {
             return Utility.GetHashCode(k.value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(ref Key k1, ref Key k2)
+        public readonly bool Equals(ref Key k1, ref Key k2)
         {
             return k1.value == k2.value;
         }

--- a/cs/src/core/Allocator/AsyncIOContext.cs
+++ b/cs/src/core/Allocator/AsyncIOContext.cs
@@ -71,7 +71,7 @@ namespace FASTER.core
         /// <summary>
         /// Indicates whether this is a default instance with no pending operation
         /// </summary>
-        public bool IsDefault() => this.callbackQueue is null && this.asyncOperation is null && this.completionEvent is null;
+        public readonly bool IsDefault() => this.callbackQueue is null && this.asyncOperation is null && this.completionEvent is null;
 
         /// <summary>
         /// Dispose

--- a/cs/src/core/Allocator/MallocFixedPageSize.cs
+++ b/cs/src/core/Allocator/MallocFixedPageSize.cs
@@ -93,7 +93,7 @@ namespace FASTER.core
         private int checkpointCallbackCount;
         private SemaphoreSlim checkpointSemaphore;
 
-        private ConcurrentQueue<long> freeList;
+        private readonly ConcurrentQueue<long> freeList;
 
         readonly ILogger logger;
 

--- a/cs/src/core/Async/AsyncOperationInternal.cs
+++ b/cs/src/core/Async/AsyncOperationInternal.cs
@@ -62,7 +62,7 @@ namespace FASTER.core
             ExceptionDispatchInfo _exception;
             readonly FasterKV<Key, Value> _fasterKV;
             readonly IFasterSession<Key, Value, Input, Output, Context> _fasterSession;
-            TAsyncOperation _asyncOperation;
+            readonly TAsyncOperation _asyncOperation;
             PendingContext<Input, Output, Context> _pendingContext;
             int CompletionComputeStatus;
 

--- a/cs/src/core/Async/AsyncOperationInternal.cs
+++ b/cs/src/core/Async/AsyncOperationInternal.cs
@@ -62,7 +62,8 @@ namespace FASTER.core
             ExceptionDispatchInfo _exception;
             readonly FasterKV<Key, Value> _fasterKV;
             readonly IFasterSession<Key, Value, Input, Output, Context> _fasterSession;
-            readonly TAsyncOperation _asyncOperation;
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Possible call side-effects?")]
+            TAsyncOperation _asyncOperation;
             PendingContext<Input, Output, Context> _pendingContext;
             int CompletionComputeStatus;
 

--- a/cs/src/core/Async/DeleteAsync.cs
+++ b/cs/src/core/Async/DeleteAsync.cs
@@ -21,10 +21,10 @@ namespace FASTER.core
             }
 
             /// <inheritdoc/>
-            public DeleteAsyncResult<Input, Output, Context> CreateCompletedResult(Status status, Output output, RecordMetadata recordMetadata) => new DeleteAsyncResult<Input, Output, Context>(status);
+            public readonly DeleteAsyncResult<Input, Output, Context> CreateCompletedResult(Status status, Output output, RecordMetadata recordMetadata) => new DeleteAsyncResult<Input, Output, Context>(status);
 
             /// <inheritdoc/>
-            public Status DoFastOperation(FasterKV<Key, Value> fasterKV, ref PendingContext<Input, Output, Context> pendingContext, IFasterSession<Key, Value, Input, Output, Context> fasterSession,
+            public readonly Status DoFastOperation(FasterKV<Key, Value> fasterKV, ref PendingContext<Input, Output, Context> pendingContext, IFasterSession<Key, Value, Input, Output, Context> fasterSession,
                                             out Output output)
             {
                 OperationStatus internalStatus;
@@ -39,12 +39,12 @@ namespace FASTER.core
             }
 
             /// <inheritdoc/>
-            public ValueTask<DeleteAsyncResult<Input, Output, Context>> DoSlowOperation(FasterKV<Key, Value> fasterKV, IFasterSession<Key, Value, Input, Output, Context> fasterSession,
+            public readonly ValueTask<DeleteAsyncResult<Input, Output, Context>> DoSlowOperation(FasterKV<Key, Value> fasterKV, IFasterSession<Key, Value, Input, Output, Context> fasterSession,
                                             PendingContext<Input, Output, Context> pendingContext, CancellationToken token)
                 => SlowDeleteAsync(fasterKV, fasterSession, pendingContext, deleteOptions, token);
 
             /// <inheritdoc/>
-            public bool HasPendingIO => false;
+            public readonly bool HasPendingIO => false;
         }
 
         /// <summary>
@@ -73,14 +73,14 @@ namespace FASTER.core
 
             /// <summary>Complete the Delete operation, issuing additional allocation asynchronously if needed. It is usually preferable to use Complete() instead of this.</summary>
             /// <returns>ValueTask for Delete result. User needs to await again if result status is Status.PENDING.</returns>
-            public ValueTask<DeleteAsyncResult<Input, Output, Context>> CompleteAsync(CancellationToken token = default)
+            public readonly ValueTask<DeleteAsyncResult<Input, Output, Context>> CompleteAsync(CancellationToken token = default)
                 => this.Status.IsPending
                     ? updateAsyncInternal.CompleteAsync(token)
                     : new ValueTask<DeleteAsyncResult<Input, Output, Context>>(new DeleteAsyncResult<Input, Output, Context>(this.Status));
 
             /// <summary>Complete the Delete operation, issuing additional I/O synchronously if needed.</summary>
             /// <returns>Status of Delete operation</returns>
-            public Status Complete() => this.Status.IsPending ? updateAsyncInternal.CompleteSync().Status : this.Status;
+            public readonly Status Complete() => this.Status.IsPending ? updateAsyncInternal.CompleteSync().Status : this.Status;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/cs/src/core/Async/RMWAsync.cs
+++ b/cs/src/core/Async/RMWAsync.cs
@@ -23,7 +23,7 @@ namespace FASTER.core
             }
 
             /// <inheritdoc/>
-            public RmwAsyncResult<Input, Output, Context> CreateCompletedResult(Status status, Output output, RecordMetadata recordMetadata) => new(status, output, recordMetadata);
+            public readonly RmwAsyncResult<Input, Output, Context> CreateCompletedResult(Status status, Output output, RecordMetadata recordMetadata) => new(status, output, recordMetadata);
 
             /// <inheritdoc/>
             public Status DoFastOperation(FasterKV<Key, Value> fasterKV, ref PendingContext<Input, Output, Context> pendingContext, IFasterSession<Key, Value, Input, Output, Context> fasterSession,
@@ -39,12 +39,12 @@ namespace FASTER.core
             }
 
             /// <inheritdoc/>
-            public ValueTask<RmwAsyncResult<Input, Output, Context>> DoSlowOperation(FasterKV<Key, Value> fasterKV, IFasterSession<Key, Value, Input, Output, Context> fasterSession,
+            public readonly ValueTask<RmwAsyncResult<Input, Output, Context>> DoSlowOperation(FasterKV<Key, Value> fasterKV, IFasterSession<Key, Value, Input, Output, Context> fasterSession,
                                             PendingContext<Input, Output, Context> pendingContext, CancellationToken token)
                 => SlowRmwAsync(fasterKV, fasterSession, pendingContext, rmwOptions, diskRequest, token);
 
             /// <inheritdoc/>
-            public bool HasPendingIO => !this.diskRequest.IsDefault();
+            public readonly bool HasPendingIO => !this.diskRequest.IsDefault();
         }
 
         /// <summary>
@@ -84,19 +84,19 @@ namespace FASTER.core
 
             /// <summary>Complete the RMW operation, issuing additional (rare) I/O asynchronously if needed. It is usually preferable to use Complete() instead of this.</summary>
             /// <returns>ValueTask for RMW result. User needs to await again if result status is pending.</returns>
-            public ValueTask<RmwAsyncResult<Input, TOutput, Context>> CompleteAsync(CancellationToken token = default) 
+            public readonly ValueTask<RmwAsyncResult<Input, TOutput, Context>> CompleteAsync(CancellationToken token = default) 
                 => this.Status.IsPending
                     ? updateAsyncInternal.CompleteAsync(token)
                     : new ValueTask<RmwAsyncResult<Input, TOutput, Context>>(new RmwAsyncResult<Input, TOutput, Context>(this.Status, this.Output, this.RecordMetadata));
 
             /// <summary>Complete the RMW operation, issuing additional (rare) I/O synchronously if needed.</summary>
             /// <returns>Status of RMW operation</returns>
-            public (Status status, TOutput output) Complete() 
+            public readonly (Status status, TOutput output) Complete() 
                 => Complete(out _);
 
             /// <summary>Complete the RMW operation, issuing additional (rare) I/O synchronously if needed.</summary>
             /// <returns>Status of RMW operation</returns>
-            public (Status status, TOutput output) Complete(out RecordMetadata recordMetadata)
+            public readonly (Status status, TOutput output) Complete(out RecordMetadata recordMetadata)
             {
                 if (!this.Status.IsPending)
                 {

--- a/cs/src/core/Async/ReadAsync.cs
+++ b/cs/src/core/Async/ReadAsync.cs
@@ -23,7 +23,7 @@ namespace FASTER.core
             }
 
             /// <inheritdoc/>
-            public ReadAsyncResult<Input, Output, Context> CreateCompletedResult(Status status, Output output, RecordMetadata recordMetadata) => new(status, output, recordMetadata);
+            public readonly ReadAsyncResult<Input, Output, Context> CreateCompletedResult(Status status, Output output, RecordMetadata recordMetadata) => new(status, output, recordMetadata);
 
             /// <inheritdoc/>
             public Status DoFastOperation(FasterKV<Key, Value> fasterKV, ref PendingContext<Input, Output, Context> pendingContext,
@@ -39,12 +39,12 @@ namespace FASTER.core
             }
 
             /// <inheritdoc/>
-            public ValueTask<ReadAsyncResult<Input, Output, Context>> DoSlowOperation(FasterKV<Key, Value> fasterKV, IFasterSession<Key, Value, Input, Output, Context> fasterSession,
+            public readonly ValueTask<ReadAsyncResult<Input, Output, Context>> DoSlowOperation(FasterKV<Key, Value> fasterKV, IFasterSession<Key, Value, Input, Output, Context> fasterSession,
                                             PendingContext<Input, Output, Context> pendingContext, CancellationToken token)
                 => SlowReadAsync(fasterKV, fasterSession, pendingContext, this.readOptions, this.diskRequest, token);
 
             /// <inheritdoc/>
-            public bool HasPendingIO => !this.diskRequest.IsDefault();
+            public readonly bool HasPendingIO => !this.diskRequest.IsDefault();
         }
 
         /// <summary>
@@ -83,12 +83,12 @@ namespace FASTER.core
 
             /// <summary>Complete the RMW operation, issuing additional (rare) I/O synchronously if needed.</summary>
             /// <returns>Status of RMW operation</returns>
-            public (Status status, TOutput output) Complete()
+            public readonly (Status status, TOutput output) Complete()
                 => Complete(out _);
 
             /// <summary>Complete the RMW operation, issuing additional (rare) I/O synchronously if needed.</summary>
             /// <returns>Status of RMW operation</returns>
-            public (Status status, TOutput output) Complete(out RecordMetadata recordMetadata)
+            public readonly (Status status, TOutput output) Complete(out RecordMetadata recordMetadata)
             {
                 if (!this.Status.IsPending)
                 {

--- a/cs/src/core/Async/UpsertAsync.cs
+++ b/cs/src/core/Async/UpsertAsync.cs
@@ -21,10 +21,10 @@ namespace FASTER.core
             }
 
             /// <inheritdoc/>
-            public UpsertAsyncResult<Input, Output, Context> CreateCompletedResult(Status status, Output output, RecordMetadata recordMetadata) => new UpsertAsyncResult<Input, Output, Context>(status, output, recordMetadata);
+            public readonly UpsertAsyncResult<Input, Output, Context> CreateCompletedResult(Status status, Output output, RecordMetadata recordMetadata) => new UpsertAsyncResult<Input, Output, Context>(status, output, recordMetadata);
 
             /// <inheritdoc/>
-            public Status DoFastOperation(FasterKV<Key, Value> fasterKV, ref PendingContext<Input, Output, Context> pendingContext, IFasterSession<Key, Value, Input, Output, Context> fasterSession,
+            public readonly Status DoFastOperation(FasterKV<Key, Value> fasterKV, ref PendingContext<Input, Output, Context> pendingContext, IFasterSession<Key, Value, Input, Output, Context> fasterSession,
                                             out Output output)
             {
                 output = default;
@@ -40,12 +40,12 @@ namespace FASTER.core
             }
 
             /// <inheritdoc/>
-            public ValueTask<UpsertAsyncResult<Input, Output, Context>> DoSlowOperation(FasterKV<Key, Value> fasterKV, IFasterSession<Key, Value, Input, Output, Context> fasterSession,
+            public readonly ValueTask<UpsertAsyncResult<Input, Output, Context>> DoSlowOperation(FasterKV<Key, Value> fasterKV, IFasterSession<Key, Value, Input, Output, Context> fasterSession,
                                             PendingContext<Input, Output, Context> pendingContext, CancellationToken token)
                 => SlowUpsertAsync(fasterKV, fasterSession, pendingContext, upsertOptions, token);
 
             /// <inheritdoc/>
-            public bool HasPendingIO => false;
+            public readonly bool HasPendingIO => false;
         }
 
         /// <summary>
@@ -84,18 +84,18 @@ namespace FASTER.core
 
             /// <summary>Complete the Upsert operation, issuing additional allocation asynchronously if needed. It is usually preferable to use Complete() instead of this.</summary>
             /// <returns>ValueTask for Upsert result. User needs to await again if result status is Status.PENDING.</returns>
-            public ValueTask<UpsertAsyncResult<Input, TOutput, Context>> CompleteAsync(CancellationToken token = default) 
+            public readonly ValueTask<UpsertAsyncResult<Input, TOutput, Context>> CompleteAsync(CancellationToken token = default) 
                 => this.Status.IsPending
                     ? updateAsyncInternal.CompleteAsync(token)
                     : new ValueTask<UpsertAsyncResult<Input, TOutput, Context>>(new UpsertAsyncResult<Input, TOutput, Context>(this.Status, this.Output, this.RecordMetadata));
 
             /// <summary>Complete the Upsert operation, issuing additional I/O synchronously if needed.</summary>
             /// <returns>Status of Upsert operation</returns>
-            public Status Complete() => this.Status.IsPending ? updateAsyncInternal.CompleteSync().Status : this.Status;
+            public readonly Status Complete() => this.Status.IsPending ? updateAsyncInternal.CompleteSync().Status : this.Status;
 
             /// <summary>Complete the Upsert operation, issuing additional I/O synchronously if needed.</summary>
             /// <returns>Status and Output of Upsert operation</returns>
-            public (Status status, TOutput output) Complete(out RecordMetadata recordMetadata)
+            public readonly (Status status, TOutput output) Complete(out RecordMetadata recordMetadata)
             {
                 if (!this.Status.IsPending)
                 {

--- a/cs/src/core/ClientSession/ClientSession.cs
+++ b/cs/src/core/ClientSession/ClientSession.cs
@@ -1127,7 +1127,7 @@ namespace FASTER.core
 
         void IClientSession.AtomicSwitch(long version)
         {
-            fht.AtomicSwitch(ctx, ctx.prevCtx, version, fht._hybridLogCheckpoint.info.checkpointTokens);
+            FasterKV<Key,Value>.AtomicSwitch(ctx, ctx.prevCtx, version, fht._hybridLogCheckpoint.info.checkpointTokens);
         }
 
         /// <summary>

--- a/cs/src/core/ClientSession/FASTERClientSession.cs
+++ b/cs/src/core/ClientSession/FASTERClientSession.cs
@@ -36,7 +36,7 @@ namespace FASTER.core
             /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
             /// <param name="readCopyOptions"><see cref="ReadCopyOptions"/> for this session; override those specified at FasterKV level, and may be overridden on individual Read operations</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(Functions functions, string sessionName = null,
+            public readonly ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(Functions functions, string sessionName = null,
                     SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null, ReadCopyOptions readCopyOptions = default)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
@@ -52,7 +52,7 @@ namespace FASTER.core
             /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
             /// <param name="readCopyOptions"><see cref="ReadCopyOptions"/> for this session; override those specified at FasterKV level, and may be overridden on individual Read operations</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(Functions functions, string sessionName, out CommitPoint commitPoint,
+            public readonly ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(Functions functions, string sessionName, out CommitPoint commitPoint,
                     SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null, ReadCopyOptions readCopyOptions = default)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
@@ -66,7 +66,7 @@ namespace FASTER.core
             /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
             /// <param name="readCopyOptions"><see cref="ReadCopyOptions"/> for this session; override those specified at FasterKV level, and may be overridden on individual Read operations</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(string sessionName = null, 
+            public readonly ClientSession<Key, Value, Input, Output, Context, Functions> NewSession<Functions>(string sessionName = null, 
                     SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null, ReadCopyOptions readCopyOptions = default)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
@@ -85,7 +85,7 @@ namespace FASTER.core
             /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
             /// <param name="readCopyOptions"><see cref="ReadCopyOptions"/> for this session; override those specified at FasterKV level, and may be overridden on individual Read operations</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(string sessionName, out CommitPoint commitPoint,
+            public readonly ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(string sessionName, out CommitPoint commitPoint,
                     SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null, ReadCopyOptions readCopyOptions = default)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {
@@ -104,7 +104,7 @@ namespace FASTER.core
             /// <param name="sessionVariableLengthStructSettings">Session-specific variable-length struct settings</param>
             /// <param name="readCopyOptions"><see cref="ReadCopyOptions"/> for this session; override those specified at FasterKV level, and may be overridden on individual Read operations</param>
             /// <returns>Session instance</returns>
-            public ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(int sessionID, out CommitPoint commitPoint,
+            public readonly ClientSession<Key, Value, Input, Output, Context, Functions> ResumeSession<Functions>(int sessionID, out CommitPoint commitPoint,
                     SessionVariableLengthStructSettings<Value, Input> sessionVariableLengthStructSettings = null, ReadCopyOptions readCopyOptions = default)
                 where Functions : IFunctions<Key, Value, Input, Output, Context>
             {

--- a/cs/src/core/Compaction/ICompactionFunctions.cs
+++ b/cs/src/core/Compaction/ICompactionFunctions.cs
@@ -27,6 +27,6 @@
 
     internal struct DefaultCompactionFunctions<Key, Value> : ICompactionFunctions<Key, Value>
     {
-        public bool IsDeleted(ref Key key, ref Value value) => false;
+        public readonly bool IsDeleted(ref Key key, ref Value value) => false;
     }
 }

--- a/cs/src/core/Device/LocalStorageDevice.cs
+++ b/cs/src/core/Device/LocalStorageDevice.cs
@@ -47,7 +47,7 @@ namespace FASTER.core
         /// </summary>
         private int numPending = 0;
 
-        private IntPtr ioCompletionPort;
+        private readonly IntPtr ioCompletionPort;
 
         /// <summary>
         /// Constructor
@@ -120,7 +120,7 @@ namespace FASTER.core
                 ioCompletionPort = Native32.CreateIoCompletionPort(new SafeFileHandle(new IntPtr(-1), false), IntPtr.Zero, UIntPtr.Zero, (uint)(workerThreads + NumCompletionThreads));
                 for (int i = 0; i < NumCompletionThreads; i++)
                 {
-                    var thread = new Thread(() => new LocalStorageDeviceCompletionWorker().Start(ioCompletionPort, _callback))
+                    var thread = new Thread(() => LocalStorageDeviceCompletionWorker.Start(ioCompletionPort, _callback))
                     {
                         IsBackground = true
                     };
@@ -555,9 +555,9 @@ namespace FASTER.core
 #if NET5_0_OR_GREATER
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
 #endif
-    unsafe sealed class LocalStorageDeviceCompletionWorker
+    unsafe static class LocalStorageDeviceCompletionWorker
     {
-        public void Start(IntPtr ioCompletionPort, IOCompletionCallback _callback)
+        public static void Start(IntPtr ioCompletionPort, IOCompletionCallback _callback)
         {
             while (true)
             {

--- a/cs/src/core/Device/ManagedLocalStorageDevice.cs
+++ b/cs/src/core/Device/ManagedLocalStorageDevice.cs
@@ -585,7 +585,7 @@ namespace FASTER.core
         /// <param name="logHandle"></param>
         /// <param name="size"></param>
         /// <returns></returns>
-        private bool SetFileSize(Stream logHandle, long size)
+        private static bool SetFileSize(Stream logHandle, long size)
         {
             logHandle.SetLength(size);
             return true;

--- a/cs/src/core/Epochs/EpochProtectedVersionScheme.cs
+++ b/cs/src/core/Epochs/EpochProtectedVersionScheme.cs
@@ -42,7 +42,7 @@ namespace FASTER.core
         /// </summary>
         public byte Phase
         {
-            get { return (byte)((Word >> kPhaseShiftInWord) & kPhaseMaskInInteger); }
+            readonly get { return (byte)((Word >> kPhaseShiftInWord) & kPhaseMaskInInteger); }
             set
             {
                 Word &= ~kPhaseMaskInWord;
@@ -52,14 +52,14 @@ namespace FASTER.core
 
         /// <summary></summary>
         /// <returns>whether EPVS is in intermediate state now (transitioning between two states)</returns>
-        public bool IsIntermediate() => (Phase & kIntermediateMask) != 0;
+        public readonly bool IsIntermediate() => (Phase & kIntermediateMask) != 0;
 
         /// <summary>
         /// Version number of the current state
         /// </summary>
         public long Version
         {
-            get { return Word & kVersionMaskInWord; }
+            readonly get { return Word & kVersionMaskInWord; }
             set
             {
                 Word &= ~kVersionMaskInWord;
@@ -106,7 +106,7 @@ namespace FASTER.core
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return $"[{Phase},{Version}]";
         }
@@ -114,13 +114,13 @@ namespace FASTER.core
         /// <summary>
         /// Compare the current <see cref="SystemState"/> to <paramref name="obj"/> for equality if obj is also a <see cref="SystemState"/>
         /// </summary>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is VersionSchemeState other && Equals(other);
         }
 
         /// <inheritdoc/>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return Word.GetHashCode();
         }
@@ -128,7 +128,7 @@ namespace FASTER.core
         /// <summary>
         /// Compare the current <see cref="SystemState"/> to <paramref name="other"/> for equality
         /// </summary>
-        private bool Equals(VersionSchemeState other)
+        private readonly bool Equals(VersionSchemeState other)
         {
             return Word == other.Word;
         }
@@ -155,7 +155,7 @@ namespace FASTER.core
     /// </summary>
     public abstract class VersionSchemeStateMachine
     {
-        private long toVersion;
+        private readonly long toVersion;
         /// <summary>
         /// The actual version this state machine is advancing to, or -1 if not yet determined
         /// </summary>
@@ -202,7 +202,7 @@ namespace FASTER.core
 
     internal class SimpleVersionSchemeStateMachine : VersionSchemeStateMachine
     {
-        private Action<long, long> criticalSection;
+        private readonly Action<long, long> criticalSection;
 
         public SimpleVersionSchemeStateMachine(Action<long, long> criticalSection, long toVersion = -1) : base(toVersion)
         {
@@ -249,7 +249,7 @@ namespace FASTER.core
     /// </summary>
     public class EpochProtectedVersionScheme
     {
-        private LightEpoch epoch;
+        private readonly LightEpoch epoch;
         private VersionSchemeState state;
         private VersionSchemeStateMachine currentMachine;
 

--- a/cs/src/core/Epochs/LightEpoch.cs
+++ b/cs/src/core/Epochs/LightEpoch.cs
@@ -542,14 +542,14 @@ namespace FASTER.core
             [FieldOffset(16)]
             public fixed long markers[6];
 
-            public override string ToString() => $"lce = {localCurrentEpoch}, tid = {threadId}, re-ent {reentrant}";
+            public override readonly string ToString() => $"lce = {localCurrentEpoch}, tid = {threadId}, re-ent {reentrant}";
         }
         struct EpochActionPair
         {
             public long epoch;
             public Action action;
 
-            public override string ToString() => $"epoch = {epoch}, action = {(action is null ? "n/a" : action.Method.ToString())}";
+            public override readonly string ToString() => $"epoch = {epoch}, action = {(action is null ? "n/a" : action.Method.ToString())}";
         }
     }
 }

--- a/cs/src/core/FasterLog/FasterLog.cs
+++ b/cs/src/core/FasterLog/FasterLog.cs
@@ -2815,6 +2815,7 @@ namespace FASTER.core
         /// </summary>
         /// <param name="length"></param>
         /// <returns></returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Shipped as public")]
         public int UnsafeAlign(int length)
             => Align(length);
 

--- a/cs/src/core/FasterLog/FasterLogRecoveryInfo.cs
+++ b/cs/src/core/FasterLog/FasterLogRecoveryInfo.cs
@@ -205,7 +205,7 @@ namespace FASTER.core
         /// <summary>
         /// </summary>
         /// <returns> size of this recovery info serialized </returns>
-        public int SerializedSize()
+        public readonly int SerializedSize()
         {
             var iteratorSize = sizeof(int);
             if (Iterators != null)
@@ -238,7 +238,7 @@ namespace FASTER.core
         /// Update iterators after persistence
         /// </summary>
         /// <param name="persistedIterators">Persisted iterators</param>
-        public void CommitIterators(ConcurrentDictionary<string, FasterLogScanIterator> persistedIterators)
+        public readonly void CommitIterators(ConcurrentDictionary<string, FasterLogScanIterator> persistedIterators)
         {
             if (Iterators?.Count > 0)
             {
@@ -253,7 +253,7 @@ namespace FASTER.core
         /// <summary>
         /// Print checkpoint info for debugging purposes
         /// </summary>
-        public void DebugPrint()
+        public readonly void DebugPrint()
         {
             Debug.WriteLine("******** Log Commit Info ********");
 

--- a/cs/src/core/Index/Common/CompletedOutput.cs
+++ b/cs/src/core/Index/Common/CompletedOutput.cs
@@ -86,12 +86,12 @@ namespace FASTER.core
         /// <summary>
         /// The key for this pending operation.
         /// </summary>
-        public ref TKey Key => ref keyContainer.Get();
+        public readonly ref TKey Key => ref keyContainer.Get();
 
         /// <summary>
         /// The input for this pending operation.
         /// </summary>
-        public ref TInput Input => ref inputContainer.Get();
+        public readonly ref TInput Input => ref inputContainer.Get();
 
         /// <summary>
         /// The output for this pending operation. It is the caller's responsibility to dispose this if necessary; <see cref="Dispose()"/> will not try to dispose this member.

--- a/cs/src/core/Index/Common/Contexts.cs
+++ b/cs/src/core/Index/Common/Contexts.cs
@@ -203,28 +203,24 @@ namespace FASTER.core
             }
 
             internal bool NoKey
-            {
-                get => (operationFlags & kNoKey) != 0;
+            { readonly get => (operationFlags & kNoKey) != 0;
                 set => operationFlags = value ? (ushort)(operationFlags | kNoKey) : (ushort)(operationFlags & ~kNoKey);
             }
 
-            internal bool HasMinAddress => this.minAddress != Constants.kInvalidAddress;
+            internal readonly bool HasMinAddress => this.minAddress != Constants.kInvalidAddress;
 
             internal bool IsAsync
-            {
-                get => (operationFlags & kIsAsync) != 0;
+            { readonly get => (operationFlags & kIsAsync) != 0;
                 set => operationFlags = value ? (ushort)(operationFlags | kIsAsync) : (ushort)(operationFlags & ~kIsAsync);
             }
 
             internal long InitialEntryAddress
-            {
-                get => recordInfo.PreviousAddress;
+            { readonly get => recordInfo.PreviousAddress;
                 set => recordInfo.PreviousAddress = value;
             }
 
             internal long InitialLatestLogicalAddress
-            {
-                get => entry.Address;
+            { readonly get => entry.Address;
                 set => entry.Address = value;
             }
 
@@ -588,7 +584,7 @@ namespace FASTER.core
         /// <summary>
         /// Write info to byte array
         /// </summary>
-        public byte[] ToByteArray()
+        public readonly byte[] ToByteArray()
         {
             using (MemoryStream ms = new())
             {
@@ -747,7 +743,7 @@ namespace FASTER.core
             info.Recover(token, checkpointManager, out commitCookie);
         }
 
-        public bool IsDefault()
+        public readonly bool IsDefault()
         {
             return info.guid == default;
         }
@@ -898,7 +894,7 @@ namespace FASTER.core
             main_ht_device = null;
         }
 
-        public bool IsDefault()
+        public readonly bool IsDefault()
         {
             return info.token == default;
         }

--- a/cs/src/core/Index/Common/OperationOptions.cs
+++ b/cs/src/core/Index/Common/OperationOptions.cs
@@ -55,7 +55,7 @@ namespace FASTER.core
         /// <summary>The destination for copies records.</summary>
         public ReadCopyTo CopyTo;
 
-        internal bool IsActive => CopyFrom != ReadCopyFrom.None && CopyTo != ReadCopyTo.None;
+        internal readonly bool IsActive => CopyFrom != ReadCopyFrom.None && CopyTo != ReadCopyTo.None;
 
         /// <summary>Constructor.</summary>
         public ReadCopyOptions(ReadCopyFrom from, ReadCopyTo to)
@@ -75,7 +75,7 @@ namespace FASTER.core
         public static ReadCopyOptions None => new() { CopyFrom = ReadCopyFrom.None, CopyTo = ReadCopyTo.None };
 
         /// <inheritdoc/>
-        public override string ToString() => $"from: {CopyFrom}, to {CopyTo}";
+        public override readonly string ToString() => $"from: {CopyFrom}, to {CopyTo}";
     }
 
     /// <summary>

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -380,7 +380,7 @@ namespace FASTER.core
             overflowBucketsAllocator.Dispose();
         }
 
-        private void Free(int version)
+        private static void Free(int version)
         {
 #if !NET5_0_OR_GREATER
             if (state[version].tableHandle.IsAllocated)

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -380,7 +380,7 @@ namespace FASTER.core
             overflowBucketsAllocator.Dispose();
         }
 
-        private static void Free(int version)
+        private void Free(int version)
         {
 #if !NET5_0_OR_GREATER
             if (state[version].tableHandle.IsAllocated)

--- a/cs/src/core/Index/FASTER/FASTERBase.cs
+++ b/cs/src/core/Index/FASTER/FASTERBase.cs
@@ -380,6 +380,7 @@ namespace FASTER.core
             overflowBucketsAllocator.Dispose();
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "stateful on down-level")]
         private void Free(int version)
         {
 #if !NET5_0_OR_GREATER

--- a/cs/src/core/Index/FASTER/Implementation/HashEntryInfo.cs
+++ b/cs/src/core/Index/FASTER/Implementation/HashEntryInfo.cs
@@ -46,8 +46,8 @@ namespace FASTER.core
         /// <summary>
         /// The original address of this hash entry (at the time of FindTag, etc.)
         /// </summary>
-        internal long Address => entry.Address;
-        internal long AbsoluteAddress => Utility.AbsoluteAddress(this.Address);
+        internal readonly long Address => entry.Address;
+        internal readonly long AbsoluteAddress => Utility.AbsoluteAddress(this.Address);
 
         /// <summary>
         /// The current address of this hash entry (which may have been updated (via CAS) in the bucket after FindTag, etc.)
@@ -63,7 +63,7 @@ namespace FASTER.core
         /// <summary>
         /// Whether the original address for this hash entry (at the time of FindTag, etc.) is a readcache address.
         /// </summary>
-        internal bool IsReadCache => entry.ReadCache;
+        internal readonly bool IsReadCache => entry.ReadCache;
 
         /// <summary>
         /// Whether the current address for this hash entry (possibly modified after FindTag, etc.) is a readcache address.

--- a/cs/src/core/Index/FASTER/Implementation/Locking/TransientLocking.cs
+++ b/cs/src/core/Index/FASTER/Implementation/Locking/TransientLocking.cs
@@ -20,7 +20,7 @@ namespace FASTER.core
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void TransientXUnlock<Input, Output, Context, FasterSession>(FasterSession fasterSession, ref Key key, ref OperationStackContext<Key, Value> stackCtx)
+        private static void TransientXUnlock<Input, Output, Context, FasterSession>(FasterSession fasterSession, ref Key key, ref OperationStackContext<Key, Value> stackCtx)
             where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
         {
             if (stackCtx.recSrc.HasTransientLock)
@@ -40,7 +40,7 @@ namespace FASTER.core
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void TransientSUnlock<Input, Output, Context, FasterSession>(FasterSession fasterSession, ref Key key, ref OperationStackContext<Key, Value> stackCtx)
+        internal static void TransientSUnlock<Input, Output, Context, FasterSession>(FasterSession fasterSession, ref Key key, ref OperationStackContext<Key, Value> stackCtx)
             where FasterSession : IFasterSession<Key, Value, Input, Output, Context>
         {
             if (stackCtx.recSrc.HasTransientLock)

--- a/cs/src/core/Index/FASTER/Implementation/OperationStackContext.cs
+++ b/cs/src/core/Index/FASTER/Implementation/OperationStackContext.cs
@@ -73,7 +73,7 @@ namespace FASTER.core
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             var delimiter = "    ";  // Environment.NewLine doesn't display in VS
             return $"hei: {hei}{delimiter}newLA {newLogicalAddress}{delimiter}recSrc: {recSrc}";

--- a/cs/src/core/Index/FASTER/Implementation/RecordSource.cs
+++ b/cs/src/core/Index/FASTER/Implementation/RecordSource.cs
@@ -70,16 +70,16 @@ namespace FASTER.core
         internal EphemeralLockResult ephemeralLockResult;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ref RecordInfo GetInfo() => ref Log.GetInfo(PhysicalAddress);
-        internal ref Key GetKey() => ref Log.GetKey(PhysicalAddress);
+        internal readonly ref RecordInfo GetInfo() => ref Log.GetInfo(PhysicalAddress);
+        internal readonly ref Key GetKey() => ref Log.GetKey(PhysicalAddress);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ref Value GetValue() => ref Log.GetValue(PhysicalAddress);
+        internal readonly ref Value GetValue() => ref Log.GetValue(PhysicalAddress);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal long SetPhysicalAddress() => this.PhysicalAddress = Log.GetPhysicalAddress(LogicalAddress);
 
-        internal bool HasInMemorySrc => HasMainLogSrc || HasReadCacheSrc;
+        internal readonly bool HasInMemorySrc => HasMainLogSrc || HasReadCacheSrc;
 
-        internal bool HasLock => HasTransientLock || ephemeralLockResult == EphemeralLockResult.Success;
+        internal readonly bool HasLock => HasTransientLock || ephemeralLockResult == EphemeralLockResult.Success;
 
         /// <summary>
         /// Initialize to the latest logical address from the caller.
@@ -100,7 +100,7 @@ namespace FASTER.core
             this.Log = srcLog;
         }
 
-        public override string ToString()
+        public override readonly string ToString()
         {
             var isRC = "(rc)";
             var llaRC = IsReadCache(LatestLogicalAddress) ? isRC : string.Empty;

--- a/cs/src/core/Index/Interfaces/NullFasterSession.cs
+++ b/cs/src/core/Index/Interfaces/NullFasterSession.cs
@@ -4,15 +4,15 @@
     {
         public static readonly NullFasterSession Instance = new();
 
-        public void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
+        public readonly void CheckpointCompletionCallback(int sessionID, string sessionName, CommitPoint commitPoint)
         {
         }
 
-        public void UnsafeResumeThread()
+        public readonly void UnsafeResumeThread()
         {
         }
 
-        public void UnsafeSuspendThread()
+        public readonly void UnsafeSuspendThread()
         {
         }
     }

--- a/cs/src/core/Index/Recovery/Recovery.cs
+++ b/cs/src/core/Index/Recovery/Recovery.cs
@@ -1034,7 +1034,7 @@ namespace FASTER.core
             }
         }
 
-        internal bool AtomicSwitch<Input, Output, Context>(FasterExecutionContext<Input, Output, Context> fromCtx, FasterExecutionContext<Input, Output, Context> toCtx, long version, ConcurrentDictionary<int, (string, CommitPoint)> tokens)
+        internal static bool AtomicSwitch<Input, Output, Context>(FasterExecutionContext<Input, Output, Context> fromCtx, FasterExecutionContext<Input, Output, Context> toCtx, long version, ConcurrentDictionary<int, (string, CommitPoint)> tokens)
         {
             lock (toCtx)
             {

--- a/cs/src/core/Index/Synchronization/FasterStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/FasterStateMachine.cs
@@ -21,7 +21,7 @@ namespace FASTER.core
         // The current state machine in the system. The value could be stale and point to the previous state machine
         // if no state machine is active at this time.
         private ISynchronizationStateMachine currentSyncStateMachine;
-        private List<IStateMachineCallback> callbacks = new List<IStateMachineCallback>();
+        private readonly List<IStateMachineCallback> callbacks = new List<IStateMachineCallback>();
         internal long lastVersion;
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace FASTER.core
 
         // Given the current global state, return the starting point of the state machine cycle
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private SystemState StartOfCurrentCycle(SystemState currentGlobalState)
+        private static SystemState StartOfCurrentCycle(SystemState currentGlobalState)
         {
             return currentGlobalState.Phase < Phase.REST
                 ? SystemState.Make(Phase.REST, currentGlobalState.Version - 1)
@@ -149,7 +149,7 @@ namespace FASTER.core
         // Given the current thread state and global state, fast forward the thread state to the
         // current state machine cycle if needed
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private SystemState FastForwardToCurrentCycle(SystemState threadState, SystemState targetStartState)
+        private static SystemState FastForwardToCurrentCycle(SystemState threadState, SystemState targetStartState)
         {
             if (threadState.Version < targetStartState.Version ||
                 threadState.Version == targetStartState.Version && threadState.Phase < targetStartState.Phase)
@@ -310,7 +310,7 @@ namespace FASTER.core
         /// <summary>
         /// Issue completion callback if needed, for the given context's prevCtx
         /// </summary>
-        internal void IssueCompletionCallback<Input, Output, Context, FasterSession>(FasterExecutionContext<Input, Output, Context> ctx, FasterSession fasterSession)
+        internal static void IssueCompletionCallback<Input, Output, Context, FasterSession>(FasterExecutionContext<Input, Output, Context> ctx, FasterSession fasterSession)
              where FasterSession : IFasterSession
         {
             CommitPoint commitPoint = default;

--- a/cs/src/core/Index/Synchronization/HybridLogCheckpointTask.cs
+++ b/cs/src/core/Index/Synchronization/HybridLogCheckpointTask.cs
@@ -120,7 +120,7 @@ namespace FASTER.core
             {
                 if (!ctx.prevCtx.markers[EpochPhaseIdx.CheckpointCompletionCallback])
                 {
-                    faster.IssueCompletionCallback(ctx, fasterSession);
+                    FasterKV<Key,Value>.IssueCompletionCallback(ctx, fasterSession);
                     ctx.prevCtx.markers[EpochPhaseIdx.CheckpointCompletionCallback] = true;
                 }
             }

--- a/cs/src/core/Index/Synchronization/StateTransitions.cs
+++ b/cs/src/core/Index/Synchronization/StateTransitions.cs
@@ -90,7 +90,7 @@ namespace FASTER.core
         /// </summary>
         public Phase Phase
         {
-            get
+            readonly get
             {
                 return (Phase)((Word >> kPhaseShiftInWord) & kPhaseMaskInInteger);
             }
@@ -106,7 +106,7 @@ namespace FASTER.core
         /// </summary>
         public long Version
         {
-            get
+            readonly get
             {
                 return Word & kVersionMaskInWord;
             }
@@ -165,7 +165,7 @@ namespace FASTER.core
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return $"[{Phase},{Version}]";
         }
@@ -173,13 +173,13 @@ namespace FASTER.core
         /// <summary>
         /// Compare the current <see cref="SystemState"/> to <paramref name="obj"/> for equality if obj is also a <see cref="SystemState"/>
         /// </summary>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is SystemState other && Equals(other);
         }
 
         /// <inheritdoc/>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return Word.GetHashCode();
         }
@@ -187,7 +187,7 @@ namespace FASTER.core
         /// <summary>
         /// Compare the current <see cref="SystemState"/> to <paramref name="other"/> for equality
         /// </summary>
-        private bool Equals(SystemState other)
+        private readonly bool Equals(SystemState other)
         {
             return Word == other.Word;
         }

--- a/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
+++ b/cs/src/core/Index/Synchronization/VersionChangeStateMachine.cs
@@ -62,7 +62,7 @@ namespace FASTER.core
 
                         if (!_ctx.markers[EpochPhaseIdx.InProgress])
                         {
-                            faster.AtomicSwitch(ctx, ctx.prevCtx, _ctx.version, tokens);
+                            FasterKV<Key, Value>.AtomicSwitch(ctx, ctx.prevCtx, _ctx.version, tokens);
                             FasterKV<Key, Value>.InitContext(ctx, ctx.prevCtx.sessionID, ctx.prevCtx.sessionName, ctx.prevCtx.serialNum);
 
                             // Has to be prevCtx, not ctx

--- a/cs/src/core/Utilities/BufferPool.cs
+++ b/cs/src/core/Utilities/BufferPool.cs
@@ -58,7 +58,8 @@ namespace FASTER.core
         /// </summary>
         public int available_bytes;
 
-        private readonly int level;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "mutable when CHECK_FREE defined")]
+        private int level;
         internal int Level => this.level
 #if CHECK_FREE
             & ~kFreeBitMask

--- a/cs/src/core/Utilities/BufferPool.cs
+++ b/cs/src/core/Utilities/BufferPool.cs
@@ -58,7 +58,7 @@ namespace FASTER.core
         /// </summary>
         public int available_bytes;
 
-        private int level;
+        private readonly int level;
         internal int Level => this.level
 #if CHECK_FREE
             & ~kFreeBitMask

--- a/cs/src/core/Utilities/CompletionEvent.cs
+++ b/cs/src/core/Utilities/CompletionEvent.cs
@@ -35,11 +35,11 @@ namespace FASTER.core
             }
         }
 
-        internal bool IsDefault() => this.semaphore is null;
+        internal readonly bool IsDefault() => this.semaphore is null;
 
-        internal void Wait(CancellationToken token = default) => this.semaphore.Wait(token);
+        internal readonly void Wait(CancellationToken token = default) => this.semaphore.Wait(token);
 
-        internal Task WaitAsync(CancellationToken token = default) => this.semaphore.WaitAsync(token);
+        internal readonly Task WaitAsync(CancellationToken token = default) => this.semaphore.WaitAsync(token);
 
         /// <inheritdoc/>
         public void Dispose()

--- a/cs/src/core/Utilities/LockType.cs
+++ b/cs/src/core/Utilities/LockType.cs
@@ -126,7 +126,7 @@ namespace FASTER.core
         public static void Sort(FixedLengthLockableKeyStruct<TKey>[] keys, ILockableContext<TKey> context) => context.SortKeyHashes(keys);
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             var hashStr = Utility.GetHashString(this.KeyHash);
             return $"key {Key}, hash {hashStr}, {LockType}";
@@ -141,11 +141,11 @@ namespace FASTER.core
         internal bool IsLockedExclusive;
         internal bool IsFound;
         internal ushort NumLockedShared;
-        internal bool IsLockedShared => NumLockedShared > 0;
+        internal readonly bool IsLockedShared => NumLockedShared > 0;
 
-        internal bool IsLocked => IsLockedExclusive || NumLockedShared > 0;
+        internal readonly bool IsLocked => IsLockedExclusive || NumLockedShared > 0;
 
-        public override string ToString()
+        public override readonly string ToString()
         {
             var locks = $"{(this.IsLockedExclusive ? "x" : string.Empty)}{this.NumLockedShared}";
             return $"found {IsFound}, locks {locks}";
@@ -164,7 +164,7 @@ namespace FASTER.core
         internal LockType LockType;
         internal LockOperationType LockOperationType;
 
-        internal bool IsSet => LockOperationType != LockOperationType.None;
+        internal readonly bool IsSet => LockOperationType != LockOperationType.None;
 
         internal LockOperation(LockOperationType opType, LockType lockType)
         {
@@ -172,6 +172,6 @@ namespace FASTER.core
             this.LockOperationType = opType;
         }
 
-        public override string ToString() => $"{LockType}: opType {LockOperationType}";
+        public override readonly string ToString() => $"{LockType}: opType {LockOperationType}";
     }
 }

--- a/cs/src/core/Utilities/Status.cs
+++ b/cs/src/core/Utilities/Status.cs
@@ -20,27 +20,27 @@ namespace FASTER.core
         /// Whether a new record for a previously non-existent key was appended to the log.
         /// Indicates that an existing record was updated in place.
         /// </summary>
-        public bool Created => (statusCode & StatusCode.AdvancedMask) == StatusCode.CreatedRecord;
+        public readonly bool Created => (statusCode & StatusCode.AdvancedMask) == StatusCode.CreatedRecord;
 
         /// <summary>
         /// Whether existing record was updated in place.
         /// </summary>
-        public bool InPlaceUpdated => (statusCode & StatusCode.AdvancedMask) == StatusCode.InPlaceUpdatedRecord;
+        public readonly bool InPlaceUpdated => (statusCode & StatusCode.AdvancedMask) == StatusCode.InPlaceUpdatedRecord;
 
         /// <summary>
         /// Whether an existing record key was copied, updated, and appended to the log.
         /// </summary>
-        public bool CopyUpdated => (statusCode & StatusCode.AdvancedMask) == StatusCode.CopyUpdatedRecord;
+        public readonly bool CopyUpdated => (statusCode & StatusCode.AdvancedMask) == StatusCode.CopyUpdatedRecord;
 
         /// <summary>
         /// Whether an existing record key was copied and appended to the log.
         /// </summary>
-        public bool Copied => (statusCode & StatusCode.AdvancedMask) == StatusCode.CopiedRecord;
+        public readonly bool Copied => (statusCode & StatusCode.AdvancedMask) == StatusCode.CopiedRecord;
 
         /// <summary>
         /// Whether an existing record key was copied, updated, and added to the readcache.
         /// </summary>
-        public bool CopiedToReadCache => (statusCode & StatusCode.AdvancedMask) == StatusCode.CopiedRecordToReadCache;
+        public readonly bool CopiedToReadCache => (statusCode & StatusCode.AdvancedMask) == StatusCode.CopiedRecordToReadCache;
     }
 
     /// <summary>
@@ -85,42 +85,42 @@ namespace FASTER.core
         /// <summary>
         /// Whether a Read or RMW found the key
         /// </summary>
-        public bool Found => (this.Record.statusCode & StatusCode.BasicMask) == StatusCode.Found;
+        public readonly bool Found => (this.Record.statusCode & StatusCode.BasicMask) == StatusCode.Found;
 
         /// <summary>
         /// Whether a Read or RMW did not find the key
         /// </summary>
-        public bool NotFound => (statusCode & StatusCode.BasicMask) == StatusCode.NotFound;
+        public readonly bool NotFound => (statusCode & StatusCode.BasicMask) == StatusCode.NotFound;
 
         /// <summary>
         /// Whether the operation went pending
         /// </summary>
-        public bool IsPending => statusCode == StatusCode.Pending;
+        public readonly bool IsPending => statusCode == StatusCode.Pending;
 
         /// <summary>
         /// Whether the operation went pending
         /// </summary>
-        public bool IsCompleted => !IsPending;
+        public readonly bool IsCompleted => !IsPending;
 
         /// <summary>
         /// Whether the operation is in an error state
         /// </summary>
-        public bool IsFaulted => statusCode == StatusCode.Error;
+        public readonly bool IsFaulted => statusCode == StatusCode.Error;
 
         /// <summary>
         /// Whether the operation was canceled
         /// </summary>
-        public bool IsCanceled => statusCode == StatusCode.Canceled;
+        public readonly bool IsCanceled => statusCode == StatusCode.Canceled;
 
         /// <summary>
         /// Whether the operation found an expired record
         /// </summary>
-        public bool Expired => (statusCode & StatusCode.Expired) == StatusCode.Expired;
+        public readonly bool Expired => (statusCode & StatusCode.Expired) == StatusCode.Expired;
 
         /// <summary>
         /// Whether the operation completed successfully, i.e., it is not pending and did not error out
         /// </summary>
-        public bool IsCompletedSuccessfully
+        public readonly bool IsCompletedSuccessfully
         {
             get
             {
@@ -132,10 +132,10 @@ namespace FASTER.core
         /// <summary>
         /// Get the underlying status code value
         /// </summary>
-        public byte Value => (byte)statusCode;
+        public readonly byte Value => (byte)statusCode;
 
         /// <inheritdoc />
         /// <remarks>"Found" is zero, so does not appear in the output by default; this handles that explicitly</remarks>
-        public override string ToString() => (this.Found ? "Found, " : string.Empty) + this.statusCode.ToString();
+        public override readonly string ToString() => (this.Found ? "Found, " : string.Empty) + this.statusCode.ToString();
     }
 }

--- a/cs/src/core/VarLen/MemoryComparer.cs
+++ b/cs/src/core/VarLen/MemoryComparer.cs
@@ -11,14 +11,14 @@ namespace FASTER.core
         where T : unmanaged
     {
         ///<inheritdoc/>
-        public unsafe long GetHashCode64(ref Memory<T> k)
+        public readonly unsafe long GetHashCode64(ref Memory<T> k)
         {
             fixed (T* ptr = k.Span)
                 return Utility.HashBytes((byte*)ptr, k.Length*sizeof(T));
         }
 
         ///<inheritdoc/>
-        public unsafe bool Equals(ref Memory<T> k1, ref Memory<T> k2)
+        public readonly unsafe bool Equals(ref Memory<T> k1, ref Memory<T> k2)
         {
             return MemoryMarshal.Cast<T, byte>(k1.Span)
                 .SequenceEqual(MemoryMarshal.Cast<T, byte>(k2.Span));
@@ -32,14 +32,14 @@ namespace FASTER.core
         where T : unmanaged
     {
         ///<inheritdoc/>
-        public unsafe long GetHashCode64(ref ReadOnlyMemory<T> k)
+        public readonly unsafe long GetHashCode64(ref ReadOnlyMemory<T> k)
         {
             fixed (T* ptr = k.Span)
                 return Utility.HashBytes((byte*)ptr, k.Length * sizeof(T));
         }
 
         ///<inheritdoc/>
-        public unsafe bool Equals(ref ReadOnlyMemory<T> k1, ref ReadOnlyMemory<T> k2)
+        public readonly unsafe bool Equals(ref ReadOnlyMemory<T> k1, ref ReadOnlyMemory<T> k2)
         {
             return MemoryMarshal.Cast<T, byte>(k1.Span)
                 .SequenceEqual(MemoryMarshal.Cast<T, byte>(k2.Span));

--- a/cs/src/core/VarLen/SpanByteAndMemory.cs
+++ b/cs/src/core/VarLen/SpanByteAndMemory.cs
@@ -46,7 +46,7 @@ namespace FASTER.core
         /// </summary>
         public int Length
         {
-            get => SpanByte.Length;
+            readonly get => SpanByte.Length;
             set => SpanByte.Length = value;
         }
 
@@ -93,6 +93,6 @@ namespace FASTER.core
         /// <summary>
         /// Is it allocated as SpanByte (on stack)?
         /// </summary>
-        public bool IsSpanByte => !SpanByte.Invalid;
+        public readonly bool IsSpanByte => !SpanByte.Invalid;
     }
 }

--- a/cs/src/core/VarLen/SpanByteComparer.cs
+++ b/cs/src/core/VarLen/SpanByteComparer.cs
@@ -9,10 +9,10 @@ namespace FASTER.core
     /// <summary>
     /// Equality comparer for SpanByte
     /// </summary>
-    public struct SpanByteComparer : IFasterEqualityComparer<SpanByte>
+    public readonly struct SpanByteComparer : IFasterEqualityComparer<SpanByte>
     {
         /// <inheritdoc />
-        public unsafe long GetHashCode64(ref SpanByte spanByte) => StaticGetHashCode64(ref spanByte);
+        public readonly unsafe long GetHashCode64(ref SpanByte spanByte) => StaticGetHashCode64(ref spanByte);
 
         /// <summary>
         /// Get 64-bit hash code
@@ -33,7 +33,7 @@ namespace FASTER.core
         }
 
         /// <inheritdoc />
-        public unsafe bool Equals(ref SpanByte k1, ref SpanByte k2) => StaticEquals(ref k1, ref k2);
+        public readonly unsafe bool Equals(ref SpanByte k1, ref SpanByte k2) => StaticEquals(ref k1, ref k2);
 
         /// <summary>
         /// Equality comparison

--- a/cs/src/core/VarLen/SpanByteVarLenStruct.cs
+++ b/cs/src/core/VarLen/SpanByteVarLenStruct.cs
@@ -11,19 +11,19 @@ namespace FASTER.core
     public struct SpanByteVarLenStruct : IVariableLengthStruct<SpanByte>
     {
         /// <inheritdoc />
-        public int GetInitialLength() => sizeof(int);
+        public readonly int GetInitialLength() => sizeof(int);
 
         /// <inheritdoc />
-        public int GetLength(ref SpanByte t) => sizeof(int) + t.Length;
+        public readonly int GetLength(ref SpanByte t) => sizeof(int) + t.Length;
 
         /// <inheritdoc />
-        public unsafe void Serialize(ref SpanByte source, void* destination) => source.CopyTo((byte*)destination);
+        public readonly unsafe void Serialize(ref SpanByte source, void* destination) => source.CopyTo((byte*)destination);
 
         /// <inheritdoc />
-        public unsafe ref SpanByte AsRef(void* source) => ref Unsafe.AsRef<SpanByte>(source);
+        public readonly unsafe ref SpanByte AsRef(void* source) => ref Unsafe.AsRef<SpanByte>(source);
 
         /// <inheritdoc />
-        public unsafe void Initialize(void* source, void* dest) { *(int*)source = (int)((byte*)dest - (byte*)source) - sizeof(int); }
+        public readonly unsafe void Initialize(void* source, void* dest) { *(int*)source = (int)((byte*)dest - (byte*)source) - sizeof(int); }
     }
 
     /// <summary>
@@ -32,13 +32,13 @@ namespace FASTER.core
     public struct SpanByteVarLenStructForSpanByteInput : IVariableLengthStruct<SpanByte, SpanByte>
     {
         /// <inheritdoc />
-        public int GetInitialLength(ref SpanByte input) => sizeof(int) + input.Length;
+        public readonly int GetInitialLength(ref SpanByte input) => sizeof(int) + input.Length;
 
         /// <summary>
         /// Length of resulting object when doing RMW with given value and input. Here we set the length
         /// to the max of input and old value lengths. You can provide a custom implementation for other cases.
         /// </summary>
-        public int GetLength(ref SpanByte t, ref SpanByte input)
+        public readonly int GetLength(ref SpanByte t, ref SpanByte input)
             => sizeof(int) + (t.Length > input.Length ? t.Length : input.Length);
     }
 }


### PR DESCRIPTION
context https://github.com/microsoft/FASTER/issues/904 (this doesn't "complete" that issue, though)

- apply `readonly` where possible, to prevent defensive copies
- change some non-public methods to `static` where possible