### PR TITLE
Add dotnet 10 build target

### DIFF
--- a/azure-pipelines-full.yml
+++ b/azure-pipelines-full.yml
@@ -39,6 +39,12 @@ jobs:
       packageType: 'sdk'
       version: '7.0.x'
 
+  - task: UseDotNet@2
+    displayName: Use .NET 10.0
+    inputs:
+      packageType: 'sdk'
+      version: '10.0.x'
+
   - task: NodeTool@0
     inputs:
        versionSpec: 14.x
@@ -155,6 +161,12 @@ jobs:
     inputs:
       packageType: 'sdk'
       version: '7.0.x'
+
+  - task: UseDotNet@2
+    displayName: Use .NET 10.0
+    inputs:
+      packageType: 'sdk'
+      version: '10.0.x'
 
   - bash: |
       sudo npm install -g azurite

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,12 @@ jobs:
       packageType: 'sdk'
       version: '7.0.x'
 
+  - task: UseDotNet@2
+    displayName: Use .NET 10.0
+    inputs:
+      packageType: 'sdk'
+      version: '10.0.x'
+
   - task: NodeTool@0
     inputs:
       versionSpec: 14.x
@@ -155,6 +161,12 @@ jobs:
     inputs:
       packageType: 'sdk'
       version: '7.0.x'
+
+  - task: UseDotNet@2
+    displayName: Use .NET 10.0
+    inputs:
+      packageType: 'sdk'
+      version: '10.0.x'
 
   - bash: |
       sudo npm install -g azurite

--- a/cs/src/core/FASTER.core.csproj
+++ b/cs/src/core/FASTER.core.csproj
@@ -52,10 +52,6 @@
     <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
-  </ItemGroup>
-
   <Choose>
 	<When Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'">
       <ItemGroup>

--- a/cs/src/core/FASTER.core.csproj
+++ b/cs/src/core/FASTER.core.csproj
@@ -41,15 +41,15 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
 	<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
-    <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-    <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
   </ItemGroup>
 
   <Choose>

--- a/cs/src/core/FASTER.core.csproj
+++ b/cs/src/core/FASTER.core.csproj
@@ -63,11 +63,6 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
       </ItemGroup>
     </When>
-    <When Condition="'$(TargetFramework)' == 'net10.0'">
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-      </ItemGroup>
-    </When>
     <Otherwise>
 	  <ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />

--- a/cs/src/core/FASTER.core.csproj
+++ b/cs/src/core/FASTER.core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -41,14 +41,18 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
 	<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
-    <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1' And '$(TargetFramework)' != 'net10.0'">
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
   </ItemGroup>
 
@@ -61,6 +65,11 @@
     <When Condition="'$(TargetFramework)' == 'net6.0'">
       <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+      </ItemGroup>
+    </When>
+    <When Condition="'$(TargetFramework)' == 'net10.0'">
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/cs/src/devices/AzureStorageDevice/FASTER.devices.AzureStorageDevice.csproj
+++ b/cs/src/devices/AzureStorageDevice/FASTER.devices.AzureStorageDevice.csproj
@@ -40,10 +40,6 @@
     <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
-  </ItemGroup>
-
 	<ItemGroup>
 	<PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
 	<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/cs/src/devices/AzureStorageDevice/FASTER.devices.AzureStorageDevice.csproj
+++ b/cs/src/devices/AzureStorageDevice/FASTER.devices.AzureStorageDevice.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -37,6 +37,10 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
   </ItemGroup>
 

--- a/cs/src/devices/AzureStorageDevice/FASTER.devices.AzureStorageDevice.csproj
+++ b/cs/src/devices/AzureStorageDevice/FASTER.devices.AzureStorageDevice.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
   </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
The dotnet 10 build target removes the `System.Linq.Async` import, preventing the sort of problems from consumers mentioned by https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/asyncenumerable