### PR TITLE
Fix commit record pointer offset calculation

### DIFF
--- a/cs/src/core/FasterLog/FasterLogIterator.cs
+++ b/cs/src/core/FasterLog/FasterLogIterator.cs
@@ -379,7 +379,7 @@ namespace FASTER.core
                 if (isCommitRecord)
                 {
                     FasterLogRecoveryInfo info = new();
-                    info.Initialize(new BinaryReader(new UnmanagedMemoryStream((byte *)physicalAddress, entryLength)));
+                    info.Initialize(new BinaryReader(new UnmanagedMemoryStream((byte*) (headerSize + physicalAddress), entryLength)));
                     if (info.CommitNum != long.MaxValue) continue;
                     
                     // Otherwise, no more entries
@@ -442,7 +442,7 @@ namespace FASTER.core
                 if (isCommitRecord)
                 {
                     FasterLogRecoveryInfo info = new();
-                    info.Initialize(new BinaryReader(new UnmanagedMemoryStream((byte *)physicalAddress, entryLength)));
+                    info.Initialize(new BinaryReader(new UnmanagedMemoryStream((byte*) (headerSize + physicalAddress), entryLength)));
                     if (info.CommitNum != long.MaxValue) continue;
                     
                     // Otherwise, no more entries


### PR DESCRIPTION
Fix commit record pointer calculation by including headerSize value in the base offset. 

Relates to #691  